### PR TITLE
Add support for common operations in Conseil

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,8 @@ libraryDependencies  ++=  Seq(
   "org.scalamock" %% "scalamock" % "4.0.0" % Test,
   "com.madgag.spongycastle" % "core" % "1.58.0.0",
   "org.scorexfoundation" %% "scrypto" % "2.0.0",
-  "com.muquit.libsodiumjna" % "libsodium-jna" % "1.0.4"
+  "com.muquit.libsodiumjna" % "libsodium-jna" % "1.0.4",
+  "com.github.alanverbner" %% "bip39" % "0.1"
 )
 
 assemblyExcludedJars in assembly := {

--- a/src/main/scala/tech/cryptonomic/conseil/routes/Tezos.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/Tezos.scala
@@ -111,8 +111,32 @@ object Tezos extends LazyLogging {
       } ~ gatherKeyInfo { keyStore =>
         path("request_faucet") {
           nodeOp.fundAccountWithFaucet(network, keyStore) match {
-            case Success(identity) => complete(JsonUtil.toJson(identity))
+            case Success(result) => complete(JsonUtil.toJson(result))
             case Failure(e) => failWith(e)
+          }
+        } ~  path("originate_account") {
+          parameters("amount".as[Float], "spendable".as[Boolean], "delegatable".as[Boolean], "delegate".as[String], "fee".as[Float]) {
+            (amount, spendable, delegatable, delegate, fee) =>
+            nodeOp.sendOriginationOperation(network, keyStore, amount, delegate, delegatable, spendable, fee) match {
+              case Success(result) => complete(JsonUtil.toJson(result))
+              case Failure(e) => failWith(e)
+            }
+          }
+        } ~  path("set_delegate") {
+          parameters("delegate".as[String], "fee".as[Float]) {
+            (delegate, fee) =>
+              nodeOp.sendDelegationOperation(network, keyStore, delegate, fee) match {
+                case Success(result) => complete(JsonUtil.toJson(result))
+                case Failure(e) => failWith(e)
+              }
+          }
+        }~  path("send_transaction") {
+          parameters("amount".as[Float], "to".as[String], "fee".as[Float]) {
+            (amount, to, fee) =>
+              nodeOp.sendTransactionOperation(network, keyStore, to, amount, fee) match {
+                case Success(result) => complete(JsonUtil.toJson(result))
+                case Failure(e) => failWith(e)
+              }
           }
         }
       }

--- a/src/main/scala/tech/cryptonomic/conseil/routes/Tezos.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/Tezos.scala
@@ -19,6 +19,7 @@ object Tezos extends LazyLogging {
 
   val nodeOp: TezosNodeOperator = new TezosNodeOperator(TezosNodeInterface)
 
+  // Directive for extracting out filter parameters for most GET operations.
   val gatherConseilFilter: Directive[Tuple1[Filter]] = parameters(
     "limit".as[Int].?,
     "block_id".as[String].*,
@@ -46,6 +47,7 @@ object Tezos extends LazyLogging {
     provide(filter)
   }
 
+  // Directive for gathering account information for most POST operations.
   val gatherKeyInfo: Directive[Tuple1[KeyStore]] = parameters(
     "publicKey".as[String],
     "privateKey".as[String],

--- a/src/main/scala/tech/cryptonomic/conseil/routes/Tezos.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/Tezos.scala
@@ -1,10 +1,11 @@
 package tech.cryptonomic.conseil.routes
 
 import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.server.{Directive, Route}
 import com.typesafe.scalalogging.LazyLogging
-import tech.cryptonomic.conseil.tezos.ApiOperations
+import tech.cryptonomic.conseil.tezos.{ApiOperations, TezosNodeInterface, TezosNodeOperator}
 import tech.cryptonomic.conseil.tezos.ApiOperations.Filter
+import tech.cryptonomic.conseil.util.CryptoUtil.KeyStore
 import tech.cryptonomic.conseil.util.{DatabaseUtil, JsonUtil}
 
 import scala.util.{Failure, Success}
@@ -16,33 +17,48 @@ object Tezos extends LazyLogging {
 
   val dbHandle = DatabaseUtil.db
 
+  val nodeOp: TezosNodeOperator = new TezosNodeOperator(TezosNodeInterface)
+
+  val gatherConseilFilter: Directive[Tuple1[Filter]] = parameters(
+    "limit".as[Int].?,
+    "block_id".as[String].*,
+    "block_level".as[Int].*,
+    "block_netid".as[String].*,
+    "block_protocol".as[String].*,
+    "operation_id".as[String].*,
+    "operation_source".as[String].*,
+    "account_id".as[String].*,
+    "account_manager".as[String].*,
+    "account_delegate".as[String].*
+  ).tflatMap{ tuple =>
+    val (limit, block_ids, block_levels, block_netIDs, block_protocols, op_ids, op_sources, account_ids, account_managers, account_delegates) = tuple
+    val filter: Filter = Filter(
+      limit = limit, blockIDs = Some(block_ids.toSet),
+      levels = Some(block_levels.toSet),
+      netIDs = Some(block_netIDs.toSet),
+      protocols = Some(block_protocols.toSet),
+      operationIDs = Some(op_ids.toSet),
+      operationSources = Some(op_sources.toSet),
+      accountIDs = Some(account_ids.toSet),
+      accountManagers = Some(account_managers.toSet),
+      accountDelegates = Some(account_delegates.toSet)
+    )
+    provide(filter)
+  }
+
+  val gatherKeyInfo: Directive[Tuple1[KeyStore]] = parameters(
+    "publicKey".as[String],
+    "privateKey".as[String],
+    "publicKeyHash".as[String]
+  ).tflatMap{ tuple =>
+    val (publicKey, privateKey, publicKeyHash) = tuple
+    val keyStore = KeyStore(publicKey = publicKey, privateKey = privateKey, publicKeyHash = publicKeyHash)
+    provide(keyStore)
+  }
+
   val route: Route = pathPrefix(Segment) { network =>
     get {
-      parameters(
-        "limit".as[Int].?,
-        "block_id".as[String].*,
-        "block_level".as[Int].*,
-        "block_netid".as[String].*,
-        "block_protocol".as[String].*,
-        "operation_id".as[String].*,
-        "operation_source".as[String].*,
-        "account_id".as[String].*,
-        "account_manager".as[String].*,
-        "account_delegate".as[String].*
-      ) { (limit, block_ids, block_levels, block_netIDs, block_protocols, op_ids, op_sources, account_ids, account_managers, account_delegates) =>
-
-        val filter: Filter = Filter(
-          limit = limit, blockIDs = Some(block_ids.toSet),
-          levels = Some(block_levels.toSet),
-          netIDs = Some(block_netIDs.toSet),
-          protocols = Some(block_protocols.toSet),
-          operationIDs = Some(op_ids.toSet),
-          operationSources = Some(op_sources.toSet),
-          accountIDs = Some(account_ids.toSet),
-          accountManagers = Some(account_managers.toSet),
-          accountDelegates = Some(account_delegates.toSet)
-        )
-
+      gatherConseilFilter{ filter =>
         pathPrefix("blocks") {
           pathEnd {
             ApiOperations.fetchBlocks(filter) match {
@@ -83,6 +99,20 @@ object Tezos extends LazyLogging {
               case Success(operationGroup) => complete(JsonUtil.toJson(operationGroup))
               case Failure(e) => failWith(e)
             }
+          }
+        }
+      }
+    } ~ post {
+      path("generate_identity") {
+        nodeOp.createIdentity() match {
+          case Success(identity) => complete(JsonUtil.toJson(identity))
+          case Failure(e) => failWith(e)
+        }
+      } ~ gatherKeyInfo { keyStore =>
+        path("request_faucet") {
+          nodeOp.fundAccountWithFaucet(network, keyStore) match {
+            case Success(identity) => complete(JsonUtil.toJson(identity))
+            case Failure(e) => failWith(e)
           }
         }
       }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -465,7 +465,7 @@ class TezosNodeOperator(node: TezosRPCInterface) extends LazyLogging {
       "managerPubkey" -> keyStore.publicKeyHash,
       "spendable"     -> spendable,
       "delegatable"   -> delegatable,
-      "delegate"      -> keyStore.publicKeyHash
+      "delegate"      -> delegate
     )
     sendOperation(network, transactionMap, keyStore, Some(fee))
   }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -452,9 +452,12 @@ class TezosNodeOperator(node: TezosRPCInterface) extends LazyLogging {
         if(faucetResult.accounts.isEmpty) throw new Exception("Free account was not created.")
         else faucetResult.accounts.head
       }.flatMap{ freeAccount =>
-        val freeAccountKeyStore = keyStore.copy(publicKeyHash = freeAccount)
-        // The hardcoded amount is a hack and will soon be mercilessly removed.
-        sendTransactionOperation(network, freeAccountKeyStore, keyStore.publicKeyHash, 1000f, 0f)
+        getAccountForBlock(network, "prevalidation", freeAccount).flatMap{account =>
+          Try(account.balance.toString.toFloat).flatMap{balance =>
+            val freeAccountKeyStore = keyStore.copy(publicKeyHash = freeAccount)
+            sendTransactionOperation(network, freeAccountKeyStore, keyStore.publicKeyHash, balance, 0f)
+          }
+        }
       }
     }
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -1,11 +1,10 @@
 package tech.cryptonomic.conseil.tezos
 
-import java.math.BigInteger
-
-import com.muquit.libsodiumjna.SodiumLibrary
+import com.muquit.libsodiumjna.{SodiumKeyPair, SodiumLibrary, SodiumUtils}
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
 import tech.cryptonomic.conseil.tezos.TezosTypes.{AccountsWithBlockHash, Block, OperationGroup}
+import tech.cryptonomic.conseil.util.CryptoUtil.KeyStore
 import tech.cryptonomic.conseil.util.JsonUtil.fromJson
 import tech.cryptonomic.conseil.util.{CryptoUtil, JsonUtil}
 
@@ -22,18 +21,13 @@ class TezosNodeOperator(node: TezosRPCInterface) extends LazyLogging {
   val sodiumLibraryPath: String = conf.getString("sodium.libraryPath")
 
   /**
-    * Tezos public/private key pair, encoded using Base58Check
-    * @param publicKey  Public key
-    * @param privateKey Private key
-    */
-  case class KeyPair(publicKey: String, privateKey: String)
-
-  /**
     * Output of transaction signing.
     * @param bytes      Signed bytes of the transaction
     * @param signature  The actual signature
     */
   case class SignedOperationGroup(bytes: Array[Byte], signature: String)
+
+  case class OperationResult(accounts: Seq[String], operationGroupID: String)
 
   /**
     * Fetches a specific account for a given block.
@@ -236,8 +230,7 @@ class TezosNodeOperator(node: TezosRPCInterface) extends LazyLogging {
     * @param blockHead  The block head
     * @param account    The sender's account
     * @param operation  The operation being forged as part of this operation group
-    * @param keys       Public/private key pair
-    * @param accountID  Public key hash to which the transaction is being sent
+    * @param keyStore   Key pair along with public key hash
     * @param fee        Fee to be paid
     * @return           Forged operation bytes (as a hex string)
     */
@@ -245,18 +238,25 @@ class TezosNodeOperator(node: TezosRPCInterface) extends LazyLogging {
                         blockHead: TezosTypes.Block,
                         account: TezosTypes.Account,
                         operation: Map[String,Any],
-                        keys: KeyPair,
-                        accountID: String,
-                        fee: Float
+                        keyStore: KeyStore,
+                        fee: Option[Float]
                      ): Try[String] = {
-    val payload: Map[String, Any] = Map(
-      "branch" -> blockHead.metadata.predecessor,
-      "source" -> accountID,
-      "operations" -> List[Map[String, Any]](operation),
-      "counter" -> (account.counter + 1),
-      "fee" -> fee,
-      "public_key" -> keys.publicKey
-    )
+    val payload: Map[String, Any] = fee match {
+      case Some(feeAmt) =>
+        Map(
+          "branch" -> blockHead.metadata.predecessor,
+          "source" -> keyStore.publicKeyHash,
+          "operations" -> List[Map[String, Any]](operation),
+          "counter" -> (account.counter + 1),
+          "fee" -> feeAmt,
+          "public_key" -> keyStore.publicKey
+        )
+      case None =>
+        Map(
+          "branch" -> blockHead.metadata.predecessor,
+          "operations" -> List[Map[String, Any]](operation)
+        )
+    }
     node.runQuery(network, "/blocks/prevalidation/proto/helpers/forge/operations", Some(JsonUtil.toJson(payload)))
       .flatMap { json =>
         Try {
@@ -272,14 +272,15 @@ class TezosNodeOperator(node: TezosRPCInterface) extends LazyLogging {
   /**
     * Signs a forged operation
     * @param forgedOperation  Forged operation group returned by the Tezos client (as a hex string)
-    * @param privateKey       Private key
+    * @param keyStore         Key pair along with public key hash
     * @return                 Bytes of the signed operation along with the actual signature
     */
-  def signOperationGroup(forgedOperation: String, privateKey: String): Try[SignedOperationGroup] = Try{
+  def signOperationGroup(forgedOperation: String, keyStore: KeyStore): Try[SignedOperationGroup] = Try{
     SodiumLibrary.setLibraryPath(sodiumLibraryPath)
-    val bytes = new BigInteger(forgedOperation, 16).toByteArray
-    val pvBytes = CryptoUtil.base58CheckDecode(privateKey, "edsk").get
-    val sig: Array[Byte] = SodiumLibrary.cryptoSignDetached(bytes, pvBytes)
+    //val bytes = new BigInteger(forgedOperation, 16).toByteArray
+    val bytes = SodiumUtils.hex2Binary(forgedOperation)
+    val pvBytes = CryptoUtil.base58CheckDecode(keyStore.privateKey, "edsk").get
+    val sig: Array[Byte] = SodiumLibrary.cryptoSignDetached(bytes, pvBytes.toArray)
     val edsig: String = CryptoUtil.base58CheckEncode(sig.toList, "edsig").get
     val sbytes = bytes ++ sig
     SignedOperationGroup(sbytes, edsig)
@@ -356,20 +357,20 @@ class TezosNodeOperator(node: TezosRPCInterface) extends LazyLogging {
     * Master function for creating and sending all supported types of operations.
     * @param network    Which Tezos network to go against
     * @param operation  The operation to create and send
-    * @param keys       Public/private key pair
-    * @param accountID  The public key hash to send the operation to
+    * @param keyStore   Key pair along with public key hash
     * @param fee        The fee to use
     * @return           The ID of the created operation group
     */
-  def sendOperation(network: String, operation: Map[String,Any], keys: KeyPair, accountID: String, fee: Float): Try[Array[String]] = {
+  def sendOperation(network: String, operation: Map[String,Any], keyStore: KeyStore, fee: Option[Float]): Try[OperationResult] = {
     getBlockHead(network).flatMap{ blockHead =>
-      getAccountForBlock(network, blockHead.metadata.hash, accountID).flatMap{ account =>
-        forgeOperations(network, blockHead, account, operation, keys, accountID, fee).flatMap { forgedOperationGroup =>
-          signOperationGroup(forgedOperationGroup, keys.privateKey).flatMap { signedOpGroup =>
+      getAccountForBlock(network, "prevalidation", keyStore.publicKeyHash).flatMap{ account =>
+        forgeOperations(network, blockHead, account, operation, keyStore, fee).flatMap { forgedOperationGroup =>
+          signOperationGroup(forgedOperationGroup, keyStore).flatMap { signedOpGroup =>
             computeOperationHash(signedOpGroup).flatMap { operationGroupHash =>
-              applyOperation(network, blockHead, operationGroupHash, forgedOperationGroup, signedOpGroup).flatMap { contracts =>
-                injectOperation(network, signedOpGroup).flatMap{ _ =>
-                  Try(contracts)
+              applyOperation(network, blockHead, operationGroupHash, forgedOperationGroup, signedOpGroup).flatMap { accounts =>
+                injectOperation(network, signedOpGroup).flatMap{ operation =>
+                  logger.info(operation)
+                  Try(OperationResult(accounts, operation))
                 }
               }
             }
@@ -382,29 +383,107 @@ class TezosNodeOperator(node: TezosRPCInterface) extends LazyLogging {
   /**
     * Creates and sends a transaction operation.
     * @param network    Which Tezos network to go against
-    * @param publicKey  Public key
-    * @param privateKey Private key
-    * @param from       Source public key hash
+    * @param keyStore   Key pair along with public key hash
     * @param to         Destination public key hash
     * @param amount     Amount to send
     * @param fee        Fee to use
     * @return           The ID of the created operation group
     */
-  def sendTransaction(
+  def sendTransactionOperation(
                        network: String,
-                       publicKey: String,
-                       privateKey: String,
-                       from: String,
+                       keyStore: KeyStore,
                        to: String,
                        amount: Float,
                        fee: Float
-                     ): Try[Array[String]] = {
-    val keys = KeyPair(publicKey, privateKey)
+                     ): Try[OperationResult] = {
     val transactionMap: Map[String,Any] = Map(
       "kind"        -> "transaction",
       "amount"      -> amount,
       "destination" -> to
     )
-    sendOperation(network, transactionMap, keys, from, fee)
+    sendOperation(network, transactionMap, keyStore, Some(fee))
+  }
+
+  private def generateHexNonce() : String = {
+    val random = new scala.util.Random
+    val alphabet = "0123456789abcedf"
+    Stream.continually(random.nextInt(alphabet.length)).map(alphabet).take(32).mkString
+  }
+
+  def sendFaucetOperation(
+                         network: String,
+                         keyStore: KeyStore
+                       ): Try[OperationResult] = {
+    val transactionMap: Map[String,Any] = Map(
+      "kind"        -> "faucet",
+      "id"          -> keyStore.publicKeyHash,
+      "nonce"       -> generateHexNonce()
+    )
+    sendOperation(network, transactionMap, keyStore, None)
+  }
+
+  def fundAccountWithFaucet(
+                             network: String,
+                             keyStore: KeyStore
+                           ): Try[OperationResult] =
+    sendFaucetOperation(network, keyStore).flatMap{ faucetResult =>
+      Try{
+        if(faucetResult.accounts.isEmpty) throw new Exception("Free account was not created.")
+        else faucetResult.accounts.head
+      }.flatMap{ freeAccount =>
+        val freeAccountKeyStore = keyStore.copy(publicKeyHash = freeAccount)
+        // The hardcoded amount is a hack and will soon be mercilessly removed.
+        sendTransactionOperation(network, freeAccountKeyStore, keyStore.publicKeyHash, 1000f, 0f)
+      }
+    }
+
+  def sendDelegationOperation(
+                               network: String,
+                               keyStore: KeyStore,
+                               delegate: String,
+                               fee: Float
+                             ): Try[OperationResult] = {
+    val transactionMap: Map[String,Any] = Map(
+      "kind"        -> "delegation",
+      "delegate"    -> delegate
+    )
+    sendOperation(network, transactionMap, keyStore, Some(fee))
+  }
+
+  def sendOriginationOperation(
+                               network: String,
+                               keyStore: KeyStore,
+                               amount: Float,
+                               delegate: String,
+                               spendable: Boolean,
+                               delegatable: Boolean,
+                               fee: Float
+                             ): Try[OperationResult] = {
+    val transactionMap: Map[String,Any] = Map(
+      "kind"          -> "origination",
+      "balance"       -> amount,
+      "managerPubkey" -> keyStore.publicKeyHash,
+      "spendable"     -> spendable,
+      "delegatable"   -> delegatable,
+      "delegate"      -> keyStore.publicKeyHash
+    )
+    sendOperation(network, transactionMap, keyStore, Some(fee))
+  }
+
+  def createIdentity(): Try[KeyStore] = {
+    SodiumLibrary.setLibraryPath(sodiumLibraryPath)
+
+    //The Java bindings for libSodium don't support generating a key pair from a seed.
+    //We will revisit this later in order to support mnemomics and passphrases
+    //val mnemonic = bip39.generate(Entropy128, WordList.load(EnglishWordList).get, new SecureRandom())
+    //val seed = bip39.toSeed(mnemonic, Some(passphrase))
+
+    val keyPair: SodiumKeyPair = SodiumLibrary.cryptoSignKeyPair()
+    val rawPublicKeyHash = SodiumLibrary.cryptoGenerichash(keyPair.getPublicKey, 20)
+    for {
+      privateKey <- CryptoUtil.base58CheckEncode(keyPair.getPrivateKey, "edsk")
+      publicKey <- CryptoUtil.base58CheckEncode(keyPair.getPublicKey, "edpk")
+      publicKeyHash <- CryptoUtil.base58CheckEncode(rawPublicKeyHash, "tz1")
+    } yield KeyStore(privateKey = privateKey, publicKey = publicKey, publicKeyHash = publicKeyHash)
   }
 }

--- a/src/main/scala/tech/cryptonomic/conseil/util/CryptoUtil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/util/CryptoUtil.scala
@@ -9,6 +9,8 @@ import scala.util.Try
   */
 object CryptoUtil {
 
+  case class KeyStore(publicKey: String, privateKey: String, publicKeyHash: String)
+
   /**
     * Get byte prefix for Base58Check encoding and decoding of a given type of data.
     * @param prefix The type of data
@@ -31,7 +33,7 @@ object CryptoUtil {
     * @param prefix   Prefix
     * @return         Encoded string
     */
-  def base58CheckEncode(payload: List[Byte], prefix: String): Try[String] =
+  def base58CheckEncode(payload: Seq[Byte], prefix: String): Try[String] =
     getBase58BytesForPrefix(prefix).flatMap { prefix =>
       Try {
         Base58Check.encode(prefix, payload)
@@ -44,7 +46,7 @@ object CryptoUtil {
     * @param prefix Prefix
     * @return       Decoded bytes
     */
-  def base58CheckDecode(s: String, prefix: String): Try[Array[Byte]] =
+  def base58CheckDecode(s: String, prefix: String): Try[Seq[Byte]] =
     getBase58BytesForPrefix(prefix).flatMap{ prefix =>
       Try {
         val charsToSlice = prefix.length

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTest.scala
@@ -3,6 +3,7 @@ package tech.cryptonomic.conseil.tezos
 import com.typesafe.scalalogging.LazyLogging
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FlatSpec, Matchers}
+import tech.cryptonomic.conseil.util.CryptoUtil.KeyStore
 
 import scala.util.Try
 
@@ -70,6 +71,18 @@ class TezosNodeOperatorTest extends FlatSpec with MockFactory with Matchers with
     }
 
   }
+
+  val keyStore: KeyStore = KeyStore(
+    publicKey = "edpku8PouyaJa2GPyXNsqsFiqjc3PZ2bc2ujzNUJQJ87N1jwTckp7n",
+    privateKey = "edskRjp9WGL5QDFBcjHJGdxh6wfNtAYZY7CFmjSXbXSHWDydw8S9VVbaPJNFaDpHC2UscMTJWVryEQCUewQ8SNEChG2Vnb6GXA",
+    publicKeyHash = "tz1eyrhHFQ6McdKkTeZtBKoRYUsgRgARN7QE"
+  )
+
+  /*val keyStore: KeyStore = KeyStore(
+    publicKey = "edpku5ViG6Pc3uYooHuWhLr3eb2x86xNettKRm5SXBg9AfoYqrWdZc",
+    privateKey = "edskRtLP6MGr3Y4taNfC19f4TjU3KYYHpfLQzxxovzX5aS4TztpbpajTVUzruNj53iLvymkwTKAnfE72dvPx7BPBan5tvdTrAg",
+    publicKeyHash = "tz1R7cAdCTtFAWmVkju1cVUceyrR1vHvhu2Z"
+  )*/
 
   "getBlock" should "should correctly fetch the genesis block" in {
     val nodeOp: TezosNodeOperator = new TezosNodeOperator(MockTezosNode)
@@ -143,15 +156,62 @@ class TezosNodeOperatorTest extends FlatSpec with MockFactory with Matchers with
 
   "sendTransaction" should "correctly send a transaction" in {
     val nodeOp: TezosNodeOperator = new TezosNodeOperator(TezosNodeInterface)
-    val result = nodeOp.sendTransaction(
+    val result = nodeOp.sendTransactionOperation(
       "alphanet",
-      "edpku5ViG6Pc3uYooHuWhLr3eb2x86xNettKRm5SXBg9AfoYqrWdZc",
-      "edskRtLP6MGr3Y4taNfC19f4TjU3KYYHpfLQzxxovzX5aS4TztpbpajTVUzruNj53iLvymkwTKAnfE72dvPx7BPBan5tvdTrAg",
+      keyStore,
       "tz1R7cAdCTtFAWmVkju1cVUceyrR1vHvhu2Z",
-      "tz1R7cAdCTtFAWmVkju1cVUceyrR1vHvhu2Z",
-      0f,
-      0f
+      100f,
+      1f
     )
-    result.isFailure should be (true)   // TODO: Set to expect success state once transaction logic is fixed.
+    result.isSuccess should be (true)
+  }
+
+  "sendFaucetRequest" should "correctly create a free account" in {
+    val nodeOp: TezosNodeOperator = new TezosNodeOperator(TezosNodeInterface)
+    val result = nodeOp.sendFaucetOperation(
+      "alphanet",
+      keyStore
+    )
+    result.isSuccess should be (true)
+  }
+
+  "fundAccountWithFaucet" should "fund a given account using the faucet" in {
+    val nodeOp: TezosNodeOperator = new TezosNodeOperator(TezosNodeInterface)
+    val result = nodeOp.fundAccountWithFaucet(
+      "alphanet",
+      keyStore
+    )
+    result.isSuccess should be (true)
+  }
+
+  "sendDelegationOperation" should "correctly delegate to a given account" in {
+    val nodeOp: TezosNodeOperator = new TezosNodeOperator(TezosNodeInterface)
+    val result = nodeOp.sendDelegationOperation(
+      "alphanet",
+      keyStore,
+      "tz1R7cAdCTtFAWmVkju1cVUceyrR1vHvhu2Z",
+      1f
+    )
+    result.isSuccess should be (true)
+  }
+
+  "sendOriginationOperation" should "originate an account" in {
+    val nodeOp: TezosNodeOperator = new TezosNodeOperator(TezosNodeInterface)
+    val result = nodeOp.sendOriginationOperation(
+      "alphanet",
+      keyStore,
+      100f,
+      "tz1R7cAdCTtFAWmVkju1cVUceyrR1vHvhu2Z",
+      spendable = true,
+      delegatable = true,
+      1f
+    )
+    result.isSuccess should be (true)
+  }
+
+  "createAccount" should "generate a new Tezos key pair" in {
+    val nodeOp: TezosNodeOperator = new TezosNodeOperator(TezosNodeInterface)
+    val result = nodeOp.createIdentity()
+    result.isSuccess should be (true)
   }
 }


### PR DESCRIPTION
This PR adds the following operation types to Conseil:
- Origination
- Faucet requests
- Delegation
- Transactions of funds

In addition, it adds the ability to generate new Tezos identities with key pairs and public key hashes. 

All of the above are available as POST routes in the Conseil API.

Contract creation and invocation is not yet support and is left on the agenda as future work.