### PR TITLE
Handling empty database bug

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -99,7 +99,10 @@ class TezosNodeOperator(node: TezosRPCInterface) extends LazyLogging {
     * @return         Blocks
     */
   def getBlocksNotInDatabase(network: String): Try[List[Block]] =
-    ApiOperations.fetchMaxLevel().flatMap{ maxLevel =>
+    ApiOperations.fetchMaxLevel().orElse{
+      logger.warn("There were apparently no rows in the database. Dumping the whole chain.")
+      Try(-1)
+    }.flatMap{ maxLevel =>
       getBlockHead(network).flatMap { blockHead =>
         val headLevel = blockHead.metadata.level
         val headHash  = blockHead.metadata.hash


### PR DESCRIPTION
Lorre would crash if presented with an empty database. A trivial check instead causes it to bootstrap all blocks into the database.