### PR TITLE
Add support in Lorre for forks between runs

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
@@ -18,14 +18,14 @@ object ApiOperations {
   /**
     * Fetches the level of the most recent block stored in the database.
     *
-    * @return Max level.
+    * @return Max level or -1 if no blocks were found in the database.
     */
   def fetchMaxLevel(): Try[Int] = Try {
     val op: Future[Option[Int]] = dbHandle.run(Tables.Blocks.map(_.level).max.result)
     val maxLevelOpt = Await.result(op, Duration.Inf)
     maxLevelOpt match {
       case Some(maxLevel) => maxLevel
-      case None => throw new Exception("No blocks in the database!")
+      case None => -1
     }
   }
 

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTest.scala
@@ -83,6 +83,8 @@ class TezosNodeOperatorTest extends FlatSpec with MockFactory with Matchers with
     blocks.get.length should be (4)
   }
 
+  // Once we can mock the database, we should test whether getBlocks() works on a forked chain.
+
   "getBlocks" should "handle a failed RPC request" in {
     val nodeOp: TezosNodeOperator = new TezosNodeOperator(MockTezosNodeWithErrors)
     val blocks = nodeOp.getBlocks("alphanet", 0, 3, None)


### PR DESCRIPTION
Lorre runs periodically to pull in from the Tezos client any new blocks not already in the database. For this, it queries for every block between the maximum level present in the database to the level of the head. Due to a database constraint, any new block record must have an existing block record with a hash corresponding to the new block's predecessor hash. 

In a boundary case, a fork might have occurred between two consecutive Lorre runs, in which case the new block with the least level will not have its predecessor present in the database. This bug fix allows the option to keep querying new blocks until a database record is found for a predecessor hash. 

In order to address all forks and not just this boundary condition, we might in the future have a process running occasionally to match the latest chain returned by the Tezos client to the ones present in the database. Should this check fail, it would trigger a download of the intermediary fork into the database. 