### PR TITLE
Filter out ISO control chars from tezos json responses before parsing

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/util/JsonUtil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/util/JsonUtil.scala
@@ -24,6 +24,6 @@ object JsonUtil {
   def toMap[V](json:String)(implicit m: Manifest[V]): Map[String, V] = fromJson[Map[String,V]](json)
 
   def fromJson[T](json: String)(implicit m : Manifest[T]): T = {
-    mapper.readValue[T](json)
+    mapper.readValue[T](json.filterNot(Character.isISOControl))
   }
 }


### PR DESCRIPTION
Hotfix for binary control characters generating exceptions in the jackson parser

This is the error
```
Sep 24 16:09:41 conseil-lorre lorre.sh[3307]:  at [Source: (String)"{"protocol":"PsYLVpVvgbLhAhoqAkMFUo6gudkJ9weNXhUYCiLDzcUpFpkk8Wt","chain_id":"NetXdQprcVkpaWU","hash":"BMDDuNKyDCR4eHJnp2k4z7AK86aj6tBhsK12zhYovAeBLvEd3Xf","header":{"level":117395,"proto":2,"predecessor":"BMBV9abraPY7tVTMsPzZCjEntcZx4jp22GeqNCbBKmmEYmGwWYD","timestamp":"2018-09-24T15:31:55Z","validation_pass":4,"operations_hash":"LLoax4rPdx6WYJvLFTcM1gmBMhxsifFqWowpLaT1xXbBG1FGQ84Tc","fitness":["00","0000000000331023"],"context":"CoVmQBLFq6jNv1d6HmyYJ4RMuvsLiKXP83XA46UPUu3UaK9oNiww","priority":"[truncated 15963 chars]; line: 1, column: 16142]
18:11
Sep 24 16:09:41 conseil-lorre lorre.sh[3307]: Exception in thread "main" com.fasterxml.jackson.core.JsonParseException: Illegal unquoted character ((CTRL-CHAR, code 0)): has to be escaped using backslash to be included in string value
Sep 24 16:09:41 conseil-lorre lorre.sh[3307]:  at [Source: (String)"{"protocol":"PsYLVpVvgbLhAhoqAkMFUo6gudkJ9weNXhUYCiLDzcUpFpkk8Wt","chain_id":"NetXdQprcVkpaWU","hash":"BMDDuNKyDCR4eHJnp2k4z7AK86aj6tBhsK12zhYovAeBLvEd3Xf","header":{"level":117395,"proto":2,"predecessor":"BMBV9abraPY7tVTMsPzZCjEntcZx4jp22GeqNCbBKmmEYmGwWYD","timestamp":"2018-09-24T15:31:55Z","validation_pass":4,"operations_hash":"LLoax4rPdx6WYJvLFTcM1gmBMhxsifFqWowpLaT1xXbBG1FGQ84Tc","fitness":["00","0000000000331023"],"context":"CoVmQBLFq6jNv1d6HmyYJ4RMuvsLiKXP83XA46UPUu3UaK9oNiww","priority":"[truncated 15963 chars]; line: 1, column: 16142]
```