### PR TITLE
Conseil 223 query result set limit support

### DIFF
--- a/doc/MetadataAndQuery.md
+++ b/doc/MetadataAndQuery.md
@@ -35,7 +35,8 @@ curl -vvv --request POST \
       "field": "field_name",            // name of the field to order by
       "direction": "asc"                // direction to order by, asc or desc
     }
-  ]
+  ],
+  "limit": 100
 }
 ```
 
@@ -70,7 +71,8 @@ curl -vvv --request POST \
       "field":"account_id", 
       "direction": "asc"
     }
-  ]
+  ],
+  "limit": 100
 }'
 ```
 

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
@@ -12,6 +12,12 @@ import scala.util.Try
   */
 object DataTypes {
 
+  /** Default value of limit parameter */
+  val defaultLimitValue: Int = 10000
+
+  /** Max value of limit parameter */
+  val maxLimitValue: Int = 100000
+
   /** Class required for OperationType enum serialization */
   class OperationTypeRef extends TypeReference[OperationType.type]
 
@@ -39,7 +45,7 @@ object DataTypes {
     fields: List[String] = List.empty,
     predicates: List[Predicate],
     orderBy: List[QueryOrdering] = List.empty,
-    limit: Int = 10000
+    limit: Option[Int] = Some(defaultLimitValue)
   ) {
     /** Method which validates query fields, as jackson runs on top of runtime reflection so NPE can happen if fields are missing */
     def validate: Option[Query] = {

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
@@ -38,7 +38,8 @@ object DataTypes {
   case class Query(
     fields: List[String] = List.empty,
     predicates: List[Predicate],
-    orderBy: List[QueryOrdering] = List.empty
+    orderBy: List[QueryOrdering] = List.empty,
+    limit: Int = 10000
   ) {
     /** Method which validates query fields, as jackson runs on top of runtime reflection so NPE can happen if fields are missing */
     def validate: Option[Query] = {

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
@@ -143,7 +143,8 @@ object ApiOperations extends DataOperations {
             operation = OperationType.in,
             set = accountDelegates.toList
           )
-        ).filter(_.set.nonEmpty)
+        ).filter(_.set.nonEmpty),
+        limit = limit.getOrElse(defaultLimit)
       )
     }
   }
@@ -392,7 +393,15 @@ object ApiOperations extends DataOperations {
     * */
   override def queryWithPredicates(tableName: String, query: Query)(implicit ec: ExecutionContext): Future[List[Map[String, Any]]] = {
     if (areFieldsValid(tableName, (query.fields ++ query.predicates.map(_.field) ++ query.orderBy.map(_.field)).toSet)) {
-      runQuery(TezosDatabaseOperations.selectWithPredicates(tableName, query.fields, sanitizePredicates(query.predicates), query.orderBy))
+      runQuery(
+        TezosDatabaseOperations.selectWithPredicates(
+          tableName,
+          query.fields,
+          sanitizePredicates(query.predicates),
+          query.orderBy,
+          Math.min(query.limit, 100000)
+        )
+      )
     } else {
       Future.successful(List.empty)
     }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
@@ -1,7 +1,7 @@
 package tech.cryptonomic.conseil.tezos
 
 import slick.jdbc.PostgresProfile.api._
-import tech.cryptonomic.conseil.generic.chain.DataOperations
+import tech.cryptonomic.conseil.generic.chain.{DataOperations, DataTypes}
 import tech.cryptonomic.conseil.tezos.FeeOperations._
 import tech.cryptonomic.conseil.generic.chain.DataTypes.{OperationType, Predicate, Query}
 import tech.cryptonomic.conseil.tezos.TezosPlatformDiscoveryOperations.{areFieldsValid, sanitizeForSql}
@@ -144,7 +144,7 @@ object ApiOperations extends DataOperations {
             set = accountDelegates.toList
           )
         ).filter(_.set.nonEmpty),
-        limit = limit.getOrElse(defaultLimit)
+        limit = limit.orElse(Some(DataTypes.defaultLimitValue))
       )
     }
   }
