### PR TITLE
**PoC-No-Merge** Conseil-177: stream save blocks

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -150,7 +150,14 @@ object TezosTypes {
                     counter: Int
                     )
 
-  final case class AccountsWithBlockHashAndLevel(
+  final case class AccountAtBlock(
+                                  id: AccountId,
+                                  blockHash: BlockHash,
+                                  blockLevel: Int,
+                                  account: Account
+  )
+
+  final case class AccountsForBlock(
                                     blockHash: BlockHash,
                                     blockLevel: Int,
                                     accounts: Map[AccountId, Account] = Map.empty

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
@@ -509,7 +509,7 @@ class TezosDatabaseOperationsTest
   }
 
   /* randomly generates a number of accounts with associated block data */
-  private def generateAccounts(howMany: Int, blockHash: BlockHash, blockLevel: Int)(implicit randomSeed: RandomSeed): AccountsWithBlockHashAndLevel = {
+  private def generateAccounts(howMany: Int, blockHash: BlockHash, blockLevel: Int)(implicit randomSeed: RandomSeed): AccountsForBlock = {
     require(howMany > 0, "the test can generates a positive number of accounts, you asked for a non positive value")
 
     val rnd = new Random(randomSeed.seed)
@@ -528,7 +528,7 @@ class TezosDatabaseOperationsTest
         )
     }.toMap
 
-    AccountsWithBlockHashAndLevel(blockHash, blockLevel, accounts)
+    AccountsForBlock(blockHash, blockLevel, accounts)
   }
 
   /* randomly populate a number of blocks based on a level range */


### PR DESCRIPTION
**This is a proof-of-concept**
======================
## might never get into production


Converts Lorre's "bulk downloads" of nodes entities to a streaming one, including

 * blocks
 * accounts

Fixes #177 
This solution would avoid repeated work on failing process and reduce the memory footprint for Lorre runs.
There are additional considerations to take into account, though:
 1. accounts are still too slow to download, the sheer number of it, so a radically different solution is needed
 1. possibly failing streams introduce the risk of inconsistencies in the database, which needs some correction algorithm that validates/invalidates currently stored blocks as consistent and recovery processes that loads missing entities on each periodic sync with tezos
 1. based on the previous point, a local filtering process should be added (based on pre-cached keys?) to avoid duplicate work on the stream processing
 1. additional chances to increase parallelism might be enabled by the different approach and the sync cycle might be reduced to optimize inconsistency windows