### PR TITLE
Removed write operation routes from Tezos.scala

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/routes/Tezos.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/Tezos.scala
@@ -128,39 +128,6 @@ object Tezos extends LazyLogging {
         }
 
       }
-    } ~ post {
-      path("generate_identity") {
-        nodeOp.createIdentity() match {
-          case Success(identity) => complete(JsonUtil.toJson(identity))
-          case Failure(e) => failWith(e)
-        }
-      } ~ gatherKeyInfo { keyStore =>
-        path("originate_account") {
-          parameters("amount".as[Float], "spendable".as[Boolean], "delegatable".as[Boolean], "delegate".as[String], "fee".as[Float]) {
-            (amount, spendable, delegatable, delegate, fee) =>
-              nodeOp.sendOriginationOperation(network, keyStore, amount, delegate, delegatable, spendable, fee) match {
-                case Success(result) => complete(JsonUtil.toJson(result))
-                case Failure(e) => failWith(e)
-              }
-          }
-        } ~  path("set_delegate") {
-          parameters("delegate".as[String], "fee".as[Float]) {
-            (delegate, fee) =>
-              nodeOp.sendDelegationOperation(network, keyStore, delegate, fee) match {
-                case Success(result) => complete(JsonUtil.toJson(result))
-                case Failure(e) => failWith(e)
-              }
-          }
-        }~  path("send_transaction") {
-          parameters("amount".as[Float], "to".as[String], "fee".as[Float]) {
-            (amount, to, fee) =>
-              nodeOp.sendTransactionOperation(network, keyStore, to, amount, fee) match {
-                case Success(result) => complete(JsonUtil.toJson(result))
-                case Failure(e) => failWith(e)
-              }
-          }
-        }
-      }
     }
   }
 }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
@@ -22,7 +22,7 @@ import scala.math.max
 object ApiOperations {
 
   private val conf = ConfigFactory.load
-  private val awaitTimeInSeconds = conf.getInt("dbawaitTimeInSecondsInSeconds")
+  private val awaitTimeInSeconds = conf.getInt("dbAwaitTimeInSeconds")
   lazy val dbHandle: Database = DatabaseUtil.db
 
   /**

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeInterface.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeInterface.scala
@@ -40,7 +40,7 @@ trait TezosRPCInterface {
 object TezosNodeInterface extends TezosRPCInterface with LazyLogging {
 
   private val conf = ConfigFactory.load
-  private val awaitTimeInSeconds = conf.getInt("dbawaitTimeInSecondsInSeconds")
+  private val awaitTimeInSeconds = conf.getInt("dbAwaitTimeInSeconds")
 
   implicit val system: ActorSystem = ActorSystem("lorre-system")
   implicit val materializer: ActorMaterializer = ActorMaterializer()


### PR DESCRIPTION
The operations routes have been removed. Also, there was a mistake in the config file reads (master said dbAwaitTimeinSecondsInSeconds instead of dbAwaitTimeInSeconds), so that was fixed too