### PR TITLE
Make SSL keystore file configurable

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -35,6 +35,7 @@ security: {
     keys: []
   },
   ssl: {
+    keystore-file: ""     #override in a specific config file
     keystore-password: "" #override in a specific config file
   }
 }

--- a/src/main/resources/developer.conf
+++ b/src/main/resources/developer.conf
@@ -7,6 +7,7 @@ security: {
     keys: ["hooman"]
   },
   ssl: {
+    keystore-file: "conseil.p12"
     keystore-password: "conseil"
   }
 }

--- a/src/main/scala/tech/cryptonomic/conseil/Conseil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Conseil.scala
@@ -49,9 +49,10 @@ object Conseil extends App with LazyLogging with EnableCORSDirectives {
   // Begin HTTPS setup
   // Drawn from https://doc.akka.io/docs/akka-http/10.0.11/scala/http/server-side/server-https-support.html#ssl-config
 
+  val keyStoreFile = conf.getString("security.ssl.keystore-file")
   val password: Array[Char] = conf.getString("security.ssl.keystore-password").toCharArray
   val ks: KeyStore = KeyStore.getInstance("PKCS12")
-  val keystore: InputStream = getClass.getClassLoader.getResourceAsStream("conseil.p12")
+  val keystore: InputStream = getClass.getClassLoader.getResourceAsStream(keyStoreFile)
 
   require(keystore != null, "Keystore required!")
   ks.load(keystore, password)


### PR DESCRIPTION
As the keystore file name and (implicitly) location were hard-coded, Conseil was not able to receive requests in production. This code change makes the keystore configurable. 