### PR TITLE
#256 Michelson integration - empty schema and accounts

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -398,7 +398,7 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
 
   val UNPARSABLE_CODE_PLACEMENT = "Unparsable code: "
 
-  private def toMichelsonScript[T <: MichelsonElement:Parser](json: Any) = {
+  private def toMichelsonScript[T <: MichelsonElement:Parser](json: Any): String = {
     Some(json).collect {
       case t: String => convert[T](t)
       case t: Micheline => convert[T](t.expression)

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -320,7 +320,7 @@ object TezosTypes {
                     balance: scala.math.BigDecimal,
                     spendable: Boolean,
                     delegate: AccountDelegate,
-                    script: Option[Any],
+                    script: Option[String],
                     counter: Int
                     )
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/dto/MichelsonSchema.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/dto/MichelsonSchema.scala
@@ -2,3 +2,7 @@ package tech.cryptonomic.conseil.tezos.michelson.dto
 
 /* Class representing a whole Michelson schema */
 case class MichelsonSchema(parameter: MichelsonExpression, storage: MichelsonExpression, code: MichelsonCode) extends MichelsonElement
+
+object MichelsonSchema {
+  def empty = MichelsonSchema(MichelsonEmptyExpression, MichelsonEmptyExpression, MichelsonCode(List.empty))
+}

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParser.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParser.scala
@@ -182,7 +182,10 @@ object JsonParser {
 
   implicit val michelsonSchemaParser: Parser[MichelsonSchema] = {
     import GenericDerivation._
-    decode[List[JsonSection]](_).map(JsonSchema).flatMap(_.toMichelsonSchema)
+    decode[List[JsonSection]](_).flatMap {
+      case Nil => Right(MichelsonSchema.empty)
+      case jsonSections => JsonSchema(jsonSections).toMichelsonSchema
+    }
   }
 
   implicit val michelsonCodeParser: Parser[MichelsonCode] = {

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/renderer/MichelsonRenderer.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/renderer/MichelsonRenderer.scala
@@ -21,8 +21,11 @@ object MichelsonRenderer {
       case MichelsonStringConstant(constant) => "\"%s\"".format(constant)
       case MichelsonEmptyExpression => "{}"
 
+      // code
       case MichelsonCode(instructions) => instructions.map(_.render()).mkString(" ;\n       ")
 
+      // schema
+      case MichelsonSchema(MichelsonEmptyExpression, MichelsonEmptyExpression, MichelsonCode(Nil)) => ""
       case MichelsonSchema(parameter, storage, code) => s"""parameter ${parameter.render()};
                                                            |storage ${storage.render()};
                                                            |code { ${code.render()} }""".stripMargin

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParserSpec.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParserSpec.scala
@@ -320,6 +320,12 @@ class JsonParserSpec extends FlatSpec with Matchers {
     parse[MichelsonSchema](json) should equal(Left(ParserError("No code code found")))
   }
 
+  it should "parse empty schema" in {
+    val json = """[]"""
+
+    parse[MichelsonSchema](json) should equal(Right(MichelsonSchema.empty))
+  }
+
   it should "convert complex json to MichelsonSchema" in {
 
     val json =

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/renderer/MichelsonRendererSpec.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/renderer/MichelsonRendererSpec.scala
@@ -90,6 +90,10 @@ class MichelsonRendererSpec extends FlatSpec with Matchers {
     michelsonInstruction.render() shouldBe "{ IF_NONE { { UNIT ; FAILWITH } } {} }"
   }
 
+  it should "render empty MichelsonSchema" in {
+    MichelsonSchema.empty.render() shouldBe ""
+  }
+
   it should "render complex MichelsonCode" in {
     val michelsonExpression = MichelsonCode(List(
       MichelsonSingleInstruction("CDR"),


### PR DESCRIPTION
Fix for parsing empty schema (``[]``) and for parsing script for accounts (they were represented as Maps, not as JSON strings).