### PR TITLE
Conseil 263: Try to fix deadlock with slick connection pooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,9 @@ conseildb = {
     user = "redacted"
     password = "redacted"
   }
-  numThreads = 10 #please make sure you know what you're doing before changing this
+  #please make sure you know what you're doing before changing these values
+  numThreads = 10
+  maxConnections = 10
 }
 
 #available blockchain platforms

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ scalaVersion := "2.12.8"
 
 val akkaHttpVersion = "10.1.0"
 val akkaVersion = "2.5.11"
-val slickVersion = "3.2.1"
+val slickVersion = "3.3.0"
 val circeVersion = "0.11.0"
 val catsVersion = "1.6.0"
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -24,7 +24,11 @@ conseildb = {
     password = "bar"
     reWriteBatchedInserts = true
   }
+  # The following numbers are based on literature from here: https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
+  # We might want to fine-tune these on the actual infrastructure, doing testing with different values
+  # Please keep both values aligned in your configuration to avoid this issue: https://github.com/dnvriend/akka-persistence-jdbc/issues/177
   numThreads = 10
+  maxConnections = 10
 }
 
 #Slick debug level


### PR DESCRIPTION
should fix #263 
need to test a whole chain reset on Lorre in dev

 * put lockstep configs in slick's connection
 * upgrade to slick's latest, that should contain a fix for the known
   issue

The issue being referred is dnvriend/akka-persistence-jdbc#177