### PR TITLE
CONSEIL-75: Add OPTIONS route to Conseil to facilitate CORS preflight checks

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/Conseil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Conseil.scala
@@ -48,6 +48,9 @@ object Conseil extends App with LazyLogging with EnableCORSDirectives {
             Tezos.route
           }
         }
+      } ~ options {
+        // Support for CORS pre-flight checks.
+        complete(s"Supported methods : GET and POST.")
       }
     }
   }


### PR DESCRIPTION
As described in #75, Arronax does not work with Conseil when the latter is run remotely. The underlying issue is discussed at https://stackoverflow.com/questions/8153832/xmlhttprequest-changes-post-to-option#8154264. As a fix, a trivial OPTIONS route is being added to ensure OPTIONS requests during CORS preflight checks are being respected. The correct CORS response headers were already being returned. 