### PR TITLE
Conseil 70 filtering operations by kind

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -10,7 +10,7 @@
     <logger name="com.base22" level="TRACE"/>
 
 
-    <root level="info">
+    <root level="debug">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/src/main/scala/tech/cryptonomic/conseil/routes/Tezos.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/Tezos.scala
@@ -30,9 +30,11 @@ object Tezos extends LazyLogging {
     "operation_source".as[String].*,
     "account_id".as[String].*,
     "account_manager".as[String].*,
-    "account_delegate".as[String].*
+    "account_delegate".as[String].*,
+    "operation_kind".as[String].*,
+    "operation_group_kind".as[String].*
   ).tflatMap{ tuple =>
-    val (limit, block_ids, block_levels, block_chainIDs, block_protocols, op_ids, op_sources, account_ids, account_managers, account_delegates) = tuple
+    val (limit, block_ids, block_levels, block_chainIDs, block_protocols, op_ids, op_sources, account_ids, account_managers, account_delegates, operation_kind, operation_group_kind) = tuple
     val filter: Filter = Filter(
       limit = limit, blockIDs = Some(block_ids.toSet),
       levels = Some(block_levels.toSet),
@@ -42,7 +44,9 @@ object Tezos extends LazyLogging {
       operationSources = Some(op_sources.toSet),
       accountIDs = Some(account_ids.toSet),
       accountManagers = Some(account_managers.toSet),
-      accountDelegates = Some(account_delegates.toSet)
+      accountDelegates = Some(account_delegates.toSet),
+      operationKinds = Some(operation_kind.toSet),
+      operationGroupKinds = Some(operation_group_kind.toSet)
     )
     provide(filter)
   }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
@@ -40,6 +40,14 @@ object ApiOperations {
                      accountIDs: Option[Set[String]] = Some(Set[String]()),
                      accountManagers: Option[Set[String]] = Some(Set[String]()),
                      accountDelegates: Option[Set[String]] = Some(Set[String]()),
+                     endorsements: Option[Set[String]] = Some(Set[String]()),
+                     proposals: Option[Set[String]] = Some(Set[String]()),
+                     ballots: Option[Set[String]] = Some(Set[String]()),
+                     managers: Option[Set[String]] = Some(Set[String]()),
+                     revelations: Option[Set[String]] = Some(Set[String]()),
+                     transactions: Option[Set[String]] = Some(Set[String]()),
+                     originations: Option[Set[String]] = Some(Set[String]()),
+                     delegations: Option[Set[String]] = Some(Set[String]())
                    )
 
   // Start helper functions for constructing Slick queries
@@ -74,6 +82,10 @@ object ApiOperations {
     if (filter.accountDelegates.isDefined && filter.accountDelegates.get.nonEmpty)
       a.delegateValue.getOrElse("").inSet(filter.accountDelegates.get)
     else true
+
+  private def filterEndorsements(filter:Filter, op: Tables.OperationGroups): Rep[Boolean] =
+    if (filter.endorsements.isDefined && filter.endorsements.get.nonEmpty)
+
 
   private def getFilterLimit(filter: Filter): Int = if (filter.limit.isDefined) filter.limit.get else 10
 


### PR DESCRIPTION
Updated batch api operations to filter blocks, operation groups, and operations by kinds.

All (conditional) joins seem to be working as expected.