### PR TITLE
Reduced logging verbosity for Conseil and Lorre.

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/Conseil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Conseil.scala
@@ -41,7 +41,7 @@ object Conseil extends App with LazyLogging with EnableCORSDirectives {
 
   val route = enableCORS {
     validateApiKey { _ =>
-      logRequest("Conseil", Logging.InfoLevel) {
+      logRequest("Conseil", Logging.DebugLevel) {
         pathPrefix("tezos") {
           Tezos.route
         }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeInterface.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeInterface.scala
@@ -33,7 +33,7 @@ object TezosNodeInterface extends TezosRPCInterface with LazyLogging {
       val port = conf.getInt(s"platforms.tezos.$network.node.port")
       val pathPrefix = conf.getString(s"platforms.tezos.$network.node.pathPrefix")
       val url = s"http://$hostname:$port/$pathPrefix$command"
-      logger.info(s"Querying URL $url for platform Tezos and network $network with payload $payload")
+      logger.debug(s"Querying URL $url for platform Tezos and network $network with payload $payload")
       val postedData = payload match {
         case None => """{}"""
         case Some(str) => str

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -191,7 +191,7 @@ class TezosNodeOperator(node: TezosRPCInterface) extends LazyLogging {
                            ): List[Block] =
     getBlock(network, hash) match {
       case Success(block) =>
-        logger.info(s"Current block height: ${block.metadata.level}")
+        logger.debug(s"Current block height: ${block.metadata.level}")
         if(block.metadata.level == 0 && minLevel <= 0)
           block :: blockSoFar
         else if(block.metadata.level == minLevel && !followFork)


### PR DESCRIPTION
As we have been logging at the 'info' level each incoming request (for Conseil) and each Tezos RPC request (for Lorre), the verbosity of the logs is causing disk space issues with syslogs and Elasticsearch. This fix changes the log levels to 'debug'. 