@@ -399,7 +399,7 @@ object ApiOperations extends DataOperations {
           query.fields,
           sanitizePredicates(query.predicates),
           query.orderBy,
-          Math.min(query.limit, 100000)
+          Math.min(query.limit.get, DataTypes.maxLimitValue)
         )
       )
     } else {

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
@@ -377,11 +377,13 @@ object TezosDatabaseOperations extends LazyLogging {
     * @param ordering       list of ordering conditions for the query
     * @return               list of map of [string, any], which represents list of rows as a map of column name to value
     */
-  def selectWithPredicates(table: String, columns: List[String], predicates: List[Predicate], ordering: List[QueryOrdering])(implicit ec: ExecutionContext):
+  def selectWithPredicates(table: String, columns: List[String], predicates: List[Predicate], ordering: List[QueryOrdering], limit: Int)
+    (implicit ec: ExecutionContext):
   DBIO[List[Map[String, Any]]] = {
      makeQuery(table, columns)
        .addPredicates(predicates)
        .addOrdering(ordering)
+       .addLimit(limit)
        .as[Map[String, Any]]
        .map(_.toList)
   }
@@ -410,9 +412,21 @@ object TezosDatabaseOperations extends LazyLogging {
     sql"""SELECT #$cols FROM #$table WHERE true """
   }
 
+  /** Prepares ordering parameters
+    * @param ordering  list of ordering parameters
+    * @return          SQLAction with ordering
+    */
   def makeOrdering(ordering: List[QueryOrdering]): SQLActionBuilder = {
     val orderingBy = ordering.map(x => s"${x.field} ${x.direction}").mkString(",")
     sql""" ORDER BY #$orderingBy"""
+  }
+
+  /** Prepares limit parameters
+    * @param limit  list of ordering parameters
+    * @return          SQLAction with ordering
+    */
+  def makeLimit(limit: Int): SQLActionBuilder = {
+    sql""" LIMIT $limit"""
   }
 
   /** maps operation type to SQL operation */

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
@@ -373,6 +373,7 @@ object TezosDatabaseOperations extends LazyLogging {
     * @param columns        list of column names
     * @param predicates     list of predicates for query to be filtered with
     * @param ordering       list of ordering conditions for the query
+    * @param limit          max number of rows fetched
     * @return               list of map of [string, any], which represents list of rows as a map of column name to value
     */
   def selectWithPredicates(

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
@@ -2,13 +2,11 @@ package tech.cryptonomic.conseil.tezos
 
 import com.typesafe.scalalogging.LazyLogging
 import slick.jdbc.PostgresProfile.api._
-import slick.jdbc.SQLActionBuilder
-import tech.cryptonomic.conseil.generic.chain.DataTypes.OperationType.OperationType
-import tech.cryptonomic.conseil.generic.chain.DataTypes.{OperationType, Predicate, QueryOrdering}
+import tech.cryptonomic.conseil.generic.chain.DataTypes.{Predicate, QueryOrdering}
 import tech.cryptonomic.conseil.tezos.FeeOperations._
 import tech.cryptonomic.conseil.tezos.TezosTypes._
 import tech.cryptonomic.conseil.util.CollectionOps._
-import tech.cryptonomic.conseil.util.DatabaseUtil.{SqlActionHelper, concatenateSqlActions, getMap, insertValuesIntoSqlAction}
+import tech.cryptonomic.conseil.util.DatabaseUtil.QueryBuilder._
 import tech.cryptonomic.conseil.util.MathUtil.{mean, stdev}
 
 import scala.concurrent.ExecutionContext
@@ -388,60 +386,5 @@ object TezosDatabaseOperations extends LazyLogging {
        .map(_.toList)
   }
 
-  /** Prepares predicates and transforms them into SQLActionBuilders
-    *
-    * @param  predicates  list of predicates to be transformed
-    * @return             list of transformed predicates
-    */
-  def makePredicates(predicates: List[Predicate]): List[SQLActionBuilder] =
-    predicates.map { predicate =>
-      concatenateSqlActions(
-        predicate.precision.map(precision => sql""" AND ROUND(#${predicate.field}, $precision) """)
-          .getOrElse(sql""" AND #${predicate.field} """),
-        List(mapOperationToSQL(predicate.operation, predicate.inverse, predicate.set.map(_.toString)))
-      )
-    }
-
-  /** Prepares query
-    * @param table    table on which query will be executed
-    * @param columns  columns which are selected from teh table
-    * @return         SQLAction with basic query
-    */
-  def makeQuery(table: String, columns: List[String]): SQLActionBuilder = {
-    val cols = if(columns.isEmpty) "*" else columns.mkString(",")
-    sql"""SELECT #$cols FROM #$table WHERE true """
-  }
-
-  /** Prepares ordering parameters
-    * @param ordering  list of ordering parameters
-    * @return          SQLAction with ordering
-    */
-  def makeOrdering(ordering: List[QueryOrdering]): SQLActionBuilder = {
-    val orderingBy = ordering.map(x => s"${x.field} ${x.direction}").mkString(",")
-    sql""" ORDER BY #$orderingBy"""
-  }
-
-  /** Prepares limit parameters
-    * @param limit  list of ordering parameters
-    * @return          SQLAction with ordering
-    */
-  def makeLimit(limit: Int): SQLActionBuilder = {
-    sql""" LIMIT $limit"""
-  }
-
-  /** maps operation type to SQL operation */
-  private def mapOperationToSQL(operation: OperationType, inverse: Boolean, vals: List[String]): SQLActionBuilder = {
-    val op = operation match {
-      case OperationType.between => sql"BETWEEN #${vals.head} AND #${vals(1)}"
-      case OperationType.in => concatenateSqlActions(sql"IN ", List(insertValuesIntoSqlAction(vals)))
-      case OperationType.like => sql"LIKE '%#${vals.head}%'"
-      case OperationType.lt | OperationType.before => sql"< '#${vals.head}'"
-      case OperationType.gt | OperationType.after => sql"> '#${vals.head}'"
-      case OperationType.eq => sql"= '#${vals.head}'"
-      case OperationType.startsWith => sql"LIKE '#${vals.head}%'"
-      case OperationType.endsWith => sql"LIKE '%#${vals.head}'"
-    }
-    concatenateSqlActions(op, List(sql" IS #${!inverse}"))
-  }
 }
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
@@ -375,9 +375,13 @@ object TezosDatabaseOperations extends LazyLogging {
     * @param ordering       list of ordering conditions for the query
     * @return               list of map of [string, any], which represents list of rows as a map of column name to value
     */
-  def selectWithPredicates(table: String, columns: List[String], predicates: List[Predicate], ordering: List[QueryOrdering], limit: Int)
-    (implicit ec: ExecutionContext):
-  DBIO[List[Map[String, Any]]] = {
+  def selectWithPredicates(
+    table: String,
+    columns: List[String],
+    predicates: List[Predicate],
+    ordering: List[QueryOrdering],
+    limit: Int)
+    (implicit ec: ExecutionContext): DBIO[List[Map[String, Any]]] = {
      makeQuery(table, columns)
        .addPredicates(predicates)
        .addOrdering(ordering)

--- a/src/main/scala/tech/cryptonomic/conseil/util/DatabaseUtil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/util/DatabaseUtil.scala
@@ -75,7 +75,12 @@ object DatabaseUtil {
         * @return new SQLActionBuilder containing ordering statements
         */
       def addOrdering(ordering: List[QueryOrdering]): SQLActionBuilder = {
-        concatenateSqlActions(action, makeOrdering(ordering))
+        val queryOrdering = if (ordering.isEmpty) {
+          List.empty
+        } else {
+          List(makeOrdering(ordering))
+        }
+        concatenateSqlActions(action, queryOrdering:_*)
       }
 
       /** Method for adding limit to existing SQLAction
@@ -119,11 +124,8 @@ object DatabaseUtil {
       * @return SQLAction with ordering
       */
     def makeOrdering(ordering: List[QueryOrdering]): SQLActionBuilder = {
-      if(ordering.isEmpty) sql""""""
-      else {
-        val orderingBy = ordering.map(x => s"${x.field} ${x.direction}").mkString(",")
-        sql""" ORDER BY #$orderingBy"""
-      }
+      val orderingBy = ordering.map(x => s"${x.field} ${x.direction}").mkString(",")
+      sql""" ORDER BY #$orderingBy"""
     }
 
     /** Prepares limit parameters

--- a/src/main/scala/tech/cryptonomic/conseil/util/DatabaseUtil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/util/DatabaseUtil.scala
@@ -2,8 +2,8 @@ package tech.cryptonomic.conseil.util
 
 import slick.jdbc.PostgresProfile.api._
 import slick.jdbc.{GetResult, PositionedParameters, SQLActionBuilder}
-import tech.cryptonomic.conseil.generic.chain.DataTypes.{Predicate, QueryOrdering}
-import tech.cryptonomic.conseil.tezos.TezosDatabaseOperations.{makePredicates, makeOrdering, makeLimit}
+import tech.cryptonomic.conseil.generic.chain.DataTypes.OperationType.OperationType
+import tech.cryptonomic.conseil.generic.chain.DataTypes.{OperationType, Predicate, QueryOrdering}
 
 /**
   * Utility functions and members for common database operations.
@@ -11,76 +11,145 @@ import tech.cryptonomic.conseil.tezos.TezosDatabaseOperations.{makePredicates, m
 object DatabaseUtil {
   lazy val db = Database.forConfig("conseildb")
 
-  /** Concatenates SQLActionsBuilders
-    * Slick does not support easy concatenation of actions so we need this function based on https://github.com/slick/slick/issues/1161
-    * @param acc      base SqlActionBuilder with which we want concatenate other actions
-    * @param actions  list of actions to concatenate
-    * @return         one SQLActionBuilder containing concatenated actions
+  /**
+    * Utility object for generic query composition with SQL interpolation
     */
-  def concatenateSqlActions(acc: SQLActionBuilder, actions: List[SQLActionBuilder]): SQLActionBuilder = {
-    actions.foldLeft(acc) {
-      case (accumulator, action) =>
-        SQLActionBuilder(accumulator.queryParts ++ action.queryParts, (p: Unit, pp: PositionedParameters) => {
-          accumulator.unitPConv.apply(p, pp)
-          action.unitPConv.apply(p, pp)
-        })
-    }
-  }
-
-  /** Creates SQLAction of sequence of values
-    * @param  xs  list of values to be inserted into SQLAction
-    * @return     SqlActionBuilder with values from parameter
-    */
-  def insertValuesIntoSqlAction[T](xs: Seq[T]): SQLActionBuilder = {
-    var b = sql"("
-    var first = true
-    xs.foreach { x =>
-      if(first) first = false
-      else b = concatenateSqlActions(b, List(sql","))
-      b = concatenateSqlActions(b, List(sql"'#$x'"))
-    }
-    concatenateSqlActions(b, List(sql")"))
-  }
-
-  /** Implicit value that allows getting table row as Map[String, Any] */
-  implicit val getMap: GetResult[Map[String, Any]] = GetResult[Map[String, Any]](positionedResult => {
-    val metadata = positionedResult.rs.getMetaData
-    (1 to positionedResult.numColumns).flatMap(i => {
-      val columnName = metadata.getColumnName(i).toLowerCase
-      val columnValue = positionedResult.nextObjectOption
-      columnValue.map(columnName -> _)
-    }).toMap
-  })
-
-  /** Implicit class providing helper methods for SQLActionBuilder */
-  implicit class SqlActionHelper(action: SQLActionBuilder) {
-    /** Method for adding predicates to existing SQLAction
-      * @param predicates list of predicates to add
-      * @return           new SQLActionBuilder containing given predicates
+  object QueryBuilder {
+    /** Concatenates SQLActionsBuilders
+      * Slick does not support easy concatenation of actions so we need this function based on https://github.com/slick/slick/issues/1161
+      *
+      * @param acc     base SqlActionBuilder with which we want concatenate other actions
+      * @param actions list of actions to concatenate
+      * @return one SQLActionBuilder containing concatenated actions
       */
-    def addPredicates(predicates: List[Predicate]): SQLActionBuilder = {
-      concatenateSqlActions(action, makePredicates(predicates))
-    }
-
-    /** Method for adding ordering to existing SQLAction
-      * @param ordering   list of QueryOrdering to add
-      * @return           new SQLActionBuilder containing ordering statements
-      */
-    def addOrdering(ordering: List[QueryOrdering]): SQLActionBuilder = {
-      val queryOrdering = if(ordering.isEmpty) {
-        List.empty
-      } else {
-        List(makeOrdering(ordering))
+    def concatenateSqlActions(acc: SQLActionBuilder, actions: List[SQLActionBuilder]): SQLActionBuilder = {
+      actions.foldLeft(acc) {
+        case (accumulator, action) =>
+          SQLActionBuilder(accumulator.queryParts ++ action.queryParts, (p: Unit, pp: PositionedParameters) => {
+            accumulator.unitPConv.apply(p, pp)
+            action.unitPConv.apply(p, pp)
+          })
       }
-      concatenateSqlActions(action, queryOrdering)
     }
 
-    /** Method for adding limit to existing SQLAction
-      * @param limit      limit to add
-      * @return           new SQLActionBuilder containing limit statement
+    /** Creates SQLAction of sequence of values
+      *
+      * @param  xs list of values to be inserted into SQLAction
+      * @return SqlActionBuilder with values from parameter
       */
-    def addLimit(limit: Int): SQLActionBuilder = {
-      concatenateSqlActions(action, List(makeLimit(limit)))
+    def insertValuesIntoSqlAction[T](xs: Seq[T]): SQLActionBuilder = {
+      var b = sql"("
+      var first = true
+      xs.foreach { x =>
+        if (first) first = false
+        else b = concatenateSqlActions(b, List(sql","))
+        b = concatenateSqlActions(b, List(sql"'#$x'"))
+      }
+      concatenateSqlActions(b, List(sql")"))
+    }
+
+    /** Implicit value that allows getting table row as Map[String, Any] */
+    implicit val getMap: GetResult[Map[String, Any]] = GetResult[Map[String, Any]](positionedResult => {
+      val metadata = positionedResult.rs.getMetaData
+      (1 to positionedResult.numColumns).flatMap(i => {
+        val columnName = metadata.getColumnName(i).toLowerCase
+        val columnValue = positionedResult.nextObjectOption
+        columnValue.map(columnName -> _)
+      }).toMap
+    })
+
+    /** Implicit class providing helper methods for SQLActionBuilder */
+    implicit class SqlActionHelper(action: SQLActionBuilder) {
+      /** Method for adding predicates to existing SQLAction
+        *
+        * @param predicates list of predicates to add
+        * @return new SQLActionBuilder containing given predicates
+        */
+      def addPredicates(predicates: List[Predicate]): SQLActionBuilder = {
+        concatenateSqlActions(action, makePredicates(predicates))
+      }
+
+      /** Method for adding ordering to existing SQLAction
+        *
+        * @param ordering list of QueryOrdering to add
+        * @return new SQLActionBuilder containing ordering statements
+        */
+      def addOrdering(ordering: List[QueryOrdering]): SQLActionBuilder = {
+        val queryOrdering = if (ordering.isEmpty) {
+          List.empty
+        } else {
+          List(makeOrdering(ordering))
+        }
+        concatenateSqlActions(action, queryOrdering)
+      }
+
+      /** Method for adding limit to existing SQLAction
+        *
+        * @param limit limit to add
+        * @return new SQLActionBuilder containing limit statement
+        */
+      def addLimit(limit: Int): SQLActionBuilder = {
+        concatenateSqlActions(action, List(makeLimit(limit)))
+      }
+    }
+
+    /** Prepares predicates and transforms them into SQLActionBuilders
+      *
+      * @param  predicates list of predicates to be transformed
+      * @return list of transformed predicates
+      */
+    def makePredicates(predicates: List[Predicate]): List[SQLActionBuilder] =
+      predicates.map { predicate =>
+        concatenateSqlActions(
+          predicate.precision.map(precision => sql""" AND ROUND(#${predicate.field}, $precision) """)
+            .getOrElse(sql""" AND #${predicate.field} """),
+          List(mapOperationToSQL(predicate.operation, predicate.inverse, predicate.set.map(_.toString)))
+        )
+      }
+
+    /** Prepares query
+      *
+      * @param table   table on which query will be executed
+      * @param columns columns which are selected from teh table
+      * @return SQLAction with basic query
+      */
+    def makeQuery(table: String, columns: List[String]): SQLActionBuilder = {
+      val cols = if (columns.isEmpty) "*" else columns.mkString(",")
+      sql"""SELECT #$cols FROM #$table WHERE true """
+    }
+
+    /** Prepares ordering parameters
+      *
+      * @param ordering list of ordering parameters
+      * @return SQLAction with ordering
+      */
+    def makeOrdering(ordering: List[QueryOrdering]): SQLActionBuilder = {
+      val orderingBy = ordering.map(x => s"${x.field} ${x.direction}").mkString(",")
+      sql""" ORDER BY #$orderingBy"""
+    }
+
+    /** Prepares limit parameters
+      *
+      * @param limit list of ordering parameters
+      * @return SQLAction with ordering
+      */
+    def makeLimit(limit: Int): SQLActionBuilder = {
+      sql""" LIMIT $limit"""
+    }
+
+    /** maps operation type to SQL operation */
+    private def mapOperationToSQL(operation: OperationType, inverse: Boolean, vals: List[String]): SQLActionBuilder = {
+      val op = operation match {
+        case OperationType.between => sql"BETWEEN #${vals.head} AND #${vals(1)}"
+        case OperationType.in => concatenateSqlActions(sql"IN ", List(insertValuesIntoSqlAction(vals)))
+        case OperationType.like => sql"LIKE '%#${vals.head}%'"
+        case OperationType.lt | OperationType.before => sql"< '#${vals.head}'"
+        case OperationType.gt | OperationType.after => sql"> '#${vals.head}'"
+        case OperationType.eq => sql"= '#${vals.head}'"
+        case OperationType.startsWith => sql"LIKE '#${vals.head}%'"
+        case OperationType.endsWith => sql"LIKE '%#${vals.head}'"
+      }
+      concatenateSqlActions(op, List(sql" IS #${!inverse}"))
     }
   }
 

--- a/src/main/scala/tech/cryptonomic/conseil/util/DatabaseUtil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/util/DatabaseUtil.scala
@@ -3,7 +3,7 @@ package tech.cryptonomic.conseil.util
 import slick.jdbc.PostgresProfile.api._
 import slick.jdbc.{GetResult, PositionedParameters, SQLActionBuilder}
 import tech.cryptonomic.conseil.generic.chain.DataTypes.{Predicate, QueryOrdering}
-import tech.cryptonomic.conseil.tezos.TezosDatabaseOperations.{makePredicates, makeOrdering}
+import tech.cryptonomic.conseil.tezos.TezosDatabaseOperations.{makePredicates, makeOrdering, makeLimit}
 
 /**
   * Utility functions and members for common database operations.
@@ -73,6 +73,14 @@ object DatabaseUtil {
         List(makeOrdering(ordering))
       }
       concatenateSqlActions(action, queryOrdering)
+    }
+
+    /** Method for adding limit to existing SQLAction
+      * @param limit      limit to add
+      * @return           new SQLActionBuilder containing limit statement
+      */
+    def addLimit(limit: Int): SQLActionBuilder = {
+      concatenateSqlActions(action, List(makeLimit(limit)))
     }
   }
 

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
@@ -685,7 +685,7 @@ class TezosDatabaseOperationsTest
 
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, List.empty, List.empty)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, List.empty, List.empty, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
@@ -708,7 +708,7 @@ class TezosDatabaseOperationsTest
 
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
@@ -730,7 +730,7 @@ class TezosDatabaseOperationsTest
 
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
@@ -758,7 +758,7 @@ class TezosDatabaseOperationsTest
 
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
@@ -772,7 +772,7 @@ class TezosDatabaseOperationsTest
       val predicates = List.empty
 
       val populateAndTest = for {
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
@@ -792,7 +792,7 @@ class TezosDatabaseOperationsTest
 
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
@@ -814,7 +814,7 @@ class TezosDatabaseOperationsTest
 
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
@@ -837,7 +837,7 @@ class TezosDatabaseOperationsTest
 
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
@@ -859,7 +859,7 @@ class TezosDatabaseOperationsTest
 
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
@@ -881,7 +881,7 @@ class TezosDatabaseOperationsTest
 
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
@@ -903,7 +903,7 @@ class TezosDatabaseOperationsTest
 
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
@@ -925,7 +925,7 @@ class TezosDatabaseOperationsTest
 
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
@@ -945,13 +945,35 @@ class TezosDatabaseOperationsTest
 
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
       result shouldBe List(
         Map("level" -> 0, "proto" -> 1, "protocol" -> "protocol", "hash" -> "R0NpYZuUeF"),
         Map("level" -> 1, "proto" -> 1, "protocol" -> "protocol", "hash" -> "aQeGrbXCmG")
+      )
+    }
+
+    "get map from a block table with between predicate when two element fulfill it but limited to 1 element" in {
+      val columns = List("level", "proto", "protocol", "hash")
+      val predicates = List(
+        Predicate(
+          field = "level",
+          operation = OperationType.between,
+          set = List(-10,10),
+          inverse = false
+        )
+      )
+
+      val populateAndTest = for {
+        _ <- Tables.Blocks ++= blocksTmp
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty, 1)
+      } yield found
+
+      val result = dbHandler.run(populateAndTest.transactionally).futureValue
+      result shouldBe List(
+        Map("level" -> 0, "proto" -> 1, "protocol" -> "protocol", "hash" -> "R0NpYZuUeF")
       )
     }
 
@@ -968,7 +990,7 @@ class TezosDatabaseOperationsTest
 
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
@@ -989,7 +1011,7 @@ class TezosDatabaseOperationsTest
 
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
@@ -1010,7 +1032,7 @@ class TezosDatabaseOperationsTest
 
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
@@ -1031,7 +1053,7 @@ class TezosDatabaseOperationsTest
 
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
@@ -1050,7 +1072,7 @@ class TezosDatabaseOperationsTest
 
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
@@ -1071,7 +1093,7 @@ class TezosDatabaseOperationsTest
 
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, List.empty, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
@@ -1105,7 +1127,7 @@ class TezosDatabaseOperationsTest
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
         _ <- Tables.Accounts += accRow
-        found <- sut.selectWithPredicates(Tables.Accounts.baseTableRow.tableName, columns, predicates, List.empty)
+        found <- sut.selectWithPredicates(Tables.Accounts.baseTableRow.tableName, columns, predicates, List.empty, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue.map(_.mapValues(_.toString))
@@ -1126,7 +1148,7 @@ class TezosDatabaseOperationsTest
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
         _ <- Tables.Accounts += accRow
-        found <- sut.selectWithPredicates(Tables.Accounts.baseTableRow.tableName, columns, predicates, List.empty)
+        found <- sut.selectWithPredicates(Tables.Accounts.baseTableRow.tableName, columns, predicates, List.empty, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
@@ -1162,7 +1184,7 @@ class TezosDatabaseOperationsTest
 
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, sortBy)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, sortBy, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
@@ -1184,7 +1206,7 @@ class TezosDatabaseOperationsTest
 
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, sortBy)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, sortBy, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
@@ -1206,7 +1228,7 @@ class TezosDatabaseOperationsTest
 
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, sortBy)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, sortBy, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
@@ -1228,7 +1250,7 @@ class TezosDatabaseOperationsTest
 
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, sortBy)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, sortBy, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
@@ -1256,7 +1278,7 @@ class TezosDatabaseOperationsTest
 
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp2
-        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, sortBy)
+        found <- sut.selectWithPredicates(Tables.Blocks.baseTableRow.tableName, columns, predicates, sortBy, 3)
       } yield found
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
@@ -13,6 +13,7 @@ import tech.cryptonomic.conseil.tezos.Tables.{AccountsRow, BlocksRow, OperationG
 import tech.cryptonomic.conseil.tezos.TezosTypes._
 import tech.cryptonomic.conseil.tezos.FeeOperations.AverageFees
 import tech.cryptonomic.conseil.generic.chain.DataTypes.{OperationType, OrderDirection, Predicate, QueryOrdering}
+import tech.cryptonomic.conseil.util.DatabaseUtil
 
 import scala.util.Random
 
@@ -1156,12 +1157,12 @@ class TezosDatabaseOperationsTest
     }
 
     "return the same results for the same query" in {
-      import tech.cryptonomic.conseil.util.DatabaseUtil._
+      import tech.cryptonomic.conseil.util.DatabaseUtil.QueryBuilder._
       val columns = List("level", "proto", "protocol", "hash")
       val tableName = Tables.Blocks.baseTableRow.tableName
       val populateAndTest = for {
         _ <- Tables.Blocks ++= blocksTmp
-        generatedQuery <- sut.makeQuery(tableName, columns).as[Map[String, Any]]
+        generatedQuery <- makeQuery(tableName, columns).as[Map[String, Any]]
       } yield generatedQuery
 
       val generatedQueryResult = dbHandler.run(populateAndTest.transactionally).futureValue


### PR DESCRIPTION
Added support of the `limit` field in the query and refactored a bit moving methods into the `QueryBuilder` object inside of `DatabaseUtil`.  Should be merged after PR #224 