### PR TITLE
Refactored code so unit tests would not fail due to DB access.

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
@@ -37,7 +37,7 @@ object Lorre extends App with LazyLogging {
     */
   def processTezosBlocks(): Try[Unit] = {
     logger.info("Processing Tezos Blocks..")
-    tezosNodeOperator.getBlocksNotInDatabase("alphanet") match {
+    tezosNodeOperator.getBlocksNotInDatabase("alphanet", followFork = true) match {
       case Success(blocks) =>
         Try {
           val dbFut = TezosDatabaseOperations.writeBlocksToDatabase(blocks, db)

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTest.scala
@@ -79,7 +79,7 @@ class TezosNodeOperatorTest extends FlatSpec with MockFactory with Matchers with
 
   "getBlocks" should "fetch the correct number of blocks" in {
     val nodeOp: TezosNodeOperator = new TezosNodeOperator(MockTezosNode)
-    val blocks = nodeOp.getBlocks("alphanet", 0, 3, None)
+    val blocks = nodeOp.getBlocks("alphanet", 0, 3, None, followFork = false)
     blocks.get.length should be (4)
   }
 
@@ -87,37 +87,37 @@ class TezosNodeOperatorTest extends FlatSpec with MockFactory with Matchers with
 
   "getBlocks" should "handle a failed RPC request" in {
     val nodeOp: TezosNodeOperator = new TezosNodeOperator(MockTezosNodeWithErrors)
-    val blocks = nodeOp.getBlocks("alphanet", 0, 3, None)
+    val blocks = nodeOp.getBlocks("alphanet", 0, 3, None, followFork = false)
     blocks.isFailure should be (true)
   }
 
   "getBlocks" should "work correctly with a hint whose level is too high" in {
     val nodeOp: TezosNodeOperator = new TezosNodeOperator(MockTezosNode)
-    val blocks = nodeOp.getBlocks("alphanet", 0, 2, Some("BMXXHxiX1zsCAMvvSUMR3jhNEBVWAp2CdviAgYrJ5NYYUJbL1zF"))
+    val blocks = nodeOp.getBlocks("alphanet", 0, 2, Some("BMXXHxiX1zsCAMvvSUMR3jhNEBVWAp2CdviAgYrJ5NYYUJbL1zF"), followFork = false)
     blocks.get.length should be (3)
   }
 
   "getBlocks" should "work correctly with a hint whose level is too low" in {
     val nodeOp: TezosNodeOperator = new TezosNodeOperator(MockTezosNode)
-    val blocks = nodeOp.getBlocks("alphanet", 2, 3, Some("BLockGenesisGenesisGenesisGenesisGenesisFFFFFgtaC8G"))
+    val blocks = nodeOp.getBlocks("alphanet", 2, 3, Some("BLockGenesisGenesisGenesisGenesisGenesisFFFFFgtaC8G"), followFork = false)
     blocks.get.length should be (0)
   }
 
   "getBlocks" should "handle an invalid block payload" in {
     val nodeOp: TezosNodeOperator = new TezosNodeOperator(MockTezosNode)
-    val blocks = nodeOp.getBlocks("alphanet", 0, 3, Some("fakeblock"))
+    val blocks = nodeOp.getBlocks("alphanet", 0, 3, Some("fakeblock"), followFork = false)
     blocks.isFailure should be (true)
   }
 
   "getBlocks" should "work correctly with an offset" in {
     val nodeOp: TezosNodeOperator = new TezosNodeOperator(MockTezosNode)
-    val blocks = nodeOp.getBlocks("alphanet", 3, None)
+    val blocks = nodeOp.getBlocks("alphanet", 3, None, followFork = false)
     blocks.get.size should be (3)
   }
 
   "getBlocks" should "work correctly with an offset and hint" in {
     val nodeOp: TezosNodeOperator = new TezosNodeOperator(MockTezosNode)
-    val blocks = nodeOp.getBlocks("alphanet", 3, Some("BMMYEBsahXhnCdb7RqGTPnt9a8kdpMApjVV5iXzxr9MFdS4MHuP"))
+    val blocks = nodeOp.getBlocks("alphanet", 3, Some("BMMYEBsahXhnCdb7RqGTPnt9a8kdpMApjVV5iXzxr9MFdS4MHuP"), followFork = false)
     blocks.get.head.metadata.hash should be ("BLockGenesisGenesisGenesisGenesisGenesisFFFFFgtaC8G")
   }
 


### PR DESCRIPTION
In #45 Lorre was made resilient to certain kinds of Tezos forks by adding database checks. Unfortunately, this broke the unit tests for functions using a mock Tezos node as the database functionality has not yet been itself mocked. This PR works around this by making the fork resiliency logic explicitly optional and having the unit tests not invoke the resiliency logic for the interim period. 

Database mocking for unit tests is queued under #38.