### PR TITLE
Using double precision numbers to do fee calcs

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/routes/Tezos.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/Tezos.scala
@@ -70,7 +70,7 @@ object Tezos extends LazyLogging {
   val route: Route = pathPrefix(Segment) { network =>
     get {
       gatherConseilFilter{ filter =>
-        validate(!filter.limit.isDefined || (filter.limit.isDefined && (filter.limit.get <= 10000)), s"Cannot ask for more than 10000 entries") {
+        validate(filter.limit.isEmpty || (filter.limit.isDefined && (filter.limit.get <= 10000)), s"Cannot ask for more than 10000 entries") {
           pathPrefix("blocks") {
             pathEnd {
               ApiOperations.fetchBlocks(filter) match {
@@ -114,7 +114,7 @@ object Tezos extends LazyLogging {
             }
           } ~ pathPrefix("operations") {
             path("avgFees") {
-              ApiOperations.averageFee(filter) match {
+              ApiOperations.fetchAverageFees(filter) match {
                 case Success(fees) => complete(JsonUtil.toJson(fees))
                 case Failure(e) => failWith(e)
               }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
@@ -278,7 +278,7 @@ object ApiOperations {
 
   /**
     * Filters Accounts, Operation Groups, Operations, and Blocks tables based on users input to the filter.
-    * @param filter
+    * @param filter Filter parameters.
     * @return
     */
   private def getFilteredTables(filter: Filter): Try[FilteredTables] = {
@@ -845,7 +845,7 @@ object ApiOperations {
     *         was performed at, and the kind of operation being
     *         averaged over.
     */
-  def averageFee(filter: Filter): Try[AverageFees] = Try {
+  def fetchAverageFees(filter: Filter): Try[AverageFees] = Try {
     val action = for {
       fee <- Tables.Fees
       if filterOperationKindsForFees(filter, fee)

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/FeeOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/FeeOperations.scala
@@ -2,7 +2,7 @@ package tech.cryptonomic.conseil.tezos
 
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
-import tech.cryptonomic.conseil.Lorre.{db}
+import tech.cryptonomic.conseil.Lorre.db
 import scala.concurrent.ExecutionContext.Implicits.global
 
 import scala.concurrent.Await
@@ -40,9 +40,7 @@ object FeeOperations extends LazyLogging {
   def processTezosAverageFees(): Try[Unit] = {
     logger.info("Processing latest Tezos fee data...")
     val operationKinds = List("seed_nonce_revelation", "delegation", "transaction", "activate_account", "origination", "reveal", "double_endorsement_evidence", "endorsement")
-    val fees = operationKinds.map{ kind =>
-      TezosDatabaseOperations.calculateAverageFees(kind)
-    }
+    val fees = operationKinds.map(TezosDatabaseOperations.calculateAverageFees)
     Try {
       val dbFut = TezosDatabaseOperations.writeFeesToDatabase(fees, db)
       dbFut onComplete {

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
@@ -189,7 +189,7 @@ object TezosDatabaseOperations {
     } yield (o.fee, o.timestamp)
     val op = dbHandle.run(action.distinct.sortBy(_._2.desc).take(numberOfFeesAveraged).result)
     val results = Await.result(op, Duration.apply(awaitTimeInSeconds, SECONDS))
-    val resultNumbers = results.map(x => x._1.getOrElse("0").toInt)
+    val resultNumbers = results.map(x => x._1.getOrElse("0").toDouble)
     val m: Int = ceil(mean(resultNumbers)).toInt
     val s: Int = ceil(stdev(resultNumbers)).toInt
     results.length match {

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeInterface.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeInterface.scala
@@ -19,10 +19,9 @@ trait TezosRPCInterface {
     * Runs an RPC call against the configured Tezos node using HTTP GET.
     * @param network  Which Tezos network to go against
     * @param command  RPC command to invoke
-    * @param payload  Optional JSON pyaload to post
     * @return         Result of the RPC call
     */
-  def runGetQuery(network: String, command: String, payload: Option[String] = None): Try[String]
+  def runGetQuery(network: String, command: String): Try[String]
 
   /**
     * Runs an RPC call against the configured Tezos node using HTTP POST.
@@ -47,14 +46,14 @@ object TezosNodeInterface extends TezosRPCInterface with LazyLogging {
   implicit val executionContext: ExecutionContextExecutor = system.dispatcher
 
   @Override
-  def runGetQuery(network: String, command: String, payload: Option[String]= None): Try[String] = {
+  def runGetQuery(network: String, command: String): Try[String] = {
     Try{
       val protocol = conf.getString(s"platforms.tezos.$network.node.protocol")
       val hostname = conf.getString(s"platforms.tezos.$network.node.hostname")
       val port = conf.getInt(s"platforms.tezos.$network.node.port")
       val pathPrefix = conf.getString(s"platforms.tezos.$network.node.pathPrefix")
       val url = s"$protocol://$hostname:$port/${pathPrefix}chains/main/$command"
-      logger.debug(s"Querying URL $url for platform Tezos and network $network with payload $payload")
+      logger.debug(s"Querying URL $url for platform Tezos and network $network")
       val responseFuture: Future[HttpResponse] =
         Http(system).singleRequest(
           HttpRequest(

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -315,7 +315,7 @@ class TezosNodeOperator(node: TezosRPCInterface) extends LazyLogging {
           "operations" -> operations
         )
     }
-    node.runGetQuery(network, "/blocks/head/proto/helpers/forge/operations", Some(JsonUtil.toJson(payload)))
+    node.runPostQuery(network, "/blocks/head/proto/helpers/forge/operations", Some(JsonUtil.toJson(payload)))
       .flatMap { json =>
         Try(JsonUtil.fromJson[TezosTypes.ForgedOperation](json)).flatMap{ forgedOperation =>
           Try(forgedOperation.operation)
@@ -375,7 +375,7 @@ class TezosNodeOperator(node: TezosRPCInterface) extends LazyLogging {
       "forged_operation" -> forgedOperationGroup,
       "signature" -> signedOpGroup.signature
     )
-    node.runGetQuery(network, "/blocks/head/proto/helpers/apply_operation", Some(JsonUtil.toJson(payload)))
+    node.runPostQuery(network, "/blocks/head/proto/helpers/apply_operation", Some(JsonUtil.toJson(payload)))
       .flatMap { result =>
         logger.debug(s"Result of operation application: $result")
         Try(JsonUtil.fromJson[TezosTypes.AppliedOperation](result))
@@ -392,7 +392,7 @@ class TezosNodeOperator(node: TezosRPCInterface) extends LazyLogging {
     val payload: Map[String, Any] = Map(
       "signedOperationContents" -> signedOpGroup.bytes.map("%02X" format _).mkString
     )
-    node.runGetQuery(network, "/inject_operation", Some(JsonUtil.toJson(payload))).flatMap{ result =>
+    node.runPostQuery(network, "/inject_operation", Some(JsonUtil.toJson(payload))).flatMap{ result =>
       Try {
         val injectedOp = JsonUtil.fromJson[TezosTypes.InjectedOperation](result)
         injectedOp.injectedOperation

--- a/src/main/scala/tech/cryptonomic/conseil/util/MathUtil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/util/MathUtil.scala
@@ -6,18 +6,18 @@ object MathUtil {
 
   /**
     * Average value of a sequence of integers.
-    * @param l Sequence of integers.
+    * @param l Sequence of doubles.
     * @return
     */
-  def mean(l: Seq[Int]): Double =
+  def mean(l: Seq[Double]): Double =
     l.sum*1.0 / l.length
 
   /**
     * Standard deviation of a sequence of integers.
-    * @param l Sequence of integers/
+    * @param l Sequence of doubles.
     * @return
     */
-  def stdev(l: Seq[Int]): Double = {
+  def stdev(l: Seq[Double]): Double = {
     val m = mean(l)
     val len = l.length*1.0
     sqrt(l.map(x => (x - m)*(x - m)).sum / len)

--- a/src/test/scala/tech/cryptonomic/conseil/util/MathUtilTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/util/MathUtilTest.scala
@@ -5,12 +5,12 @@ import org.scalatest.{FlatSpec, Matchers}
 class MathUtilTest extends FlatSpec with Matchers {
 
   "MathUtilTest" should "correctly calculate the mean of a sequence" in {
-    val dataset = List(1,2,3,4,5,6,7,8,9,10)
+    val dataset = List(1d,2d,3d,4d,5d,6d,7d,8d,9d,10d)
     MathUtil.mean(dataset) should be (5.5)
   }
 
   "MathUtilTest" should "correctly caculate the population standard deviation of a sequence" in {
-    val dataset = List(1,2,3,4,5,6,7,8,9,10)
+    val dataset = List(1d,2d,3d,4d,5d,6d,7d,8d,9d,10d)
     MathUtil.stdev(dataset) should be (2.8722813232690143)
   }
 


### PR DESCRIPTION
This addresses #134.

In addition, it fixes the invocation of GET requests by removing the unused `payload` argument and ensuring all HTTP calls for performing Tezos operations actually perform POST requests.