### PR TITLE
Conseil json decoding failure handling

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataFetcher.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataFetcher.scala
@@ -16,8 +16,9 @@ import cats.syntax.semigroupal._
   *
   * @tparam Eff the higher-order effect type (e.g. `Try`, `Future`, `IO`, `Either`)
   * @tparam Coll a traversable type (used to wrap mutliple requests and corresponding return values)
+  * @tparam Err the expected type of possible errors that the Eff-wrapped operations might raise
   */
-trait DataFetcher[Eff[_], Coll[_]] {
+trait DataFetcher[Eff[_], Coll[_], Err] {
   /** the input type, e.g. ids of data */
   type In
   /** the output type, e.g. the decoded block data */
@@ -37,8 +38,9 @@ trait DataFetcher[Eff[_], Coll[_]] {
     * 1. get encoded (e.g. json) values from the node, given a traversable input collection
     * 2. keep the correlation with the input and decode each value (e.g. from json) to a corresponding output
     * 3. return the traversable collection containing paired input and output values, all wrapped in the effect F
+    * The resulting effect will also encode a possible failure in virtue of the implicit MonadError instance that is provided
     */
-  def fetch(implicit app: Monad[Eff], tr: Traverse[Coll]): Kleisli[Eff, Coll[In], Coll[(In, Out)]] =
+  def fetch(implicit app: MonadError[Eff, Err], tr: Traverse[Coll]): Kleisli[Eff, Coll[In], Coll[(In, Out)]] =
     fetchData.andThen(encoded => decodeData.second[In].traverse(encoded))
 
 }
@@ -79,7 +81,7 @@ object DataFetcher {
    * Example: the fetcher for tezos blocks might have type `Aux[Future, List, Int, BlockData, String]
    * where the Int is for the offset from a given block, and String is a representation of a json value.
    */
-  private type Aux[Eff[_], Coll[_], Input, Output, Encoding] = DataFetcher[Eff, Coll] {
+  private type Aux[Eff[_], Coll[_], Err, Input, Output, Encoding] = DataFetcher[Eff, Coll, Err] {
       type In = Input
       type Out = Output
       type Encoded = Encoding
@@ -99,10 +101,10 @@ object DataFetcher {
     * - decodes the json string both as a list of operations and a list of accounts
     * - returns the decodings in a tuple, where each pair of outputs is also paired to the corresponding input hash, i.e. (I -> (O, O2))
     */
-  def addDecoding[Eff[_]: Apply, Coll[_], Input, Output, Output2, Encoding](
-    fetcher: Aux[Eff,Coll,Input,Output,Encoding],
+  def addDecoding[Eff[_]: Apply, Coll[_], Err, Input, Output, Output2, Encoding](
+    fetcher: Aux[Eff, Coll, Err, Input, Output, Encoding],
     additionalDecode: Kleisli[Eff, Encoding, Output2]
-  ) = new DataFetcher[Eff, Coll] {
+  ) = new DataFetcher[Eff, Coll, Err] {
     type In = Input
     type Out = (Output, Output2)
     type Encoded = Encoding
@@ -117,10 +119,12 @@ object DataFetcher {
     * For an example refer to `mergeResults` taking three arguments, and
     * consider the equivalent case for two.
     */
-  def mergeResults[Eff[_]: Monad, Coll[_] : Traverse: FunctorFilter, Input, Output1, Output2, Output, Encoding1, Encoding2](
-    mf1: Aux[Eff, Coll, Input, Output1, Encoding1],
-    mf2: Aux[Eff, Coll, Input, Output2, Encoding2]
-  )(merge: (Output1, Output2) => Output): Kleisli[Eff, Coll[Input], Coll[(Input, Output)]] =
+  def mergeResults[Eff[_]: Monad, Coll[_] : Traverse: FunctorFilter, Err, Input, Output1, Output2, Output, Encoding1, Encoding2](
+    mf1: Aux[Eff, Coll, Err, Input, Output1, Encoding1],
+    mf2: Aux[Eff, Coll, Err, Input, Output2, Encoding2]
+  )(merge: (Output1, Output2) => Output)(
+    implicit appErr: MonadError[Eff, Err]
+  ): Kleisli[Eff, Coll[Input], Coll[(Input, Output)]] =
     combineResults(mf1, mf2) {
       (outs1, outs2) =>
         outs1.mapFilter {
@@ -154,11 +158,13 @@ object DataFetcher {
     *
     * and if we run the "fetch" Kleisli on the merged fetchers, passing a `List[BlockHash]` we get a `Future[List[(BlockHash, CurrentVotes)]]
     */
-  def mergeResults[Eff[_]: Monad, Coll[_] : Traverse: FunctorFilter, Input, Output1, Output2, Output3, Output, Encoding1, Encoding2, Encoding3](
-    mf1: Aux[Eff, Coll, Input, Output1, Encoding1],
-    mf2: Aux[Eff, Coll, Input, Output2, Encoding2],
-    mf3: Aux[Eff, Coll, Input, Output3, Encoding3]
-  )(merge: (Output1, Output2, Output3) => Output = (_: Output1, _: Output2, _: Output3)): Kleisli[Eff, Coll[Input], Coll[(Input, Output)]] =
+  def mergeResults[Eff[_]: Monad, Coll[_] : Traverse: FunctorFilter, Err, Input, Output1, Output2, Output3, Output, Encoding1, Encoding2, Encoding3](
+    mf1: Aux[Eff, Coll, Err, Input, Output1, Encoding1],
+    mf2: Aux[Eff, Coll, Err, Input, Output2, Encoding2],
+    mf3: Aux[Eff, Coll, Err, Input, Output3, Encoding3]
+  )(merge: (Output1, Output2, Output3) => Output = (_: Output1, _: Output2, _: Output3))(
+    implicit appErr: MonadError[Eff, Err]
+  ): Kleisli[Eff, Coll[Input], Coll[(Input, Output)]] =
     combineResults(mf1, mf2, mf3) {
       (outs1, outs2, outs3) =>
         /* here we only traverse a single output collection, assuming that the others will share the same "keys" (i.e. first element in the tuple)
@@ -180,10 +186,12 @@ object DataFetcher {
     *
     * For an example refer to `combineResults` with three arguments, and consider the equivalent for two.
     */
-  def combineResults[Eff[_]: Monad, Coll[_] : Traverse, Input, Encoding1, Encoding2, Output1, Output2, Output](
-    mf1: Aux[Eff, Coll, Input, Output1, Encoding1],
-    mf2: Aux[Eff, Coll, Input, Output2, Encoding2]
-  )(combine: (Coll[(Input, Output1)], Coll[(Input, Output2)]) => Coll[(Input, Output)]): Kleisli[Eff, Coll[Input], Coll[(Input, Output)]] =
+  def combineResults[Eff[_]: Monad, Coll[_] : Traverse, Err, Input, Encoding1, Encoding2, Output1, Output2, Output](
+    mf1: Aux[Eff, Coll, Err, Input, Output1, Encoding1],
+    mf2: Aux[Eff, Coll, Err, Input, Output2, Encoding2]
+  )(combine: (Coll[(Input, Output1)], Coll[(Input, Output2)]) => Coll[(Input, Output)])(
+    implicit appErr: MonadError[Eff, Err]
+  ): Kleisli[Eff, Coll[Input], Coll[(Input, Output)]] =
     (mf1.fetch).product(mf2.fetch).map(combine.tupled)
 
   /** Combines three DataFetchers acting on the same inputs to get am arbitrary combination of the outputs,
@@ -196,11 +204,13 @@ object DataFetcher {
     * The difference with merge is that we combine three whole traversables (e.g. Lists), containing the "hash to value" pairs, instead
     * of merging each element with matching input `I` into a single traversable of outputs
     */
-  def combineResults[Eff[_]: Monad , Coll[_] : Traverse: FunctorFilter, Input, Encoding1, Encoding2, Encoding3, Output1, Output2, Output3, Output](
-    mf1: Aux[Eff, Coll, Input, Output1, Encoding1],
-    mf2: Aux[Eff, Coll, Input, Output2, Encoding2],
-    mf3: Aux[Eff, Coll, Input, Output3, Encoding3]
-  )(combine: (Coll[(Input, Output1)], Coll[(Input, Output2)], Coll[(Input, Output3)]) => Coll[(Input, Output)]): Kleisli[Eff, Coll[Input], Coll[(Input, Output)]] =
+  def combineResults[Eff[_]: Monad , Coll[_] : Traverse: FunctorFilter, Err, Input, Encoding1, Encoding2, Encoding3, Output1, Output2, Output3, Output](
+    mf1: Aux[Eff, Coll, Err, Input, Output1, Encoding1],
+    mf2: Aux[Eff, Coll, Err, Input, Output2, Encoding2],
+    mf3: Aux[Eff, Coll, Err, Input, Output3, Encoding3]
+  )(combine: (Coll[(Input, Output1)], Coll[(Input, Output2)], Coll[(Input, Output3)]) => Coll[(Input, Output)])(
+    implicit appErr: MonadError[Eff, Err]
+  ): Kleisli[Eff, Coll[Input], Coll[(Input, Output)]] =
     Apply[({type L[a] = Kleisli[Eff, Coll[Input], a]})#L].tuple3(mf1.fetch, mf2.fetch, mf3.fetch).map(combine.tupled)
 
   /** Allows to add an additional decoder to a "multi-fetch" instance, by providing an extension method `decodeAlso(additionalDecode)`,
@@ -209,12 +219,12 @@ object DataFetcher {
     */
   object Syntax {
 
-    implicit class DataFetchOps[Eff[_], Coll[_], Input, Output, Encoding](m: Aux[Eff, Coll, Input, Output, Encoding]) {
+    implicit class DataFetchOps[Eff[_], Coll[_], Err, Input, Output, Encoding](m: Aux[Eff, Coll, Err, Input, Output, Encoding]) {
       def decodeAlso[Output2](
         additionalDecode: Kleisli[Eff, Encoding, Output2]
       )(
         implicit app: Apply[Eff]
-      ): Aux[Eff, Coll, Input, (Output, Output2), Encoding] =
+      ): Aux[Eff, Coll, Err, Input, (Output, Output2), Encoding] =
         addDecoding(m, additionalDecode)
     }
   }

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataFetcher.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataFetcher.scala
@@ -78,7 +78,7 @@ object DataFetcher {
   /* An alias used to define function constraints on the internal dependent types (i.e. `I`, `O`, `E`)
    * which would be otherwise opaque in any function signature
    *
-   * Example: the fetcher for tezos blocks might have type `Aux[Future, List, Int, BlockData, String]
+   * Example: the fetcher for tezos blocks might have type `Aux[Future, List, Throwable, Int, BlockData, String]
    * where the Int is for the offset from a given block, and String is a representation of a json value.
    */
   private type Aux[Eff[_], Coll[_], Err, Input, Output, Encoding] = DataFetcher[Eff, Coll, Err] {

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/JsonDecoders.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/JsonDecoders.scala
@@ -14,7 +14,6 @@ object JsonDecoders {
     import cats.ApplicativeError
     import cats.syntax.functor._
     import io.circe.Decoder
-    import io.circe.{ Error, Errors }
     import io.circe.generic.extras._
     import io.circe.generic.extras.semiauto._
     import io.circe.generic.extras.Configuration
@@ -32,28 +31,6 @@ object JsonDecoders {
       import cats.syntax.bifunctor._
 
       decode[A](json).leftWiden[Throwable].raiseOrPure[Eff]
-    }
-
-    /** Collects failures in json parsing, when circe is used to decode the objects out of strings
-      *
-      * @param jsonResults a list of generic input data that internally has some json string
-      * @param decoding the operation that converts a single generic Encoded value to a possibly failed Decoded type
-      * @tparam Encoded a json string, possibly with additional data, e.g. the original request correlation-id for our tezos-rpc
-      * @tparam Decoded the type of the final result of correctly decoding the input json
-      * @return an `Either` with all `io.circe.Errors` aggregated on the `Left` if there's any, or a `Right` with all the decoded results
-      */
-    def handleDecodingErrors[Encoded, Decoded](jsonResults: List[Encoded], decoding: Encoded => Either[Error, Decoded]): Either[Errors, List[Decoded]] = {
-      import cats.data._
-      import cats.syntax.either._
-
-      val results = jsonResults.map(decoding)
-
-      lazy val correctlyDecoded: List[Decoded] = results.collect { case Right(dec) => dec }
-      val decodingErrors: Option[io.circe.Errors] =
-        NonEmptyList.fromList(results.collect { case Left(decodingError) => decodingError })
-          .map(io.circe.Errors)
-
-      decodingErrors.fold(ifEmpty = correctlyDecoded.asRight[io.circe.Errors])(_.asLeft[List[Decoded]])
     }
 
     /* local definition of a base-58-check string wrapper, to allow parsing validation */

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeFetchers.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeFetchers.scala
@@ -108,7 +108,7 @@ trait BlocksDataFetchers {
         decodeLiftingTo[Future, Out](json)
           .onError {
             case err: io.circe.Error =>
-              logger.error(s"I fetched a voting period json from tezos node that I'm unable to decode: $json", err).pure[Future]
+              logger.error(s"I fetched a voting proposal period json from tezos node that I'm unable to decode: $json", err).pure[Future]
           }
     )
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -393,7 +393,7 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
       fetchedBlocksData.map {
         case (offset, md) =>
           val (ops, accs) = if (isGenesis(md)) (List.empty, List.empty) else operationalDataMap(md.hash)
-          val votes = proposalsMap.getOrElse(md.hash, CurrentVotes.defaultValue)
+          val votes = proposalsMap.getOrElse(md.hash, CurrentVotes.empty)
           (parseMichelsonScripts(Block(md, ops, votes)), accs)
       }
     }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -55,14 +55,13 @@ object TezosNodeOperator {
   * @param batchConf configuration for batched download of node data
   * @param executionContext thread context for async operations
   */
-class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchConf: BatchFetchConfiguration)(implicit executionContext: ExecutionContext)
+class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchConf: BatchFetchConfiguration)(implicit val fetchFutureContext: ExecutionContext)
   extends LazyLogging
   with BlocksDataFetchers {
   import TezosNodeOperator.isGenesis
   import batchConf.{accountConcurrencyLevel, blockOperationsConcurrencyLevel, blockPageSize}
 
   override val fetchConcurrency = blockOperationsConcurrencyLevel
-  override val fetchFutureContext = executionContext
 
   //use this alias to make signatures easier to read and kept in-sync
   type BlockFetchingResults = List[(Block, List[AccountId])]

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -342,7 +342,7 @@ object TezosTypes {
   )
 
   final object CurrentVotes {
-    val defaultValue = CurrentVotes(periodKind = ProposalPeriod.proposal, quorum = None, active = None)
+    val empty = CurrentVotes(periodKind = ProposalPeriod.proposal, quorum = None, active = None)
   }
 
   final case class Block(

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
@@ -85,7 +85,7 @@ trait TezosDataGeneration extends RandomGenerationKit {
           metadata = BlockHeaderMetadata(balance_updates = None)
         ),
         operationGroups = List.empty,
-        votes = CurrentVotes.defaultValue
+        votes = CurrentVotes.empty
       )
 
     //we need a block to start

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosTypesTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosTypesTest.scala
@@ -95,7 +95,7 @@ class TezosTypesTest extends WordSpec with Matchers {
   }
 
   private val blockData = BlockData("_", None, BlockHash("_"), BlockHeader(0, 0, BlockHash("_"), ZonedDateTime.now(), 0, None, Seq.empty, "_", None), BlockHeaderMetadata(None))
-  private val blockVotes = CurrentVotes.defaultValue
+  private val blockVotes = CurrentVotes.empty
   private val operationGroup = OperationsGroup("_", None, OperationHash("_"), BlockHash("_"), List.empty, None)
   private val number = PositiveDecimal(1)
   private val transaction = Transaction(number, number, number, number, number, ContractId("_"), ContractId("_"), None, ResultMetadata(null, List.empty))


### PR DESCRIPTION
I made a few changes to make usage of circe decoding into Future results more regular.

This includes usage in the DataFetchers and allows more regular handling of local errors (during decoding)
The change explicitly adds constraints to the `Eff` in fetchers, so that fetching might include error handling via type class functions.

This is not related to any specific issue, but it's targeted toward more complete logging of failures to trace application unexpected shutdowns