### PR TITLE
Remove jackson-parsing error encountering duplicate keys

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/util/JsonUtil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/util/JsonUtil.scala
@@ -53,7 +53,7 @@ object JsonUtil {
     mapper.registerModule(DefaultScalaModule)
       .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
       .enable(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY)
-      .enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION)
+      .disable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION)
 
   def toJson[T](value: T): JsonString =
     JsonString(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(value))

--- a/src/test/scala/tech/cryptonomic/conseil/util/JsonUtilTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/util/JsonUtilTest.scala
@@ -5,6 +5,8 @@ import org.scalatest.Inspectors._
 import JsonUtil._
 import com.stephenn.scalatest.jsonassert.JsonMatchers
 
+case class TestObject(field: String = "")
+
 class JsonUtilTest extends WordSpec with Matchers with JsonMatchers {
 
   "JsonUtil" should {
@@ -40,8 +42,7 @@ class JsonUtilTest extends WordSpec with Matchers with JsonMatchers {
           "{", //incomplete
           "{field : true}", //missing quotes
           """{"field" : trues}""", // invalid field value
-          """{"field" : true, }""", // incomplete object fields
-          """{"field" : true, "field" : 1}""" // duplicate field
+          """{"field" : true, }""" // incomplete object fields
         )
 
       forAll(invalid) {
@@ -51,6 +52,18 @@ class JsonUtilTest extends WordSpec with Matchers with JsonMatchers {
           jsonTry.failed.get shouldBe a [JsonParseException]
       }
     }
+
+    "allow lenient parsing of json with duplicate object keys, actually deserialized or not" in {
+
+      val duplicateKey = """{"field": "value", "field": "dup"}"""
+
+      JsonUtil.fromJson[TestObject](duplicateKey) shouldBe TestObject(field = "dup")
+
+      val duplicateInnerKey = """{"field": "value", "inner": {"field":"inner", "field": "dup", "another": 10}}"""
+
+      JsonUtil.fromJson[TestObject](duplicateInnerKey) shouldBe TestObject(field = "value")
+    }
+
 
   }
 


### PR DESCRIPTION
This hotfix disable json parsing verification of duplicate object keys, as happened while working on tezos-alphanet in some internal result error for a transaction