### PR TITLE
Conseil 206: accounts fetch checkpoint

### DIFF
--- a/doc/conseil.sql
+++ b/doc/conseil.sql
@@ -146,7 +146,7 @@ CREATE TABLE public.operations (
 CREATE TABLE public.accounts_checkpoint (
     account_id character varying NOT NULL,
     block_id character varying NOT NULL,
-    block_level numeric DEFAULT '-1'::integer NOT NULL
+    block_level integer DEFAULT '-1'::integer NOT NULL
 );
 
 --

--- a/doc/conseil.sql
+++ b/doc/conseil.sql
@@ -139,6 +139,15 @@ CREATE TABLE public.operations (
     pkh character varying
 );
 
+--
+-- Name: accounts_checkpoint; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.accounts_checkpoint (
+    account_id character varying NOT NULL,
+    block_id character varying NOT NULL,
+    block_level numeric DEFAULT '-1'::integer NOT NULL
+);
 
 --
 -- Name: operations_operation_id_seq; Type: SEQUENCE; Schema: public; Owner: -
@@ -263,6 +272,12 @@ CREATE INDEX ix_operations_source ON public.operations USING btree (source);
 ALTER TABLE ONLY public.accounts
     ADD CONSTRAINT accounts_block_id_fkey FOREIGN KEY (block_id) REFERENCES public.blocks(hash);
 
+--
+-- Name: accounts checkpoint_block_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.accounts_checkpoint
+    ADD CONSTRAINT checkpoint_block_id_fkey FOREIGN KEY (block_id) REFERENCES public.blocks(hash);
 
 --
 -- Name: operation_groups block; Type: FK CONSTRAINT; Schema: public; Owner: -

--- a/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
@@ -138,7 +138,7 @@ object Lorre extends App with TezosErrors with LazyLogging {
     saveAccounts.andThen {
       //additional cleanup, that can fail with no downsides
       case Success(checkpoints) =>
-        val processed = Some(checkpoints.values.flatten.toSet)
+        val processed = Some(checkpoints.keySet)
         db.run(TezosDb.cleanAccountsCheckpoint(processed))
       case _ =>
         ()

--- a/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
@@ -6,7 +6,6 @@ import akka.Done
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
 import tech.cryptonomic.conseil.tezos.{TezosErrors, FeeOperations, TezosNodeInterface, TezosNodeOperator, TezosDatabaseOperations => TezosDb}
-import tech.cryptonomic.conseil.tezos.TezosTypes.{AccountId, Block}
 import tech.cryptonomic.conseil.util.DatabaseUtil
 
 import scala.concurrent.duration._
@@ -53,6 +52,7 @@ object Lorre extends App with TezosErrors with LazyLogging {
       tezosNodeOperator.node
         .shutdown()
         .flatMap(ShutdownComplete => system.terminate())
+
     Await.result(nodeShutdown, shutdownWait)
     logger.info("All things closed")
   }
@@ -61,8 +61,8 @@ object Lorre extends App with TezosErrors with LazyLogging {
   def mainLoop(iteration: Int): Unit = {
     val noOp = Future.successful(())
     val processing = for {
-      accountIds <- processTezosBlocks()
-      _ <- processTezosAccounts(accountIds)
+      _ <- processTezosBlocks()
+      _ <- processTezosAccounts()
       _ <-
         if (iteration % feeUpdateInterval == 0)
           FeeOperations.processTezosAverageFees()
@@ -96,19 +96,20 @@ object Lorre extends App with TezosErrors with LazyLogging {
 
   /**
     * Fetches all blocks not in the database from the Tezos network and adds them to the database.
+    * Additionally stores account references that needs updating, too
     */
-  def processTezosBlocks(): Future[Map[Block, List[AccountId]]] = {
+  def processTezosBlocks(): Future[Done] = {
     logger.info("Processing Tezos Blocks..")
     tezosNodeOperator.getBlocksNotInDatabase(network, followFork = true).flatMap {
       blocksWithAccounts =>
-        //ignore the account ids for storage
-        val blocks= blocksWithAccounts.map { case (block, _) => block }
-        db.run(TezosDb.writeBlocks(blocks))
+        db.run(TezosDb.writeBlocksAndCheckpointAccounts(blocksWithAccounts.toMap))
           .andThen {
-            case Success(_) => logger.info("Wrote {} blocks to the database", blocks.size)
-            case Failure(e) => logger.error(s"Could not write blocks to the database because $e")
+            case Success(accountsCount) =>
+              logger.info("Wrote {} blocks to the database, checkpoint stored for{} account updates", blocksWithAccounts.size, accountsCount.fold("")(" " + _))
+            case Failure(e) =>
+              logger.error(s"Could not write blocks or accounts checkpoints to the database because $e")
           }
-          .map(_ => blocksWithAccounts.toMap)
+          .map(_ => Done)
     }.andThen {
       case Failure(e) =>
         logger.error("Could not fetch blocks from client", e)
@@ -116,21 +117,31 @@ object Lorre extends App with TezosErrors with LazyLogging {
   }
 
   /**
-    * Fetches and stores all accounts from the latest block stored in the database.
+    * Fetches and stores all accounts from the latest blocks stored in the database.
     *
     * NOTE: as the call is now async, it won't stop the application on error as before, so
     * we should evaluate how to handle failed processing
     */
-  def processTezosAccounts(accountsInvolved: Map[Block, List[AccountId]]): Future[Done] = {
+  def processTezosAccounts(): Future[Done] = {
     logger.info("Processing latest Tezos accounts data..")
-    tezosNodeOperator.getAccountsForBlocks(network, accountsInvolved).flatMap {
-      case accountsInfo =>
-        db.run(TezosDb.writeAccounts(accountsInfo)).andThen {
-          case Success(rows) =>
-            logger.info("{} accounts were touched on the database.", rows)
-          case Failure(e) =>
-            logger.error("Could not write accounts to the database")
-        }
+
+    def logOutcome[A](outcome: Future[A]): Future[A] = outcome.andThen {
+      case Success(rows) =>
+        logger.info("{} accounts were touched on the database.", rows)
+      case Failure(e) =>
+        logger.error("Could not write accounts to the database")
+    }
+
+    val saveAccounts = for {
+      checkpoints <- db.run(TezosDb.getLatestAccountsFromCheckpoint)
+      accountsInfo <- tezosNodeOperator.getAccountsForBlocks(network, checkpoints)
+      accountsStored <- logOutcome(db.run(TezosDb.writeAccounts(accountsInfo)))
+    } yield accountsStored
+
+    saveAccounts.andThen {
+      //additional cleanup, that can fail with no downsides
+      case Success(_) => db.run(TezosDb.cleanAccountsCheckpoint())
+      case _ => ()
     }.transform {
       case Failure(e) =>
         val error = "I failed to fetch accounts from client and update them"

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
@@ -76,12 +76,12 @@ trait Tables {
   /** Entity class storing rows of table AccountsCheckpoint
    *  @param accountId Database column account_id SqlType(varchar)
    *  @param blockId Database column block_id SqlType(varchar)
-   *  @param blockLevel Database column block_level SqlType(numeric), Default(-1) */
-  case class AccountsCheckpointRow(accountId: String, blockId: String, blockLevel: scala.math.BigDecimal = scala.math.BigDecimal("-1"))
+   *  @param blockLevel Database column block_level SqlType(int4), Default(-1) */
+  case class AccountsCheckpointRow(accountId: String, blockId: String, blockLevel: Int = -1)
   /** GetResult implicit for fetching AccountsCheckpointRow objects using plain SQL queries */
-  implicit def GetResultAccountsCheckpointRow(implicit e0: GR[String], e1: GR[scala.math.BigDecimal]): GR[AccountsCheckpointRow] = GR{
+  implicit def GetResultAccountsCheckpointRow(implicit e0: GR[String], e1: GR[Int]): GR[AccountsCheckpointRow] = GR{
     prs => import prs._
-    AccountsCheckpointRow.tupled((<<[String], <<[String], <<[scala.math.BigDecimal]))
+    AccountsCheckpointRow.tupled((<<[String], <<[String], <<[Int]))
   }
   /** Table description of table accounts_checkpoint. Objects of this class serve as prototypes for rows in queries. */
   class AccountsCheckpoint(_tableTag: Tag) extends profile.api.Table[AccountsCheckpointRow](_tableTag, "accounts_checkpoint") {
@@ -93,8 +93,8 @@ trait Tables {
     val accountId: Rep[String] = column[String]("account_id")
     /** Database column block_id SqlType(varchar) */
     val blockId: Rep[String] = column[String]("block_id")
-    /** Database column block_level SqlType(numeric), Default(-1) */
-    val blockLevel: Rep[scala.math.BigDecimal] = column[scala.math.BigDecimal]("block_level", O.Default(scala.math.BigDecimal("-1")))
+    /** Database column block_level SqlType(int4), Default(-1) */
+    val blockLevel: Rep[Int] = column[Int]("block_level", O.Default(-1))
 
     /** Foreign key referencing Blocks (database name checkpoint_block_id_fkey) */
     lazy val blocksFk = foreignKey("checkpoint_block_id_fkey", blockId, Blocks)(r => r.hash, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -5,6 +5,9 @@ package tech.cryptonomic.conseil.tezos
   */
 object TezosTypes {
 
+  /** convenience alias to simplify declarations of block hash+level tuples */
+  type BlockReference = (BlockHash, Int)
+
   final case class BlockHash(value: String) extends AnyVal
 
   final case class OperationHash(value: String) extends AnyVal

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/InMemoryDatabase.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/InMemoryDatabase.scala
@@ -55,7 +55,8 @@ trait InMemoryDatabase extends BeforeAndAfterAll with BeforeAndAfterEach {
     Tables.OperationGroups,
     Tables.Operations,
     Tables.Accounts,
-    Tables.Fees
+    Tables.Fees,
+    Tables.AccountsCheckpoint
   )
 
   protected val dbSchema =


### PR DESCRIPTION
closes #206 

The enhancements stores persistently the accounts ids to be fetched, returned as a side-result from the blocks processing.

Such persistent data is then read to update accounts data, thus avoiding the risk of data loss in the case of failure during the account processing, as the next cycle will simply add new data at the checkpoint, and then fetch what's needed again.

The chages also inverted the halting behaviour on accounts processing failure, now if you need to stop Lorre on failure the env-variable `LORRE_FAILURE_IGNORE` must be set to `"false"` or `"no"`