### PR TITLE
Conseil-103: no partial functions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,9 @@ scalaVersion := "2.12.4"
 val akkaHttpVersion = "10.1.0"
 val akkaVersion = "2.5.11"
 
+scapegoatVersion in ThisBuild := "1.3.8"
+scapegoatIgnoredFiles := Seq(".*/tech/cryptonomic/conseil/tezos/Tables.scala")
+
 libraryDependencies  ++=  Seq(
   "ch.qos.logback" % "logback-classic" % "1.2.3",
   "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
@@ -33,3 +36,5 @@ excludeDependencies ++= Seq(
 )
 
 assemblyOutputPath in assembly := file("/tmp/conseil.jar")
+
+scalacOptions ++= ScalacOptions.common

--- a/project/ScalacOptions.scala
+++ b/project/ScalacOptions.scala
@@ -1,0 +1,51 @@
+object ScalacOptions {
+
+  val common = Seq(
+    "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
+    "-encoding", "utf-8",                // Specify character encoding used by source files.
+    "-explaintypes",                     // Explain type errors in more detail.
+    "-feature",                          // Emit warning and location for usages of features that should be imported explicitly.
+    "-language:existentials",            // Existential types (besides wildcard types) can be written and inferred
+    "-language:experimental.macros",     // Allow macro definition (besides implementation and application)
+    "-language:higherKinds",             // Allow higher-kinded types
+    "-language:implicitConversions",     // Allow definition of implicit functions called views
+    "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
+    "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
+    // "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
+    "-Xfuture",                          // Turn on future language features.
+    // "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
+    "-Xlint:by-name-right-associative",  // By-name parameter of right associative operator.
+    "-Xlint:constant",                   // Evaluation of a constant arithmetic expression results in an error.
+    "-Xlint:delayedinit-select",         // Selecting member of DelayedInit.
+    "-Xlint:doc-detached",               // A Scaladoc comment appears to be detached from its element.
+    "-Xlint:inaccessible",               // Warn about inaccessible types in method signatures.
+    "-Xlint:infer-any",                  // Warn when a type argument is inferred to be `Any`.
+    "-Xlint:missing-interpolator",       // A string literal appears to be missing an interpolator id.
+    "-Xlint:nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
+    "-Xlint:nullary-unit",               // Warn when nullary methods return Unit.
+    "-Xlint:option-implicit",            // Option.apply used implicit view.
+    "-Xlint:package-object-classes",     // Class or object defined in package object.
+    "-Xlint:poly-implicit-overload",     // Parameterized overloaded implicit methods are not visible as view bounds.
+    "-Xlint:private-shadow",             // A private field (or class parameter) shadows a superclass field.
+    "-Xlint:stars-align",                // Pattern sequence wildcard must align with sequence component.
+    "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
+    "-Xlint:unsound-match",              // Pattern match may not be typesafe.
+    // "-Yno-adapted-args",                 // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
+    "-Ypartial-unification",             // Enable partial unification in type constructor inference
+    "-Ywarn-dead-code",                  // Warn when dead code is identified.
+    "-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
+    "-Ywarn-inaccessible",               // Warn about inaccessible types in method signatures.
+    "-Ywarn-infer-any",                  // Warn when a type argument is inferred to be `Any`.
+    "-Ywarn-nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
+    "-Ywarn-nullary-unit",               // Warn when nullary methods return Unit.
+    // "-Ywarn-numeric-widen",              // Warn when numerics are widened.
+    "-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
+    "-Ywarn-unused:imports",             // Warn if an import selector is not referenced.
+    "-Ywarn-unused:locals",              // Warn if a local definition is unused.
+    "-Ywarn-unused:params",              // Warn if a value parameter is unused.
+    // "-Ywarn-unused:patvars",             // Warn if a variable bound in a pattern is unused.
+    "-Ywarn-unused:privates",            // Warn if a private member is unused.
+    "-Ywarn-value-discard"               // Warn when non-Unit expression results are unused.
+  )
+
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.2.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
+addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.0.9")

--- a/src/main/scala/tech/cryptonomic/conseil/Conseil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Conseil.scala
@@ -46,7 +46,7 @@ object Conseil extends App with LazyLogging with EnableCORSDirectives {
         }
       } ~ options {
         // Support for CORS pre-flight checks.
-        complete(s"Supported methods : GET and POST.")
+        complete("Supported methods : GET and POST.")
       }
     }
   }

