### PR TITLE
Add a docker configuration to easily spin up a local db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .settings/
 target/
 .idea/
+pgdata/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.1"
+
+services:
+  conseil-postgres:
+    image: postgres:9.5.13
+    ports:
+    - 5432:5432
+    environment:
+      POSTGRES_USER: "conseiluser"
+      POSTGRES_PASSWORD: "p@ssw0rd"
+      POSTGRES_DB: "conseil-local"
+    volumes:
+    - "./pgdata:/var/lib/postgresql/data"
+    


### PR DESCRIPTION
A step towards creating an automated local environment
#132 

 * define the docker-compose file
 * the compose file defines a generic user and
   password, which would need overwriting
   based on the specific developer conf
 * mount a local directory as a volume so that
  postgres data would be kept between docker runs

Needs to improve the user/pass definition to avoid
manual intervention that keeps the git staging dirty