### PR TITLE
Conseil 260: fix missing balance updates in blocks

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/tezos/Balances.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/Balances.scala
@@ -116,7 +116,7 @@ object BlockBalances {
 
     //the updates might actually be missing from json
     override def getAllBalanceUpdates(data: BlockData)(implicit show: Show[Symbol]) =
-      Map(BLOCK_SOURCE -> Option(data.metadata.balance_updates).getOrElse(List.empty))
+      Map(BLOCK_SOURCE -> data.metadata.balance_updates.getOrElse(List.empty))
 
     override def getHash(data: BlockData) = Option(data.hash.value)
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -266,8 +266,11 @@ class TezosNodeOperator(val node: TezosRPCInterface, batchConf: BatchFetchConfig
     val jsonToBlockData: ((Int, String)) => Future[BlockData] = {
       case (_, json) =>
         decode[BlockData](JS.sanitize(json)) match {
-          case Left(error) => Future.failed(error)
-          case Right(results) => Future.successful(results)
+          case Left(error) =>
+            logger.error("I fetched a block definition from tezos node that I'm unable to decode: {}", json)
+            Future.failed(error)
+          case Right(results) =>
+            Future.successful(results)
         }
     }
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -63,7 +63,7 @@ object TezosTypes {
 
 
   final case class BlockHeaderMetadata(
-    balance_updates: List[OperationMetadata.BalanceUpdate]
+    balance_updates: Option[List[OperationMetadata.BalanceUpdate]]
   )
 
   /** Naming can be deceiving, we're sticking with the json schema use of `positive_bignumber`

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
@@ -220,7 +220,7 @@ class TezosDatabaseOperationsTest
         block.copy(
           data = block.data.copy(
             metadata = block.data.metadata.copy(
-              balance_updates = generateBalanceUpdates(2)(randomSeed + idx)
+              balance_updates = Option(generateBalanceUpdates(2)(randomSeed + idx))
             )
           )
         )

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
@@ -82,7 +82,7 @@ trait TezosDataGeneration extends RandomGenerationKit {
             context = s"context$level",
             signature = Some(s"sig${generateHash(10)}")
           ),
-          metadata = BlockHeaderMetadata(balance_updates = List.empty)
+          metadata = BlockHeaderMetadata(balance_updates = None)
         ),
         operationGroups = List.empty
       )
@@ -113,7 +113,7 @@ trait TezosDataGeneration extends RandomGenerationKit {
             timestamp = atTime
           ),
           metadata = generated.data.metadata.copy(
-            balance_updates = balanceUpdates
+            balance_updates = Some(balanceUpdates)
           )
         )
       )


### PR DESCRIPTION
Closes #260 

The fix makes block metadata balance_updates optional

Handling only the Genesis block differently didn't actually solve the issue, because the block at level 1 in alphanet was still missing that expected data.

This confirms that the json schemas available on tezos are not correct or maybe that we should verify if there are discrepancies between tezos protocol versions?