### PR TITLE
Conseil 254 adding CSV output to query endpoint

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
@@ -12,7 +12,6 @@ import tech.cryptonomic.conseil.tezos.TezosPlatformDiscoveryOperations
   * Classes used for deserializing query.
   */
 object DataTypes {
-
   import io.scalaland.chimney.dsl._
 
   /** Type representing Map[String, Any] */
@@ -104,7 +103,6 @@ object DataTypes {
     val json, csv = Value
   }
 
-
   /** Enumeration for order direction */
   object OrderDirection extends Enumeration {
     type OrderDirection = Value
@@ -116,5 +114,4 @@ object DataTypes {
     type OperationType = Value
     val in, between, like, lt, gt, eq, startsWith, endsWith, before, after, isnull = Value
   }
-
 }

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.`type`.TypeReference
 import com.fasterxml.jackson.module.scala.JsonScalaEnumeration
 import tech.cryptonomic.conseil.generic.chain.DataTypes.OperationType.OperationType
 import tech.cryptonomic.conseil.generic.chain.DataTypes.OrderDirection.OrderDirection
+import tech.cryptonomic.conseil.generic.chain.DataTypes.OutputType.OutputType
 import tech.cryptonomic.conseil.tezos.TezosPlatformDiscoveryOperations
 
 
@@ -33,6 +34,9 @@ object DataTypes {
   /** Class required for OperationType enum serialization */
   class OperationTypeRef extends TypeReference[OperationType.type]
 
+  /** Class required for OutputType enum serialization */
+  class OutputTypeRef extends TypeReference[OutputType.type]
+
   /** Class representing predicate */
   case class Predicate(
     field: String,
@@ -45,6 +49,7 @@ object DataTypes {
   /** Class required for Ordering enum serialization */
   class QueryOrderingRef extends TypeReference[OrderDirection.type]
 
+  /** Class representing representing query ordering */
   case class QueryOrdering(field: String, @JsonScalaEnumeration(classOf[QueryOrderingRef]) direction: OrderDirection)
 
   /** Class representing invalid query field */
@@ -58,7 +63,8 @@ object DataTypes {
     fields: List[String] = List.empty,
     predicates: List[Predicate] = List.empty,
     orderBy: List[QueryOrdering] = List.empty,
-    limit: Int = defaultLimitValue
+    limit: Int = defaultLimitValue,
+    output: OutputType = OutputType.json
   )
 
   /** Class representing query got through the REST API */
@@ -66,7 +72,8 @@ object DataTypes {
     fields: Option[List[String]],
     predicates: Option[List[Predicate]],
     orderBy: Option[List[QueryOrdering]],
-    limit: Option[Int]
+    limit: Option[Int],
+    @JsonScalaEnumeration(classOf[OutputTypeRef]) output: Option[OutputType]
   ) {
     /** Method which validates query fields, as jackson runs on top of runtime reflection so NPE can happen if fields are missing */
     def validate(entity: String): Either[List[QueryValidationError], Query] = {
@@ -88,6 +95,13 @@ object DataTypes {
       }
     }
   }
+
+  /** Enumeration for output types */
+  object OutputType extends Enumeration {
+    type OutputType = Value
+    val json, csv = Value
+  }
+
 
   /** Enumeration for order direction */
   object OrderDirection extends Enumeration {

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
@@ -12,6 +12,7 @@ import tech.cryptonomic.conseil.tezos.TezosPlatformDiscoveryOperations
   * Classes used for deserializing query.
   */
 object DataTypes {
+
   import io.scalaland.chimney.dsl._
 
   /** Type representing Map[String, Any] */
@@ -19,10 +20,8 @@ object DataTypes {
 
   /** Type representing Map[String, Option[Any]] for query response */
   type QueryResponse = Map[String, Option[Any]]
-
   /** Default value of limit parameter */
   val defaultLimitValue: Int = 10000
-
   /** Max value of limit parameter */
   val maxLimitValue: Int = 100000
 
@@ -30,6 +29,9 @@ object DataTypes {
   sealed trait QueryValidationError extends Product with Serializable {
     val message: String
   }
+
+  /** Class which contains output type with the response */
+  case class QueryResponseWithOutput(queryResponse: List[QueryResponse], output: OutputType)
 
   /** Class required for OperationType enum serialization */
   class OperationTypeRef extends TypeReference[OperationType.type]

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
@@ -50,7 +50,7 @@ object DataTypes {
   /** Class required for Ordering enum serialization */
   class QueryOrderingRef extends TypeReference[OrderDirection.type]
 
-  /** Class representing representing query ordering */
+  /** Class representing query ordering */
   case class QueryOrdering(field: String, @JsonScalaEnumeration(classOf[QueryOrderingRef]) direction: OrderDirection)
 
   /** Class representing invalid query field */

--- a/src/main/scala/tech/cryptonomic/conseil/routes/Data.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/Data.scala
@@ -6,7 +6,7 @@ import com.typesafe.scalalogging.LazyLogging
 import tech.cryptonomic.conseil.config.Platforms.PlatformsConfiguration
 import tech.cryptonomic.conseil.db.DatabaseApiFiltering
 import tech.cryptonomic.conseil.generic.chain.DataPlatform
-import tech.cryptonomic.conseil.generic.chain.DataTypes.OutputType
+import tech.cryptonomic.conseil.generic.chain.DataTypes.QueryResponseWithOutput
 import tech.cryptonomic.conseil.tezos.ApiOperations
 import tech.cryptonomic.conseil.tezos.TezosTypes.{AccountId, BlockHash}
 import tech.cryptonomic.conseil.util.ConfigUtil
@@ -29,8 +29,8 @@ class Data(config: PlatformsConfiguration, queryProtocolPlatform: DataPlatform)(
 
   import cats.instances.either._
   import cats.instances.future._
-  import cats.syntax.bitraverse._
   import cats.instances.option._
+  import cats.syntax.bitraverse._
   import cats.syntax.traverse._
 
   /*
@@ -42,15 +42,17 @@ class Data(config: PlatformsConfiguration, queryProtocolPlatform: DataPlatform)(
   val postRoute: Route = queryEndpoint.implementedByAsync {
     case ((platform, network, entity), apiQuery, _) =>
       apiQuery.validate(entity).map { validQuery =>
-      platformNetworkValidation(platform, network) {
-        val sth = queryProtocolPlatform.queryWithPredicates(platform, entity, validQuery)
-        if(validQuery.output == OutputType.csv) {
-          Right(sth)
-        } else {
-          Left(sth)
+        platformNetworkValidation(platform, network) {
+          queryProtocolPlatform.queryWithPredicates(platform, entity, validQuery).map { queryResponseOpt =>
+            queryResponseOpt.map { queryResponses =>
+              QueryResponseWithOutput(
+                queryResponses,
+                validQuery.output
+              )
+            }
+          }
         }
-      }
-    }.left.map(Future.successful).bisequence.map(eitherOptionOps)
+      }.left.map(Future.successful).bisequence.map(eitherOptionOps)
   }
 
   /** V2 Route implementation for blocks endpoint */

--- a/src/main/scala/tech/cryptonomic/conseil/routes/DataHelpers.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/DataHelpers.scala
@@ -35,7 +35,7 @@ trait DataHelpers extends QueryStringListsServer with Validation with akkahttp.s
     }.getOrElse("")
     val values = queryResponse.map { values =>
       values.values.map {
-        case Some(xx) => xx
+        case Some(value) => value
         case None => "null"
       }.mkString(",")
     }

--- a/src/main/scala/tech/cryptonomic/conseil/routes/DataHelpers.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/DataHelpers.scala
@@ -12,8 +12,6 @@ import endpoints.algebra.Documentation
 import tech.cryptonomic.conseil.generic.chain.DataTypes._
 import tech.cryptonomic.conseil.routes.openapi.{DataEndpoints, QueryStringListsServer, Validation}
 import tech.cryptonomic.conseil.tezos.Tables
-import tech.cryptonomic.conseil.util.Conversion
-import tech.cryptonomic.conseil.util.Conversion.Id
 
 /** Trait with helpers needed for data routes */
 trait DataHelpers extends QueryStringListsServer with Validation with akkahttp.server.Endpoints
@@ -30,7 +28,7 @@ trait DataHelpers extends QueryStringListsServer with Validation with akkahttp.s
       complete(StatusCodes.BadRequest -> s"Errors: \n${errors.mkString("\n")}")
     case Right(QueryResponseWithOutput(queryResponse, OutputType.csv)) =>
       complete(HttpEntity.Strict(ContentTypes.`text/csv(UTF-8)`, ByteString(queryResponse.convertTo[String])))
-    case Right(success@QueryResponseWithOutput) =>
+    case Right(success) =>
       response(success)
   }
 

--- a/src/main/scala/tech/cryptonomic/conseil/routes/DataHelpers.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/DataHelpers.scala
@@ -40,6 +40,24 @@ trait DataHelpers extends QueryStringListsServer with Validation with akkahttp.s
     )
   }
 
+  override implicit def queryResponseSchemaWithCsv: JsonSchema[Either[List[QueryResponse], List[QueryResponse]]] =
+    new JsonSchema[Either[List[QueryResponse], List[QueryResponse]]] {
+      override def encoder: Encoder[Either[List[QueryResponse], List[QueryResponse]]] = new Encoder[Either[List[QueryResponse], List[QueryResponse]]] {
+        override def apply(a: Either[List[QueryResponse], List[QueryResponse]]): Json =  a match {
+          case Left(value) => value.asJson
+          case Right(value) =>
+            (value.headOption.map(_.keys.mkString(",")).getOrElse("") :: value.map { xxx =>
+            xxx.values.map {
+              case Some(xx) => xx
+              case None => "null"
+            }.mkString(",")
+          }).mkString("\n").asJson
+        }
+      }
+
+      override def decoder: Decoder[Either[List[QueryResponse], List[QueryResponse]]] = ???
+    }
+
   /** Implementation of JSON encoder for Any */
   def anyEncoder: Encoder[Any] = (a: Any) => a match {
     case x: java.lang.String => Json.fromString(x)

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/CsvConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/CsvConversions.scala
@@ -1,0 +1,26 @@
+package tech.cryptonomic.conseil.routes.openapi
+
+import tech.cryptonomic.conseil.generic.chain.DataTypes.QueryResponse
+import tech.cryptonomic.conseil.util.Conversion
+import tech.cryptonomic.conseil.util.Conversion.Id
+
+/** Object containing implicit conversions to CSV format */
+object CsvConversions {
+
+  /** Type alias representing CSV string */
+  type CsvString = String
+
+  /** Implicit instance of the conversion from List[QueryResponse] to CsvString */
+  implicit val queryToCsv: Conversion[Id, List[QueryResponse], CsvString] = (from: List[QueryResponse]) => {
+    val headers = from.headOption.map { headerList =>
+      headerList.keys.mkString(",")
+    }.getOrElse("")
+    val values = from.map { values =>
+      values.values.map {
+        case Some(value) => value
+        case None => "null"
+      }.mkString(",")
+    }
+    (headers :: values).mkString("\n")
+  }
+}

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataEndpoints.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataEndpoints.scala
@@ -22,13 +22,13 @@ trait DataEndpoints
     jsonResponse[A](docs = Some(s"Query compatibility endpoint for $endpointName")).orNotFound(Some("Not Found"))
 
   /** V2 Query endpoint definition */
-  def queryEndpoint: Endpoint[((String, String, String), ApiQuery, String), Option[Either[List[QueryValidationError], List[QueryResponse]]]] =
+  def queryEndpoint: Endpoint[((String, String, String), ApiQuery, String), Option[Either[List[QueryValidationError], Either[List[QueryResponse], List[QueryResponse]]]]] =
     endpoint(
       request = post(url = commonPath / segment[String](name = "entity"),
         entity = jsonRequest[ApiQuery](),
         headers = header("apiKey")),
       response = validated(
-        response = jsonResponse[List[QueryResponse]](docs = Some("Query endpoint")),
+        response = jsonResponse[Either[List[QueryResponse], List[QueryResponse]]](docs = Some("Query endpoint")),
         invalidDocs = Some("Can't query - invalid entity!")
       ).orNotFound(Some("Not found")),
       tags = List("Query")

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataEndpoints.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataEndpoints.scala
@@ -1,7 +1,7 @@
 package tech.cryptonomic.conseil.routes.openapi
 
 import endpoints.algebra
-import tech.cryptonomic.conseil.generic.chain.DataTypes.{AnyMap, ApiQuery, QueryResponse, QueryValidationError}
+import tech.cryptonomic.conseil.generic.chain.DataTypes._
 import tech.cryptonomic.conseil.tezos.ApiOperations.Filter
 import tech.cryptonomic.conseil.tezos.FeeOperations.AverageFees
 import tech.cryptonomic.conseil.tezos.Tables
@@ -18,17 +18,14 @@ trait DataEndpoints
   /** Common path among endpoints */
   private val commonPath = path / "v2" / "data" / segment[String](name = "platform") / segment[String](name = "network")
 
-  private def compatibilityQuery[A: JsonResponse](endpointName: String): Response[Option[A]] =
-    jsonResponse[A](docs = Some(s"Query compatibility endpoint for $endpointName")).orNotFound(Some("Not Found"))
-
   /** V2 Query endpoint definition */
-  def queryEndpoint: Endpoint[((String, String, String), ApiQuery, String), Option[Either[List[QueryValidationError], Either[List[QueryResponse], List[QueryResponse]]]]] =
+  def queryEndpoint: Endpoint[((String, String, String), ApiQuery, String), Option[Either[List[QueryValidationError], QueryResponseWithOutput]]] =
     endpoint(
       request = post(url = commonPath / segment[String](name = "entity"),
         entity = jsonRequest[ApiQuery](),
         headers = header("apiKey")),
       response = validated(
-        response = jsonResponse[Either[List[QueryResponse], List[QueryResponse]]](docs = Some("Query endpoint")),
+        response = jsonResponse[QueryResponseWithOutput](docs = Some("Query endpoint")),
         invalidDocs = Some("Can't query - invalid entity!")
       ).orNotFound(Some("Not found")),
       tags = List("Query")
@@ -113,6 +110,10 @@ trait DataEndpoints
       response = compatibilityQuery[AverageFees]("average fees"),
       tags = List("Fees")
     )
+
+  /** Common method for compatibility queries */
+  private def compatibilityQuery[A: JsonResponse](endpointName: String): Response[Option[A]] =
+    jsonResponse[A](docs = Some(s"Query compatibility endpoint for $endpointName")).orNotFound(Some("Not Found"))
 
   /** V2 Operations endpoint definition */
   def operationsEndpoint: Endpoint[((String, String, Filter), String), Option[List[QueryResponse]]] =

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataJsonSchemas.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataJsonSchemas.scala
@@ -8,7 +8,7 @@ import tech.cryptonomic.conseil.tezos.Tables
 import tech.cryptonomic.conseil.tezos.Tables.AccountsRow
 
 /** Trait containing Data endpoints JSON schemas */
-trait DataJsonSchemas extends algebra.JsonSchemas with generic.JsonSchemas   {
+trait DataJsonSchemas extends algebra.JsonSchemas with generic.JsonSchemas {
 
   /** API query schema */
   implicit def queryRequestSchema: JsonSchema[ApiQuery] =
@@ -29,6 +29,11 @@ trait DataJsonSchemas extends algebra.JsonSchemas with generic.JsonSchemas   {
   /** Query ordering direction schema */
   implicit def queryOrderingDirectionSchema: JsonSchema[OrderDirection.Value] =
     enumeration(OrderDirection.values.toSeq)(_.toString)
+
+  /** Query output schema */
+  implicit def queryOutputSchema: JsonSchema[OutputType.Value] =
+    enumeration(OutputType.values.toSeq)(_.toString)
+
 
   /** Timestamp schema */
   implicit def timestampSchema: JsonSchema[java.sql.Timestamp]
@@ -52,7 +57,7 @@ trait DataJsonSchemas extends algebra.JsonSchemas with generic.JsonSchemas   {
   implicit def queryResponseSchema: JsonSchema[List[QueryResponse]]
 
   /** Query response schema schema */
-  implicit def queryResponseSchemaWithCsv: JsonSchema[Either[List[QueryResponse], List[QueryResponse]]]
+  implicit def queryResponseSchemaWithCsv: JsonSchema[QueryResponseWithOutput]
 
   /** AnyMap schema */
   implicit def blocksByHashSchema: JsonSchema[AnyMap]

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataJsonSchemas.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataJsonSchemas.scala
@@ -53,11 +53,11 @@ trait DataJsonSchemas extends algebra.JsonSchemas with generic.JsonSchemas {
   /** Any schema */
   implicit def anySchema: JsonSchema[Any]
 
-  /** Query response schema schema */
+  /** Query response schema */
   implicit def queryResponseSchema: JsonSchema[List[QueryResponse]]
 
-  /** Query response schema schema */
-  implicit def queryResponseSchemaWithCsv: JsonSchema[QueryResponseWithOutput]
+  /** Query response schema with output type */
+  implicit def queryResponseSchemaWithOutputType: JsonSchema[QueryResponseWithOutput]
 
   /** AnyMap schema */
   implicit def blocksByHashSchema: JsonSchema[AnyMap]

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataJsonSchemas.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataJsonSchemas.scala
@@ -51,6 +51,9 @@ trait DataJsonSchemas extends algebra.JsonSchemas with generic.JsonSchemas   {
   /** Query response schema schema */
   implicit def queryResponseSchema: JsonSchema[List[QueryResponse]]
 
+  /** Query response schema schema */
+  implicit def queryResponseSchemaWithCsv: JsonSchema[Either[List[QueryResponse], List[QueryResponse]]]
+
   /** AnyMap schema */
   implicit def blocksByHashSchema: JsonSchema[AnyMap]
 

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/OpenApiDoc.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/OpenApiDoc.scala
@@ -53,7 +53,7 @@ object OpenApiDoc extends DataEndpoints
   /** Function for validation definition in documentation which appends DocumentedResponse to the list of possible results from the query.
     * In this case if query fails to validate it will return 400 Bad Request.
     * */
-  override def validated(response: List[OpenApiDoc.DocumentedResponse], invalidDocs: Documentation): List[OpenApiDoc.DocumentedResponse] =
+  override def validated[A](response: List[OpenApiDoc.DocumentedResponse], invalidDocs: Documentation): List[OpenApiDoc.DocumentedResponse] =
     response :+ OpenApiDoc.DocumentedResponse(
       status = 400,
       documentation = invalidDocs.getOrElse(""),
@@ -65,7 +65,7 @@ object OpenApiDoc extends DataEndpoints
       documentation = invalidDocs.getOrElse(""),
       content = Map(
         "application/json" -> MediaType(None),
-        "text/plain" -> MediaType(None)
+        "text/csv" -> MediaType(None)
       )
     )
 
@@ -93,5 +93,5 @@ object OpenApiDoc extends DataEndpoints
   /** Documented JSON schema for blocks by hash */
   override implicit def blocksByHashSchema: DocumentedJsonSchema = DocumentedJsonSchema.Primitive("Any - not yet supported")
 
-  override implicit def queryResponseSchemaWithCsv: OpenApiDoc.DocumentedJsonSchema = DocumentedJsonSchema.Primitive("Any - not yet supported")
+  override implicit def queryResponseSchemaWithOutputType: OpenApiDoc.DocumentedJsonSchema = DocumentedJsonSchema.Primitive("Any - not yet supported")
 }

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/OpenApiDoc.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/OpenApiDoc.scala
@@ -16,7 +16,7 @@ object OpenApiDoc extends DataEndpoints
   with openapi.JsonSchemaEntities
   with openapi.BasicAuthentication {
 
-  /** OpenAPI JSON*/
+  /** OpenAPI JSON */
   def openapiJson: Json =
     openapi.asJson
 
@@ -52,13 +52,20 @@ object OpenApiDoc extends DataEndpoints
 
   /** Function for validation definition in documentation which appends DocumentedResponse to the list of possible results from the query.
     * In this case if query fails to validate it will return 400 Bad Request.
-    *  */
-  override def validated[A](response: List[OpenApiDoc.DocumentedResponse], invalidDocs: Documentation): List[OpenApiDoc.DocumentedResponse] =
+    * */
+  override def validated(response: List[OpenApiDoc.DocumentedResponse], invalidDocs: Documentation): List[OpenApiDoc.DocumentedResponse] =
     response :+ OpenApiDoc.DocumentedResponse(
       status = 400,
       documentation = invalidDocs.getOrElse(""),
       content = Map(
         "application/json" -> MediaType(schema = Some(Schema.Array(Schema.simpleString)))
+      )
+    ) :+ OpenApiDoc.DocumentedResponse(
+      status = 200,
+      documentation = invalidDocs.getOrElse(""),
+      content = Map(
+        "application/json" -> MediaType(None),
+        "text/plain" -> MediaType(None)
       )
     )
 
@@ -69,9 +76,9 @@ object OpenApiDoc extends DataEndpoints
   override implicit def queryResponseSchema: DocumentedJsonSchema = DocumentedJsonSchema.Primitive("Any - not yet supported")
 
   /** Documented query string for query string list */
-  override def qsList[A: QueryStringParam](name: String, docs: Option[String]): DocumentedQueryString = new DocumentedQueryString(
+  override def qsList[A: QueryStringParam](name: String, docs: Option[String]): DocumentedQueryString = DocumentedQueryString(
     List(
-      DocumentedParameter(name, false, docs, Schema.Array(implicitly[QueryStringParam[A]]))
+      DocumentedParameter(name, required = false, docs, Schema.Array(implicitly[QueryStringParam[A]]))
     )
   )
 
@@ -85,4 +92,6 @@ object OpenApiDoc extends DataEndpoints
 
   /** Documented JSON schema for blocks by hash */
   override implicit def blocksByHashSchema: DocumentedJsonSchema = DocumentedJsonSchema.Primitive("Any - not yet supported")
+
+  override implicit def queryResponseSchemaWithCsv: OpenApiDoc.DocumentedJsonSchema = DocumentedJsonSchema.Primitive("Any - not yet supported")
 }

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/Validation.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/Validation.scala
@@ -2,10 +2,11 @@ package tech.cryptonomic.conseil.routes.openapi
 
 import endpoints.algebra
 import endpoints.algebra.Documentation
-import tech.cryptonomic.conseil.generic.chain.DataTypes.QueryValidationError
+import tech.cryptonomic.conseil.generic.chain.DataTypes.{QueryResponseWithOutput, QueryValidationError}
 
 /** Trait adding validation for query  */
-trait Validation { self: algebra.Responses =>
+trait Validation {
+  self: algebra.Responses =>
   /** Method for validating query request */
-  def validated[A](response: Response[A], invalidDocs: Documentation): Response[Either[List[QueryValidationError], A]]
+  def validated(response: Response[QueryResponseWithOutput], invalidDocs: Documentation): Response[Either[List[QueryValidationError], QueryResponseWithOutput]]
 }

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/Validation.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/Validation.scala
@@ -2,11 +2,11 @@ package tech.cryptonomic.conseil.routes.openapi
 
 import endpoints.algebra
 import endpoints.algebra.Documentation
-import tech.cryptonomic.conseil.generic.chain.DataTypes.{QueryResponseWithOutput, QueryValidationError}
+import tech.cryptonomic.conseil.generic.chain.DataTypes.QueryValidationError
 
 /** Trait adding validation for query  */
 trait Validation {
   self: algebra.Responses =>
   /** Method for validating query request */
-  def validated(response: Response[QueryResponseWithOutput], invalidDocs: Documentation): Response[Either[List[QueryValidationError], QueryResponseWithOutput]]
+  def validated[A](response: Response[A], invalidDocs: Documentation): Response[Either[List[QueryValidationError], A]]
 }

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/CsvConversionsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/CsvConversionsTest.scala
@@ -1,0 +1,36 @@
+package tech.cryptonomic.conseil.tezos
+
+import org.scalatest.{Matchers, WordSpec}
+import tech.cryptonomic.conseil.generic.chain.DataTypes.QueryResponse
+
+class CsvConversionsTest extends WordSpec with Matchers {
+
+  import tech.cryptonomic.conseil.util.Conversion.Syntax._
+  import tech.cryptonomic.conseil.routes.openapi.CsvConversions._
+
+  "CSV conversions" should {
+
+    "correctly convert List[QueryResponse] to CsvString" in {
+      val queryResponse: List[QueryResponse] = List(Map("a" -> Some("1"), "b" -> Some(2), "c" -> Some(3.0), "d" -> None))
+      val expectedResult: CsvString =
+        """
+          |a,b,c,d
+          |1,2,3.0,null
+        """.stripMargin.trim
+
+      val result = queryResponse.convertTo[CsvString]
+
+      result shouldBe expectedResult
+    }
+
+    "correctly convert empty list" in {
+      val queryResponse: List[QueryResponse] = List.empty
+      val expectedResult: CsvString = ""
+
+      val result = queryResponse.convertTo[CsvString]
+
+      result shouldBe expectedResult
+    }
+  }
+
+}


### PR DESCRIPTION
~~currently query endpoint supports CSV output with the `Accept: text/plain` header or with wildcard `text/*` or without any `Accept:` header. The issue probably will need to be resolved within the `endpoints` library. Consulted with @anonymoussprocket and it is ok for now.~~
I was wrong, I fixed issue with `text/csv` and it works correctly.