### PR TITLE
Feature/256 lambda support

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -112,7 +112,7 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
       responseList =>
         responseList.collect {
           case (id, json) =>
-            val accountTry = Try(fromJson[Account](json)).map((id, _))
+            val accountTry: Try[(AccountId, Account)] = Try(fromJson[Account](json)).map((id, _))
             accountTry.failed.foreach(_ => logger.error("Failed to convert json to an Account for id {}. The content was {}.", id, json))
             accountTry
               .toOption

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/dto/MichelsonInstruction.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/dto/MichelsonInstruction.scala
@@ -8,18 +8,18 @@ package tech.cryptonomic.conseil.tezos.michelson.dto
  *   { DIP { DIP { DUP } ; NIL operation } ; SWAP ; {} }
  *   | |   | |     |       |                 |      |
  *   | |   | |     |       |                 |      MichelsonEmptyInstruction
- *   | |   | |     |       |                 MichelsonSimpleInstruction (not typed)
- *   | |   | |     |       MichelsonSimpleInstruction (with type "operation")
- *   | |   | |     MichelsonSimpleInstruction (not typed)
- *   | |   | MichelsonComplexInstruction (with embedded "DUP" instruction as a one element List)
+ *   | |   | |     |       |                 MichelsonSingleInstruction (not typed)
+ *   | |   | |     |       MichelsonSingleInstruction (with type "operation")
+ *   | |   | |     MichelsonSingleInstruction (not typed)
+ *   | |   | MichelsonSingleInstruction (with embedded "DUP" instruction as a one element List)
  *   | |   MichelsonInstructionSequence (containing a complex instruction "DIP { ... }" and a simple one "NIL operation" separated with ";")
- *   | MichelsonComplexInstruction (with embedded MichelsonInstructionSequence as above)
+ *   | MichelsonSingleInstruction (with embedded MichelsonInstructionSequence as above)
  *   MichelsonInstructionSequence (with three instructions separated with ";": "DIP { ... }", "SWAP" and empty instruction)
  * */
 sealed trait MichelsonInstruction extends MichelsonElement
 
 /* Class representing a simple Michelson instruction which can contains following expressions */
-case class MichelsonSimpleInstruction(prim: String, embeddedElements: List[MichelsonElement] = List.empty) extends MichelsonInstruction
+case class MichelsonSingleInstruction(prim: String, embeddedElements: List[MichelsonElement] = List.empty) extends MichelsonInstruction
 
 /* Class representing a sequence of Michelson instructions */
 case class MichelsonInstructionSequence(instructions: List[MichelsonInstruction] = List.empty) extends MichelsonInstruction

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/dto/MichelsonInstruction.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/dto/MichelsonInstruction.scala
@@ -14,15 +14,12 @@ package tech.cryptonomic.conseil.tezos.michelson.dto
  *   | |   | MichelsonComplexInstruction (with embedded "DUP" instruction as a one element List)
  *   | |   MichelsonInstructionSequence (containing a complex instruction "DIP { ... }" and a simple one "NIL operation" separated with ";")
  *   | MichelsonComplexInstruction (with embedded MichelsonInstructionSequence as above)
- *   MichelsonInstructionSequence (with two instructions separated with ";": "DIP { ... }" and "SWAP")
+ *   MichelsonInstructionSequence (with three instructions separated with ";": "DIP { ... }", "SWAP" and empty instruction)
  * */
 sealed trait MichelsonInstruction extends MichelsonElement
 
 /* Class representing a simple Michelson instruction which can contains following expressions */
-case class MichelsonSimpleInstruction(prim: String, michelsonExpressions: List[MichelsonExpression] = List.empty) extends MichelsonInstruction
-
-/* Class representing a Michelson instruction with other embedded instructions */
-case class MichelsonComplexInstruction(prim: String, embeddedOperations: List[MichelsonInstruction] = List.empty) extends MichelsonInstruction
+case class MichelsonSimpleInstruction(prim: String, embeddedElements: List[MichelsonElement] = List.empty) extends MichelsonInstruction
 
 /* Class representing a sequence of Michelson instructions */
 case class MichelsonInstructionSequence(instructions: List[MichelsonInstruction] = List.empty) extends MichelsonInstruction

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/renderer/MichelsonRenderer.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/renderer/MichelsonRenderer.scala
@@ -11,7 +11,6 @@ object MichelsonRenderer {
       // instructions
       case MichelsonSimpleInstruction(prim, List()) => prim
       case MichelsonSimpleInstruction(prim, args) => s"$prim ${args.map(_.render()).mkString(" ")}"
-      case MichelsonComplexInstruction(prim, args) => s"$prim ${args.map(_.render()).mkString(" ")}"
       case MichelsonInstructionSequence(args) => s"{ ${args.map(_.render()).mkString(" ; ")} }"
       case MichelsonEmptyInstruction => "{}"
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/renderer/MichelsonRenderer.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/renderer/MichelsonRenderer.scala
@@ -9,8 +9,8 @@ object MichelsonRenderer {
     def render(): String = self match {
 
       // instructions
-      case MichelsonSimpleInstruction(prim, List()) => prim
-      case MichelsonSimpleInstruction(prim, args) => s"$prim ${args.map(_.render()).mkString(" ")}"
+      case MichelsonSingleInstruction(prim, List()) => prim
+      case MichelsonSingleInstruction(prim, args) => s"$prim ${args.map(_.render()).mkString(" ")}"
       case MichelsonInstructionSequence(args) => s"{ ${args.map(_.render()).mkString(" ; ")} }"
       case MichelsonEmptyInstruction => "{}"
 

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParserSpec.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParserSpec.scala
@@ -68,21 +68,21 @@ class JsonParserSpec extends FlatSpec with Matchers {
     val json = """{"prim": "DUP"}"""
 
     parse[MichelsonInstruction](json) should equal(Right(
-      MichelsonSimpleInstruction("DUP")))
+      MichelsonSingleInstruction("DUP")))
   }
 
   it should "parse MichelsonInstructionSequence" in {
     val json = """[{"prim": "CDR"}, {"prim": "DUP"}]"""
 
     parse[MichelsonInstruction](json) should equal(Right(
-      MichelsonInstructionSequence(List(MichelsonSimpleInstruction("CDR"), MichelsonSimpleInstruction("DUP")))))
+      MichelsonInstructionSequence(List(MichelsonSingleInstruction("CDR"), MichelsonSingleInstruction("DUP")))))
   }
 
   it should "parse typed MichelsonInstruction" in {
     val json = """{"prim": "NIL", "args": [{"prim": "operation"}]}"""
 
     parse[MichelsonInstruction](json) should equal(Right(
-      MichelsonSimpleInstruction("NIL", List(MichelsonType("operation")))))
+      MichelsonSingleInstruction("NIL", List(MichelsonType("operation")))))
   }
 
   it should "parse complex MichelsonInstruction" in {
@@ -90,8 +90,8 @@ class JsonParserSpec extends FlatSpec with Matchers {
 
     parse[MichelsonInstruction](json) should equal(Right(
       MichelsonInstructionSequence(List(
-        MichelsonSimpleInstruction("DIP", List(MichelsonInstructionSequence(List(
-          MichelsonSimpleInstruction("DUP")))))))))
+        MichelsonSingleInstruction("DIP", List(MichelsonInstructionSequence(List(
+          MichelsonSingleInstruction("DUP")))))))))
   }
 
   it should "parse MichelsonInstruction typed with int data" in {
@@ -110,7 +110,7 @@ class JsonParserSpec extends FlatSpec with Matchers {
 
     parse[MichelsonInstruction](json) should equal(Right(
       MichelsonInstructionSequence(List(
-        MichelsonSimpleInstruction("PUSH", List(
+        MichelsonSingleInstruction("PUSH", List(
           MichelsonType("mutez"),
           MichelsonIntConstant(0)))))))
   }
@@ -131,7 +131,7 @@ class JsonParserSpec extends FlatSpec with Matchers {
 
     parse[MichelsonInstruction](json) should equal(Right(
         MichelsonInstructionSequence(List(
-            MichelsonSimpleInstruction("PUSH", List(
+            MichelsonSingleInstruction("PUSH", List(
                 MichelsonType("mutez"),
                 MichelsonStringConstant("0")))))))
   }
@@ -158,10 +158,10 @@ class JsonParserSpec extends FlatSpec with Matchers {
 
     parse[MichelsonInstruction](json) should equal(Right(
       MichelsonInstructionSequence(List(
-        MichelsonSimpleInstruction("IF_NONE", List(MichelsonInstructionSequence(List(
+        MichelsonSingleInstruction("IF_NONE", List(MichelsonInstructionSequence(List(
           MichelsonInstructionSequence(List(
-            MichelsonSimpleInstruction("UNIT"),
-            MichelsonSimpleInstruction("FAILWITH")))))))))))
+            MichelsonSingleInstruction("UNIT"),
+            MichelsonSingleInstruction("FAILWITH")))))))))))
   }
 
   it should "parse empty MichelsonInstruction" in {
@@ -188,11 +188,11 @@ class JsonParserSpec extends FlatSpec with Matchers {
 
     parse[MichelsonInstruction](json) should equal(Right(
       MichelsonInstructionSequence(List(
-        MichelsonSimpleInstruction("IF_NONE", List(
+        MichelsonSingleInstruction("IF_NONE", List(
           MichelsonEmptyInstruction, MichelsonInstructionSequence(List(
             MichelsonInstructionSequence(List(
-              MichelsonSimpleInstruction("UNIT"),
-              MichelsonSimpleInstruction("FAILWITH"))))),
+              MichelsonSingleInstruction("UNIT"),
+              MichelsonSingleInstruction("FAILWITH"))))),
           MichelsonEmptyInstruction))))))
   }
 