--- a/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
@@ -41,7 +41,7 @@ object Lorre extends App with LazyLogging {
   private val purgeAccountsInterval = conf.getInt("lorre.purgeAccountsInterval")
 
   lazy val db = DatabaseUtil.db
-  val tezosNodeOperator = new TezosNodeOperator(TezosNodeInterface())
+  val tezosNodeOperator = new TezosNodeOperator(new TezosNodeInterface())
 
   //whatever happens we try to clean up
   sys.addShutdownHook(shutdown)

--- a/src/main/scala/tech/cryptonomic/conseil/db/DatabaseQueryExecution.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/db/DatabaseQueryExecution.scala
@@ -21,100 +21,100 @@ object DatabaseQueryExecution {
 
   sealed trait JoinedTables
 
-  case class BlocksOperationGroupsOperationsAccounts(
+  final case class BlocksOperationGroupsOperationsAccounts(
     join: Query[
       (Tables.Blocks, Tables.OperationGroups, Tables.Operations, Tables.Accounts),
       (Tables.BlocksRow, Tables.OperationGroupsRow, Tables.OperationsRow, Tables.AccountsRow),
       Seq]
   ) extends JoinedTables
 
-  case class BlocksOperationGroupsOperations(
+  final case class BlocksOperationGroupsOperations(
     join: Query[
       (Tables.Blocks, Tables.OperationGroups, Tables.Operations),
       (Tables.BlocksRow, Tables.OperationGroupsRow, Tables.OperationsRow),
       Seq]
   ) extends JoinedTables
 
-  case class BlocksOperationGroupsAccounts(
+  final case class BlocksOperationGroupsAccounts(
     join: Query[
       (Tables.Blocks, Tables.OperationGroups, Tables.Accounts),
       (Tables.BlocksRow, Tables.OperationGroupsRow, Tables.AccountsRow),
       Seq]
   ) extends JoinedTables
 
-  case class BlocksOperationGroups(
+  final case class BlocksOperationGroups(
     join: Query[
       (Tables.Blocks, Tables.OperationGroups),
       (Tables.BlocksRow, Tables.OperationGroupsRow),
       Seq]
   ) extends JoinedTables
 
-  case class BlocksOperationsAccounts(
+  final case class BlocksOperationsAccounts(
     join: Query[
       (Tables.Blocks, Tables.Operations, Tables.Accounts),
       (Tables.BlocksRow, Tables.OperationsRow, Tables.AccountsRow),
       Seq]
   ) extends JoinedTables
 
-  case class BlocksOperations(
+  final case class BlocksOperations(
     join: Query[
       (Tables.Blocks, Tables.Operations),
       (Tables.BlocksRow, Tables.OperationsRow),
       Seq]
   ) extends JoinedTables
 
-  case class BlocksAccounts(
+  final case class BlocksAccounts(
     join: Query[
       (Tables.Blocks, Tables.Accounts),
       (Tables.BlocksRow, Tables.AccountsRow),
       Seq]
   ) extends JoinedTables
 
-  case class Blocks(
+  final case class Blocks(
     join: Query[Tables.Blocks, Tables.BlocksRow, Seq]
   ) extends JoinedTables
 
-  case class OperationGroupsOperationsAccounts(
+  final case class OperationGroupsOperationsAccounts(
     join: Query[
       (Tables.OperationGroups, Tables.Operations, Tables.Accounts),
       (Tables.OperationGroupsRow, Tables.OperationsRow, Tables.AccountsRow),
       Seq]
   ) extends JoinedTables
 
-  case class OperationGroupsOperations(
+  final case class OperationGroupsOperations(
     join: Query[
       (Tables.OperationGroups, Tables.Operations),
       (Tables.OperationGroupsRow, Tables.OperationsRow),
       Seq]
   ) extends JoinedTables
 
-  case class OperationGroupsAccounts(
+  final case class OperationGroupsAccounts(
     join: Query[
       (Tables.OperationGroups, Tables.Accounts),
       (Tables.OperationGroupsRow, Tables.AccountsRow),
       Seq]
   ) extends JoinedTables
 
-  case class OperationGroups(
+  final case class OperationGroups(
     join: Query[Tables.OperationGroups, Tables.OperationGroupsRow, Seq]
   ) extends JoinedTables
 
-  case class OperationsAccounts(
+  final case class OperationsAccounts(
     join: Query[
       (Tables.Operations, Tables.Accounts),
       (Tables.OperationsRow, Tables.AccountsRow),
       Seq]
   ) extends JoinedTables
 
-  case class Operations(
+  final case class Operations(
     join: Query[Tables.Operations, Tables.OperationsRow, Seq]
   ) extends JoinedTables
 
-  case class Accounts(
+  final case class Accounts(
     join: Query[Tables.Accounts, Tables.AccountsRow, Seq]
   ) extends JoinedTables
 
-  case object EmptyJoin extends JoinedTables
+  final case object EmptyJoin extends JoinedTables
 
   /**
     * This represents a database query that returns all of the columns of the table in a scala tuple.
@@ -124,13 +124,13 @@ object DatabaseQueryExecution {
     */
   sealed trait Action
 
-  case class BlocksAction(action: Query[Tables.Blocks, Tables.BlocksRow, Seq]) extends Action
+  final case class BlocksAction(action: Query[Tables.Blocks, Tables.BlocksRow, Seq]) extends Action
 
-  case class OperationGroupsAction(action: Query[Tables.OperationGroups, Tables.OperationGroupsRow, Seq]) extends Action
+  final case class OperationGroupsAction(action: Query[Tables.OperationGroups, Tables.OperationGroupsRow, Seq]) extends Action
 
-  case class AccountsAction(action: Query[Tables.Accounts, Tables.AccountsRow, Seq]) extends Action
+  final case class AccountsAction(action: Query[Tables.Accounts, Tables.AccountsRow, Seq]) extends Action
 
-  case class TableSelection(
+  final case class TableSelection(
     blocks: Boolean,
     operationGroups: Boolean,
     operations: Boolean,

--- a/src/main/scala/tech/cryptonomic/conseil/routes/Tezos.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/Tezos.scala
@@ -1,8 +1,8 @@
 package tech.cryptonomic.conseil.routes
 
-import akka.http.scaladsl.marshalling.{PredefinedToEntityMarshallers, ToEntityMarshaller}
-import akka.http.scaladsl.model.MediaTypes
-import akka.http.scaladsl.server.{Directive, Route}
+import akka.http.scaladsl.marshalling.{PredefinedToEntityMarshallers, ToEntityMarshaller, ToResponseMarshaller, ToResponseMarshallable}
+import akka.http.scaladsl.model.{MediaTypes, StatusCodes}
+import akka.http.scaladsl.server.{Directive, Route, StandardRoute}
 import akka.http.scaladsl.server.Directives._
 import com.typesafe.scalalogging.LazyLogging
 import tech.cryptonomic.conseil.tezos._
@@ -11,9 +11,8 @@ import tech.cryptonomic.conseil.tezos.TezosTypes.{BlockHash, AccountId}
 import tech.cryptonomic.conseil.db.DatabaseApiFiltering
 import tech.cryptonomic.conseil.util.JsonUtil
 import tech.cryptonomic.conseil.util.CryptoUtil.KeyStore
-import tech.cryptonomic.conseil.util.JsonUtil
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 /** Provides useful route and directive definitions */
 object Tezos {
@@ -37,7 +36,7 @@ object Tezos {
     "account_delegate".as[String].*,
     "sort_by".as[String].?,
     "order".as[String].?
-  ).as(Filter.readParams)
+  ).as(Filter.readParams _)
 
   // Directive for gathering account information for most POST operations.
   val gatherKeyInfo: Directive[Tuple1[KeyStore]] = parameters(
@@ -62,49 +61,61 @@ object Tezos {
 class Tezos(implicit apiExecutionContext: ExecutionContext) extends LazyLogging with DatabaseApiFiltering {
 
   import Tezos._
+  import JsonUtil.{toJson, JsonString}
 
   /* reuse the same context as the one for ApiOperations calls
    * as long as it doesn't create issues or performance degradation
    */
   override val asyncApiFiltersExecutionContext = apiExecutionContext
 
-  //this automatically accepts any type `T` as content for calling [[RequestContext.complete]]
-  //converts to json string via JsonUtil adding the correct content-type to the response entity
-  implicit def jsonStringMarshaller[T]: ToEntityMarshaller[T] =
+  //add the correct content-type for [[JsonUtil]]-converted values
+  implicit val jsonMarshaller: ToEntityMarshaller[JsonString] =
     PredefinedToEntityMarshallers.StringMarshaller
-      .compose(JsonUtil.toJson[T])
-      .wrap(MediaTypes.`application/json`)(identity)
+      .compose((_: JsonString).json)
+      .wrap(MediaTypes.`application/json`)(identity _)
+
+  private[this] def handleNoneAsNotFound[T, R: ToResponseMarshaller](operation: => Future[Option[T]])(converter: T => R = identity _): Future[ToResponseMarshallable] =
+    operation.map {
+      case Some(content) => converter(content)
+      case None => StatusCodes.NotFound
+    }
+
+  /* converts the future value to [[JsonString]] and completes the call */
+  private[this] def completeWithJson[T](futureValue: Future[T]): StandardRoute =
+    complete(futureValue.map(toJson[T]))
 
   /** expose filtered results through rest endpoints */
   val route: Route = pathPrefix(Segment) { network =>
     get {
       gatherConseilFilter{ filter =>
-        validate(filter.limit.forall(_ <= 10000), s"Cannot ask for more than 10000 entries") {
+        validate(filter.limit.forall(_ <= 10000), "Cannot ask for more than 10000 entries") {
           pathPrefix("blocks") {
             pathEnd {
-              complete(ApiOperations.fetchBlocks(filter))
+              completeWithJson(ApiOperations.fetchBlocks(filter))
             } ~ path("head") {
-                complete(ApiOperations.fetchLatestBlock())
+                completeWithJson(ApiOperations.fetchLatestBlock())
             } ~ path(Segment).as(BlockHash) { blockId =>
-                complete(ApiOperations.fetchBlock(blockId))
+                complete(
+                  handleNoneAsNotFound(ApiOperations.fetchBlock(blockId))(converter = toJson)
+                )
             }
           } ~ pathPrefix("accounts") {
             pathEnd {
-              complete(ApiOperations.fetchAccounts(filter))
+              completeWithJson(ApiOperations.fetchAccounts(filter))
             } ~ path(Segment).as(AccountId) { accountId =>
-              complete(ApiOperations.fetchAccount(accountId))
+              completeWithJson(ApiOperations.fetchAccount(accountId))
             }
           } ~ pathPrefix("operation_groups") {
             pathEnd {
-              complete(ApiOperations.fetchOperationGroups(filter))
+              completeWithJson(ApiOperations.fetchOperationGroups(filter))
             } ~ path(Segment) { operationGroupId =>
-              complete(ApiOperations.fetchOperationGroup(operationGroupId))
+              completeWithJson(ApiOperations.fetchOperationGroup(operationGroupId))
             }
           } ~ pathPrefix("operations") {
             path("avgFees") {
-                complete(ApiOperations.fetchAverageFees(filter))
+                completeWithJson(ApiOperations.fetchAverageFees(filter))
             } ~ pathEnd {
-                complete(ApiOperations.fetchOperations(filter))
+                completeWithJson(ApiOperations.fetchOperations(filter))
             }
           }
         }

--- a/src/main/scala/tech/cryptonomic/conseil/routes/Tezos.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/Tezos.scala
@@ -85,13 +85,13 @@ class Tezos(implicit apiExecutionContext: ExecutionContext) extends LazyLogging 
               complete(ApiOperations.fetchBlocks(filter))
             } ~ path("head") {
                 complete(ApiOperations.fetchLatestBlock())
-            } ~ path(Segment).as(BlockHash.apply) { blockId =>
+            } ~ path(Segment).as(BlockHash) { blockId =>
                 complete(ApiOperations.fetchBlock(blockId))
             }
           } ~ pathPrefix("accounts") {
             pathEnd {
               complete(ApiOperations.fetchAccounts(filter))
-            } ~ path(Segment).as(AccountId.apply) { accountId =>
+            } ~ path(Segment).as(AccountId) { accountId =>
               complete(ApiOperations.fetchAccount(accountId))
             }
           } ~ pathPrefix("operation_groups") {

--- a/src/main/scala/tech/cryptonomic/conseil/routes/Tezos.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/Tezos.scala
@@ -109,7 +109,9 @@ class Tezos(implicit apiExecutionContext: ExecutionContext) extends LazyLogging 
             pathEnd {
               completeWithJson(ApiOperations.fetchOperationGroups(filter))
             } ~ path(Segment) { operationGroupId =>
-              completeWithJson(ApiOperations.fetchOperationGroup(operationGroupId))
+              complete(
+                handleNoneAsNotFound(ApiOperations.fetchOperationGroup(operationGroupId))(converter = toJson)
+              )
             }
           } ~ pathPrefix("operations") {
             path("avgFees") {

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
@@ -211,10 +211,8 @@ object ApiOperations {
     apiFilters(filter)(0)
 
   /**
-    * Given the operation kind and the number of columns wanted,
-    *
-    * return the mean (along with +/- one standard deviation) of
-    * fees incurred in those operations.
+    * Given the operation kind return the mean (along with +/- one standard deviation)
+    * of fees incurred in those operations.
     * @param filter Filters to apply, specifically operation kinds
     * @param apiFilters an instance in scope that actually executes filtered data-fetching
     * @param ec ExecutionContext needed to invoke the data fetching using async results
@@ -223,10 +221,10 @@ object ApiOperations {
     *           was performed at, and the kind of operation being
     *           averaged over.
     */
-  def fetchAverageFees(filter: Filter)(implicit apiFilters: ApiFiltering[Future, Tables.FeesRow], ec: ExecutionContext): Future[AverageFees] =
+  def fetchAverageFees(filter: Filter)(implicit apiFilters: ApiFiltering[Future, Tables.FeesRow], ec: ExecutionContext): Future[Option[AverageFees]] =
     apiFilters(filter)(0)
       .map( rows =>
-        rows.head match {
+        rows.headOption map {
           case Tables.FeesRow(low, medium, high, timestamp, kind) => AverageFees(low, medium, high, timestamp, kind)
         }
       )

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
@@ -1,6 +1,5 @@
 package tech.cryptonomic.conseil.tezos
 
-import com.typesafe.config.ConfigFactory
 import slick.jdbc.PostgresProfile.api._
 import tech.cryptonomic.conseil.tezos.{TezosDatabaseOperations => TezosDb}
 import tech.cryptonomic.conseil.tezos.FeeOperations._
@@ -14,7 +13,6 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 object ApiOperations {
 
-  private val conf = ConfigFactory.load
   lazy val dbHandle: Database = DatabaseUtil.db
 
   /** Define sorting order for api queries */
@@ -52,7 +50,7 @@ object ApiOperations {
     * @param sortBy                 Database column name to sort by
     * @param order                  Sort items ascending or descending
     */
-  case class Filter(
+  final case class Filter(
                      limit: Option[Int] = Some(defaultLimit),
                      blockIDs: Set[String] = Set.empty,
                      levels: Set[Int] = Set.empty,

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/FeeOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/FeeOperations.scala
@@ -32,7 +32,7 @@ object FeeOperations extends LazyLogging {
     * @param timestamp The timestamp when the calculation took place
     * @param kind      The kind of operation being averaged over
     */
-  case class AverageFees(
+  final case class AverageFees(
                  low: Int,
                  medium: Int,
                  high: Int,

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeInterface.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeInterface.scala
@@ -82,7 +82,7 @@ object TezosNodeConfig {
 /**
   * Concrete implementation of the above.
   */
-case class TezosNodeInterface()(implicit system: ActorSystem) extends TezosRPCInterface with LazyLogging {
+class TezosNodeInterface(implicit system: ActorSystem) extends TezosRPCInterface with LazyLogging {
   import TezosNodeConfig._
 
   implicit val materializer: ActorMaterializer = ActorMaterializer()

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -5,16 +5,16 @@ package tech.cryptonomic.conseil.tezos
   */
 object TezosTypes {
 
-  case class BlockHash(value: String) extends AnyVal
+  final case class BlockHash(value: String) extends AnyVal
 
-  case class OperationHash(value: String) extends AnyVal
+  final case class OperationHash(value: String) extends AnyVal
 
-  case class AccountId(id: String) extends AnyVal
+  final case class AccountId(id: String) extends AnyVal
 
   /** a conventional value to get the latest block in the chain */
   final lazy val blockHeadHash = BlockHash("head")
 
-  case class BlockHeader(
+  final case class BlockHeader(
                         level: Int,
                         proto: Int,
                         predecessor: BlockHash,
@@ -26,14 +26,14 @@ object TezosTypes {
                         signature: Option[String]
                         )
 
-  case class BlockMetadata(
+  final case class BlockMetadata(
                             protocol: String,
                             chain_id: Option[String],
                             hash: BlockHash,
                             header: BlockHeader
                   )
 
-  case class OperationMetadata(
+  final case class OperationMetadata(
                               delegate: Option[String],
                               slots: Option[List[Int]],
                               balanceUpdates: Option[List[AppliedOperationBalanceUpdates]],
@@ -41,7 +41,7 @@ object TezosTypes {
                               internalOperationResult: Option[AppliedInternalOperationResult]
                               )
 
-  case class AppliedOperationBalanceUpdates(
+  final case class AppliedOperationBalanceUpdates(
                                              kind: String,
                                              contract: Option[String],
                                              change: Int,
@@ -50,7 +50,7 @@ object TezosTypes {
                                              level: Option[Int]
                                            )
 
-  case class AppliedOperationResultStatus(
+  final case class AppliedOperationResultStatus(
                                    status: String,
                                    errors: Option[List[String]],
                                    storage: Option[Any],
@@ -60,7 +60,7 @@ object TezosTypes {
                                    storageSizeDiff: Option[Int]
                                    )
 
-  case class AppliedInternalOperationResult(
+  final case class AppliedInternalOperationResult(
                                            kind: String,
                                            source: String,
                                            nonce: Int,
@@ -77,25 +77,25 @@ object TezosTypes {
                                            script: Option[ScriptedContracts],
                                            )
 
-  case class ScriptedContracts(
+  final case class ScriptedContracts(
                               storage: Any,
                               code: Any
                               )
 
-  case class InlinedEndorsement(
+  final case class InlinedEndorsement(
                                branch: String,
                                operation: InlinedEndorsementContents,
                                signature: Option[String]
                                )
 
-  case class InlinedEndorsementContents(
+  final case class InlinedEndorsementContents(
                                        kind: String,
                                        block: String,
                                        level: String,
                                        slots: List[Int]
                                        )
 
-  case class Operation(
+  final case class Operation(
                        kind: String,
                        block: Option[String],
                        level: Option[Int],
@@ -127,7 +127,7 @@ object TezosTypes {
                        delegate: Option[String]
                        )
 
-  case class OperationGroup (
+  final case class OperationGroup (
                               protocol: String,
                               chain_id: Option[String],
                               hash: OperationHash,
@@ -136,12 +136,12 @@ object TezosTypes {
                               signature: Option[String],
                             )
 
-  case class AccountDelegate(
+  final case class AccountDelegate(
                             setable: Boolean,
                             value: Option[String]
                             )
 
-  case class Account(
+  final case class Account(
                     manager: String,
                     balance: scala.math.BigDecimal,
                     spendable: Boolean,
@@ -150,31 +150,31 @@ object TezosTypes {
                     counter: Int
                     )
 
-  case class AccountsWithBlockHashAndLevel(
+  final case class AccountsWithBlockHashAndLevel(
                                     blockHash: BlockHash,
                                     blockLevel: Int,
                                     accounts: Map[AccountId, Account] = Map.empty
                                   )
 
-  case class Block(
+  final case class Block(
                     metadata: BlockMetadata,
                     operationGroups: List[OperationGroup]
                   )
 
-  case class ManagerKey(
+  final case class ManagerKey(
                        manager: String,
                        key: Option[String]
                        )
 
-  case class ForgedOperation(operation: String)
+  final case class ForgedOperation(operation: String)
 
-  case class AppliedOperationError(
+  final case class AppliedOperationError(
                                   kind: String,
                                   id: String,
                                   hash: String
                                   )
 
-  case class AppliedOperationResult(
+  final case class AppliedOperationResult(
                                    operation: String,
                                    status: String,
                                    operationKind: Option[String],
@@ -183,7 +183,7 @@ object TezosTypes {
                                    errors: Option[List[AppliedOperationError]]
                                    )
 
-  case class AppliedOperation(
+  final case class AppliedOperation(
                              kind: String,
                              balance_updates: Option[List[AppliedOperationBalanceUpdates]],
                              operation_results: Option[List[AppliedOperationResult]],
@@ -191,8 +191,8 @@ object TezosTypes {
                              contract: Option[String]
                              )
 
-  case class InjectedOperation(injectedOperation: String)
+  final case class InjectedOperation(injectedOperation: String)
 
-  case class MichelsonExpression(prim: String, args: List[String])
+  final case class MichelsonExpression(prim: String, args: List[String])
 
 }

--- a/src/main/scala/tech/cryptonomic/conseil/util/CollectionOps.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/util/CollectionOps.scala
@@ -15,7 +15,7 @@ object CollectionOps {
       }
     }
 
-  implicit class keyedSeq[K, V](seq: Seq[(K, V)]) {
+  implicit class KeyedSeq[K, V](seq: Seq[(K, V)]) {
     def byKey(): Map[K, Seq[V]] = groupByKey(seq)
   }
 

--- a/src/main/scala/tech/cryptonomic/conseil/util/CryptoUtil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/util/CryptoUtil.scala
@@ -9,7 +9,7 @@ import scala.util.Try
   */
 object CryptoUtil {
 
-  case class KeyStore(publicKey: String, privateKey: String, publicKeyHash: String)
+  final case class KeyStore(publicKey: String, privateKey: String, publicKeyHash: String)
 
   /**
     * Get byte prefix for Base58Check encoding and decoding of a given type of data.

--- a/src/main/scala/tech/cryptonomic/conseil/util/JsonUtil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/util/JsonUtil.scala
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.module.scala.DefaultScalaModule
   */
 object JsonUtil {
 
-  case class JsonString(json: String) extends AnyVal with Product with Serializable
+  final case class JsonString(json: String) extends AnyVal with Product with Serializable
 
   val mapper = new ObjectMapper() with ScalaObjectMapper
   mapper.registerModule(DefaultScalaModule)

--- a/src/main/scala/tech/cryptonomic/conseil/util/JsonUtil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/util/JsonUtil.scala
@@ -9,16 +9,18 @@ import com.fasterxml.jackson.module.scala.DefaultScalaModule
   */
 object JsonUtil {
 
+  case class JsonString(json: String) extends AnyVal with Product with Serializable
+
   val mapper = new ObjectMapper() with ScalaObjectMapper
   mapper.registerModule(DefaultScalaModule)
   mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
-  def toJson(value: Map[Symbol, Any]): String = {
+  def toJson(value: Map[Symbol, Any]): JsonString = {
     toJson(value map { case (k,v) => k.name -> v})
   }
 
-  def toJson[T](value: T): String = {
-    mapper.writerWithDefaultPrettyPrinter().writeValueAsString(value)
+  def toJson[T](value: T): JsonString = {
+    JsonString(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(value))
   }
 
   def toMap[V](json:String)(implicit m: Manifest[V]): Map[String, V] = fromJson[Map[String,V]](json)


### PR DESCRIPTION
Removed possible api operation failures due to missing results, now handled at the http layer with a `404 Not Found` response code.

This includes fetching by hash or fetching fees with no matching filter.

Doing so we reduced the surface of functions that may throw exceptions for some inputs as per #103 

To check for other possible sources of inconsistencies or errors we introduce the usage of a plugin (scapegoat) that can check for potential code-style-level issues, and added several commonly advised compiler flags that warn about other sources of mistakes.

To allow usage of the sbt plugin, we **update the version of sbt to the latest available**. No visible impact was detected doing so.