### PR TITLE
Increased default logging verbosity

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -10,7 +10,7 @@
     <logger name="com.base22" level="TRACE"/>
 
 
-    <root level="info">
+    <root level="debug">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>


### PR DESCRIPTION
Lorre and Conseil are regularly failing in production as they are not able to process return values from the Tezos client. This PR increases the Logback verbosity to make it easier to look at production logs and fix issues.

Please note this change will reverted as soon as stability is achieved. 