### PR TITLE
Added apiKey to permitted CORS headers

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/directives/EnableCORSDirectives.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/directives/EnableCORSDirectives.scala
@@ -12,7 +12,7 @@ trait EnableCORSDirectives extends RespondWithDirectives {
   )
 
   private val allowedCorsHeaders = List(
-    "X-Requested-With", "content-type", "origin", "accept"
+    "X-Requested-With", "content-type", "origin", "accept", "apiKey"
   )
 
   lazy val enableCORS =


### PR DESCRIPTION
Browser queries against Conseil are failing as 'apiKey' is not among the permitted CORS headers.