@@ -209,7 +209,7 @@ class JsonParserSpec extends FlatSpec with Matchers {
 
     parse[MichelsonInstruction](json) should equal(Right(
       MichelsonInstructionSequence(List(
-        MichelsonSimpleInstruction("IF_NONE", List(
+        MichelsonSingleInstruction("IF_NONE", List(
           MichelsonEmptyInstruction))))))
   }
 
@@ -256,11 +256,11 @@ class JsonParserSpec extends FlatSpec with Matchers {
         |}""".stripMargin
 
     parse[MichelsonInstruction](json) should equal(Right(
-      MichelsonSimpleInstruction("LAMBDA", List(
+      MichelsonSingleInstruction("LAMBDA", List(
         MichelsonType("address"),
         MichelsonType("contract", List(
           MichelsonType("unit"))), MichelsonInstructionSequence(List(
-        MichelsonSimpleInstruction("DUP")))))))
+        MichelsonSingleInstruction("DUP")))))))
   }
 
   it should "convert simplest json to MichelsonSchema" in {
@@ -298,14 +298,14 @@ class JsonParserSpec extends FlatSpec with Matchers {
     parse[MichelsonSchema](json) should equal(Right(MichelsonSchema(
         MichelsonType("int"),
         MichelsonType("int"),
-        MichelsonCode(List(MichelsonSimpleInstruction("DUP"))))))
+        MichelsonCode(List(MichelsonSingleInstruction("DUP"))))))
   }
 
   it should "parse MichelsonCode" in {
     val json = """[{"prim": "DUP"}]"""
 
     parse[MichelsonCode](json) should equal(Right(MichelsonCode(
-        List(MichelsonSimpleInstruction("DUP")))))
+        List(MichelsonSingleInstruction("DUP")))))
   }
 
   it should "give meaningful error in case of json without parameter section" in {
@@ -496,17 +496,17 @@ class JsonParserSpec extends FlatSpec with Matchers {
                     MichelsonType("mutez"))))),
                 MichelsonType("address"))))))))))),
       MichelsonCode(List(
-        MichelsonSimpleInstruction("CDR"),
-        MichelsonSimpleInstruction("DUP"),
-        MichelsonSimpleInstruction("NIL", List(
+        MichelsonSingleInstruction("CDR"),
+        MichelsonSingleInstruction("DUP"),
+        MichelsonSingleInstruction("NIL", List(
           MichelsonType("operation"))),
         MichelsonInstructionSequence(List(
-          MichelsonSimpleInstruction("DIP", List(MichelsonInstructionSequence(List(
-            MichelsonSimpleInstruction("DIP", List(MichelsonInstructionSequence(List(
-              MichelsonSimpleInstruction("DUP"))))),
-            MichelsonSimpleInstruction("SWAP"))))),
-          MichelsonSimpleInstruction("SWAP"),
-          MichelsonSimpleInstruction("NIL", List(
+          MichelsonSingleInstruction("DIP", List(MichelsonInstructionSequence(List(
+            MichelsonSingleInstruction("DIP", List(MichelsonInstructionSequence(List(
+              MichelsonSingleInstruction("DUP"))))),
+            MichelsonSingleInstruction("SWAP"))))),
+          MichelsonSingleInstruction("SWAP"),
+          MichelsonSingleInstruction("NIL", List(
             MichelsonType("operation"))))))))))
   }
 }

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParserSpec.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParserSpec.scala
@@ -90,7 +90,7 @@ class JsonParserSpec extends FlatSpec with Matchers {
 
     parse[MichelsonInstruction](json) should equal(Right(
       MichelsonInstructionSequence(List(
-        MichelsonComplexInstruction("DIP", List(MichelsonInstructionSequence(List(
+        MichelsonSimpleInstruction("DIP", List(MichelsonInstructionSequence(List(
           MichelsonSimpleInstruction("DUP")))))))))
   }
 
@@ -158,7 +158,7 @@ class JsonParserSpec extends FlatSpec with Matchers {
 
     parse[MichelsonInstruction](json) should equal(Right(
       MichelsonInstructionSequence(List(
-        MichelsonComplexInstruction("IF_NONE", List(MichelsonInstructionSequence(List(
+        MichelsonSimpleInstruction("IF_NONE", List(MichelsonInstructionSequence(List(
           MichelsonInstructionSequence(List(
             MichelsonSimpleInstruction("UNIT"),
             MichelsonSimpleInstruction("FAILWITH")))))))))))
@@ -188,11 +188,28 @@ class JsonParserSpec extends FlatSpec with Matchers {
 
     parse[MichelsonInstruction](json) should equal(Right(
       MichelsonInstructionSequence(List(
-        MichelsonComplexInstruction("IF_NONE", List(
+        MichelsonSimpleInstruction("IF_NONE", List(
           MichelsonEmptyInstruction, MichelsonInstructionSequence(List(
             MichelsonInstructionSequence(List(
               MichelsonSimpleInstruction("UNIT"),
               MichelsonSimpleInstruction("FAILWITH"))))),
+          MichelsonEmptyInstruction))))))
+  }
+
+  it should "parse empty MichelsonInstruction when it appears alone" in {
+    val json =
+      """[
+        |  {
+        |    "prim": "IF_NONE",
+        |    "args": [
+        |      []
+        |    ]
+        |  }
+        |]""".stripMargin
+
+    parse[MichelsonInstruction](json) should equal(Right(
+      MichelsonInstructionSequence(List(
+        MichelsonSimpleInstruction("IF_NONE", List(
           MichelsonEmptyInstruction))))))
   }
 
@@ -214,21 +231,36 @@ class JsonParserSpec extends FlatSpec with Matchers {
         MichelsonEmptyExpression))))
   }
 
-  it should "parse empty MichelsonInstruction when it appears alone" in {
+  it should "parse LAMBDA MichelsonInstruction" in {
     val json =
-      """[
-        |  {
-        |    "prim": "IF_NONE",
-        |    "args": [
-        |      []
+      """{
+        |  "prim": "LAMBDA",
+        |  "args": [
+        |    {
+        |      "prim": "address"
+        |    },
+        |    {
+        |      "prim": "contract",
+        |      "args": [
+        |        {
+        |          "prim": "unit"
+        |        }
+        |      ]
+        |    },
+        |    [
+        |      {
+        |        "prim": "DUP"
+        |      }
         |    ]
-        |  }
-        |]""".stripMargin
+        |  ]
+        |}""".stripMargin
 
     parse[MichelsonInstruction](json) should equal(Right(
-      MichelsonInstructionSequence(List(
-        MichelsonComplexInstruction("IF_NONE", List(
-          MichelsonEmptyInstruction))))))
+      MichelsonSimpleInstruction("LAMBDA", List(
+        MichelsonType("address"),
+        MichelsonType("contract", List(
+          MichelsonType("unit"))), MichelsonInstructionSequence(List(
+        MichelsonSimpleInstruction("DUP")))))))
   }
 
   it should "convert simplest json to MichelsonSchema" in {
@@ -292,155 +324,155 @@ class JsonParserSpec extends FlatSpec with Matchers {
 
     val json =
       """[
+        |  {
+        |    "prim": "parameter",
+        |    "args": [
         |      {
-        |          "prim": "parameter",
-        |          "args": [
-        |              {
-        |                  "prim": "unit"
-        |              }
-        |          ]
-        |      },
+        |        "prim": "unit"
+        |      }
+        |    ]
+        |  },
+        |  {
+        |    "prim": "storage",
+        |    "args": [
         |      {
-        |          "prim": "storage",
-        |          "args": [
+        |        "prim": "contract",
+        |        "args": [
+        |          {
+        |            "prim": "or",
+        |            "args": [
         |              {
-        |                  "prim": "contract",
-        |                  "args": [
+        |                "prim": "option",
+        |                "args": [
+        |                  {
+        |                    "prim": "address"
+        |                  }
+        |                ]
+        |              },
+        |              {
+        |                "prim": "or",
+        |                "args": [
+        |                  {
+        |                    "prim": "pair",
+        |                    "args": [
         |                      {
-        |                          "prim": "or",
-        |                          "args": [
+        |                        "prim": "option",
+        |                        "args": [
+        |                          {
+        |                            "prim": "address"
+        |                          }
+        |                        ]
+        |                      },
+        |                      {
+        |                        "prim": "option",
+        |                        "args": [
+        |                          {
+        |                            "prim": "mutez"
+        |                          }
+        |                        ]
+        |                      }
+        |                    ]
+        |                  },
+        |                  {
+        |                    "prim": "or",
+        |                    "args": [
+        |                      {
+        |                        "prim": "mutez"
+        |                      },
+        |                      {
+        |                        "prim": "or",
+        |                        "args": [
+        |                          {
+        |                            "prim": "pair",
+        |                            "args": [
         |                              {
-        |                                  "prim": "option",
-        |                                  "args": [
-        |                                      {
-        |                                          "prim": "address"
-        |                                      }
-        |                                  ]
+        |                                "prim": "option",
+        |                                "args": [
+        |                                  {
+        |                                    "prim": "address"
+        |                                  }
+        |                                ]
         |                              },
         |                              {
-        |                                  "prim": "or",
-        |                                  "args": [
-        |                                      {
-        |                                          "prim": "pair",
-        |                                          "args": [
-        |                                              {
-        |                                                  "prim": "option",
-        |                                                  "args": [
-        |                                                      {
-        |                                                          "prim": "address"
-        |                                                      }
-        |                                                  ]
-        |                                              },
-        |                                              {
-        |                                                  "prim": "option",
-        |                                                  "args": [
-        |                                                      {
-        |                                                          "prim": "mutez"
-        |                                                      }
-        |                                                  ]
-        |                                              }
-        |                                          ]
-        |                                      },
-        |                                      {
-        |                                          "prim": "or",
-        |                                          "args": [
-        |                                              {
-        |                                                  "prim": "mutez"
-        |                                              },
-        |                                              {
-        |                                                  "prim": "or",
-        |                                                  "args": [
-        |                                                      {
-        |                                                          "prim": "pair",
-        |                                                          "args": [
-        |                                                              {
-        |                                                                  "prim": "option",
-        |                                                                  "args": [
-        |                                                                      {
-        |                                                                          "prim": "address"
-        |                                                                      }
-        |                                                                  ]
-        |                                                              },
-        |                                                              {
-        |                                                                  "prim": "option",
-        |                                                                  "args": [
-        |                                                                      {
-        |                                                                          "prim": "mutez"
-        |                                                                      }
-        |                                                                  ]
-        |                                                              }
-        |                                                          ]
-        |                                                      },
-        |                                                      {
-        |                                                          "prim": "address"
-        |                                                      }
-        |                                                  ]
-        |                                              }
-        |                                          ]
-        |                                      }
-        |                                  ]
-        |                              }
-        |                          ]
-        |                      }
-        |                  ]
-        |              }
-        |          ]
-        |      },
-        |      {
-        |          "prim": "code",
-        |          "args": [
-        |              [
-        |                  {
-        |                      "prim": "CDR"
-        |                  },
-        |                  {
-        |                      "prim": "DUP"
-        |                  },
-        |                  {
-        |                      "prim": "NIL",
-        |                      "args": [
-        |                          {
-        |                              "prim": "operation"
-        |                          }
-        |                      ]
-        |                  },
-        |                  [
-        |                      {
-        |                          "prim": "DIP",
-        |                          "args": [
-        |                              [
+        |                                "prim": "option",
+        |                                "args": [
         |                                  {
-        |                                      "prim": "DIP",
-        |                                      "args": [
-        |                                          [
-        |                                              {
-        |                                                  "prim": "DUP"
-        |                                              }
-        |                                          ]
-        |                                      ]
-        |                                  },
-        |                                  {
-        |                                      "prim": "SWAP"
+        |                                    "prim": "mutez"
         |                                  }
-        |                              ]
-        |                          ]
-        |                      },
-        |                      {
-        |                          "prim": "SWAP"
-        |                      },
-        |                      {
-        |                          "prim": "NIL",
-        |                          "args": [
-        |                              {
-        |                                  "prim": "operation"
+        |                                ]
         |                              }
-        |                          ]
+        |                            ]
+        |                          },
+        |                          {
+        |                            "prim": "address"
+        |                          }
+        |                        ]
         |                      }
-        |                  ]
-        |              ]
-        |          ]
+        |                    ]
+        |                  }
+        |                ]
+        |              }
+        |            ]
+        |          }
+        |        ]
         |      }
-        |  ]""".stripMargin
+        |    ]
+        |  },
+        |  {
+        |    "prim": "code",
+        |    "args": [
+        |      [
+        |        {
+        |          "prim": "CDR"
+        |        },
+        |        {
+        |          "prim": "DUP"
+        |        },
+        |        {
+        |          "prim": "NIL",
+        |          "args": [
+        |            {
+        |              "prim": "operation"
+        |            }
+        |          ]
+        |        },
+        |        [
+        |          {
+        |            "prim": "DIP",
+        |            "args": [
+        |              [
+        |                {
+        |                  "prim": "DIP",
+        |                  "args": [
+        |                    [
+        |                      {
+        |                        "prim": "DUP"
+        |                      }
+        |                    ]
+        |                  ]
+        |                },
+        |                {
+        |                  "prim": "SWAP"
+        |                }
+        |              ]
+        |            ]
+        |          },
+        |          {
+        |            "prim": "SWAP"
+        |          },
+        |          {
+        |            "prim": "NIL",
+        |            "args": [
+        |              {
+        |                "prim": "operation"
+        |              }
+        |            ]
+        |          }
+        |        ]
+        |      ]
+        |    ]
+        |  }
+        |]""".stripMargin
 
     parse[MichelsonSchema](json) should equal(Right(MichelsonSchema(
       MichelsonType("unit"),
@@ -469,8 +501,8 @@ class JsonParserSpec extends FlatSpec with Matchers {
         MichelsonSimpleInstruction("NIL", List(
           MichelsonType("operation"))),
         MichelsonInstructionSequence(List(
-          MichelsonComplexInstruction("DIP", List(MichelsonInstructionSequence(List(
-            MichelsonComplexInstruction("DIP", List(MichelsonInstructionSequence(List(
+          MichelsonSimpleInstruction("DIP", List(MichelsonInstructionSequence(List(
+            MichelsonSimpleInstruction("DIP", List(MichelsonInstructionSequence(List(
               MichelsonSimpleInstruction("DUP"))))),
             MichelsonSimpleInstruction("SWAP"))))),
           MichelsonSimpleInstruction("SWAP"),

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/renderer/MichelsonRendererSpec.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/renderer/MichelsonRendererSpec.scala
@@ -36,26 +36,26 @@ class MichelsonRendererSpec extends FlatSpec with Matchers {
   }
 
   it should "render MichelsonCode with only one simple instruction" in {
-    val michelsonCode = MichelsonCode(List(MichelsonSimpleInstruction("CDR")))
+    val michelsonCode = MichelsonCode(List(MichelsonSingleInstruction("CDR")))
 
     michelsonCode.render() shouldBe "CDR"
   }
 
   it should "render MichelsonCode with two simple instructions" in {
-    val michelsonCode = MichelsonCode(List(MichelsonSimpleInstruction("CDR"), MichelsonSimpleInstruction("DUP")))
+    val michelsonCode = MichelsonCode(List(MichelsonSingleInstruction("CDR"), MichelsonSingleInstruction("DUP")))
 
     michelsonCode.render() shouldBe """CDR ;
                                       |       DUP""".stripMargin
   }
 
   it should "render MichelsonCode with typed instruction" in {
-    val michelsonCode = MichelsonCode(List(MichelsonSimpleInstruction("NIL", List(MichelsonType("operation")))))
+    val michelsonCode = MichelsonCode(List(MichelsonSingleInstruction("NIL", List(MichelsonType("operation")))))
 
     michelsonCode.render() shouldBe "NIL operation"
   }
 
   it should "render MichelsonCode with typed instruction with constant" in {
-    val michelsonCode = MichelsonCode(List(MichelsonSimpleInstruction("PUSH", List(MichelsonType("mutez"), MichelsonIntConstant(0)))))
+    val michelsonCode = MichelsonCode(List(MichelsonSingleInstruction("PUSH", List(MichelsonType("mutez"), MichelsonIntConstant(0)))))
 
     michelsonCode.render() shouldBe "PUSH mutez 0"
   }
@@ -63,8 +63,8 @@ class MichelsonRendererSpec extends FlatSpec with Matchers {
   it should "render MichelsonCode with instruction sequence" in {
     val michelsonCode = MichelsonCode(List(
       MichelsonInstructionSequence(List(
-        MichelsonSimpleInstruction("DIP"),
-        MichelsonSimpleInstruction("SWAP")))))
+        MichelsonSingleInstruction("DIP"),
+        MichelsonSingleInstruction("SWAP")))))
 
     michelsonCode.render() shouldBe "{ DIP ; SWAP }"
   }
@@ -72,19 +72,19 @@ class MichelsonRendererSpec extends FlatSpec with Matchers {
   it should "render MichelsonCode with complex instruction" in {
     val michelsonCode = MichelsonCode(List(
       MichelsonInstructionSequence(List(
-        MichelsonSimpleInstruction("DIP", List(MichelsonInstructionSequence(List(
-          MichelsonSimpleInstruction("DUP")))))))))
+        MichelsonSingleInstruction("DIP", List(MichelsonInstructionSequence(List(
+          MichelsonSingleInstruction("DUP")))))))))
 
     michelsonCode.render() shouldBe "{ DIP { DUP } }"
   }
 
   it should "render MichelsonInstruction with empty embedded instruction" in {
     val michelsonInstruction = MichelsonInstructionSequence(List(
-      MichelsonSimpleInstruction("IF_NONE", List(
+      MichelsonSingleInstruction("IF_NONE", List(
         MichelsonInstructionSequence(List(
           MichelsonInstructionSequence(List(
-            MichelsonSimpleInstruction("UNIT"),
-            MichelsonSimpleInstruction("FAILWITH"))))),
+            MichelsonSingleInstruction("UNIT"),
+            MichelsonSingleInstruction("FAILWITH"))))),
         MichelsonEmptyInstruction))))
 
     michelsonInstruction.render() shouldBe "{ IF_NONE { { UNIT ; FAILWITH } } {} }"
@@ -92,26 +92,26 @@ class MichelsonRendererSpec extends FlatSpec with Matchers {
 
   it should "render complex MichelsonCode" in {
     val michelsonExpression = MichelsonCode(List(
-      MichelsonSimpleInstruction("CDR"),
-      MichelsonSimpleInstruction("DUP"),
-      MichelsonSimpleInstruction("NIL", List(
+      MichelsonSingleInstruction("CDR"),
+      MichelsonSingleInstruction("DUP"),
+      MichelsonSingleInstruction("NIL", List(
         MichelsonType("operation"))),
       MichelsonInstructionSequence(List(
-        MichelsonSimpleInstruction("DIP", List(
+        MichelsonSingleInstruction("DIP", List(
           MichelsonInstructionSequence(List(
-            MichelsonSimpleInstruction("DIP", List(
+            MichelsonSingleInstruction("DIP", List(
               MichelsonInstructionSequence(List(
-                MichelsonSimpleInstruction("DUP"))))),
-            MichelsonSimpleInstruction("SWAP"))))),
-        MichelsonSimpleInstruction("SWAP"))),
+                MichelsonSingleInstruction("DUP"))))),
+            MichelsonSingleInstruction("SWAP"))))),
+        MichelsonSingleInstruction("SWAP"))),
       MichelsonInstructionSequence(List(
-        MichelsonSimpleInstruction("DIP", List(
+        MichelsonSingleInstruction("DIP", List(
           MichelsonInstructionSequence(List(
-            MichelsonSimpleInstruction("DIP", List(MichelsonInstructionSequence(List(
-              MichelsonSimpleInstruction("DUP"))))),
-            MichelsonSimpleInstruction("NIL", List(
+            MichelsonSingleInstruction("DIP", List(MichelsonInstructionSequence(List(
+              MichelsonSingleInstruction("DUP"))))),
+            MichelsonSingleInstruction("NIL", List(
               MichelsonType("operation"))))))),
-        MichelsonSimpleInstruction("SWAP")))
+        MichelsonSingleInstruction("SWAP")))
     ))
 
     michelsonExpression.render() shouldBe

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/renderer/MichelsonRendererSpec.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/renderer/MichelsonRendererSpec.scala
@@ -72,7 +72,7 @@ class MichelsonRendererSpec extends FlatSpec with Matchers {
   it should "render MichelsonCode with complex instruction" in {
     val michelsonCode = MichelsonCode(List(
       MichelsonInstructionSequence(List(
-        MichelsonComplexInstruction("DIP", List(MichelsonInstructionSequence(List(
+        MichelsonSimpleInstruction("DIP", List(MichelsonInstructionSequence(List(
           MichelsonSimpleInstruction("DUP")))))))))
 
     michelsonCode.render() shouldBe "{ DIP { DUP } }"
@@ -80,7 +80,7 @@ class MichelsonRendererSpec extends FlatSpec with Matchers {
 
   it should "render MichelsonInstruction with empty embedded instruction" in {
     val michelsonInstruction = MichelsonInstructionSequence(List(
-      MichelsonComplexInstruction("IF_NONE", List(
+      MichelsonSimpleInstruction("IF_NONE", List(
         MichelsonInstructionSequence(List(
           MichelsonInstructionSequence(List(
             MichelsonSimpleInstruction("UNIT"),
@@ -97,17 +97,17 @@ class MichelsonRendererSpec extends FlatSpec with Matchers {
       MichelsonSimpleInstruction("NIL", List(
         MichelsonType("operation"))),
       MichelsonInstructionSequence(List(
-        MichelsonComplexInstruction("DIP", List(
+        MichelsonSimpleInstruction("DIP", List(
           MichelsonInstructionSequence(List(
-            MichelsonComplexInstruction("DIP", List(
+            MichelsonSimpleInstruction("DIP", List(
               MichelsonInstructionSequence(List(
                 MichelsonSimpleInstruction("DUP"))))),
             MichelsonSimpleInstruction("SWAP"))))),
         MichelsonSimpleInstruction("SWAP"))),
       MichelsonInstructionSequence(List(
-        MichelsonComplexInstruction("DIP", List(
+        MichelsonSimpleInstruction("DIP", List(
           MichelsonInstructionSequence(List(
-            MichelsonComplexInstruction("DIP", List(MichelsonInstructionSequence(List(
+            MichelsonSimpleInstruction("DIP", List(MichelsonInstructionSequence(List(
               MichelsonSimpleInstruction("DUP"))))),
             MichelsonSimpleInstruction("NIL", List(
               MichelsonType("operation"))))))),


### PR DESCRIPTION
This PR brings support for LAMBDA instruction (https://tezos.gitlab.io/master/whitedoc/michelson.html#xii-full-grammar). This is a very specific instruction because it's the only one which have both expressions and instructions as arguments. In odrer to add support for that feature I needed to join ``MichelsonSimpleInstruction`` and ``MichelsonComplexInstruction`` classses and change the way they are parsed.