### PR TITLE
#256 Michelson integration - annotations support

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/dto/MichelsonExpression.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/dto/MichelsonExpression.scala
@@ -14,7 +14,7 @@ sealed trait MichelsonExpression extends MichelsonElement
  *   (contract (or (option address) int))
  *    |        |    |               |
  *    |        |    |               single type "int"
- *    |        |    type "option" with one argument "adress"
+ *    |        |    type "option" with one argument "address"
  *    |        type "or" with two arguments: "option address" and "int"
  *    type "contract" with one complex argument
  *
@@ -32,7 +32,7 @@ sealed trait MichelsonExpression extends MichelsonElement
  *
  *    MichelsonType("pair", List(MichelsonIntConstant(0), MichelsonEmptyExpression))
  * */
-case class MichelsonType(prim: String, args: List[MichelsonExpression] = List.empty) extends MichelsonExpression
+case class MichelsonType(prim: String, args: List[MichelsonExpression] = List.empty, annotations: List[String] = List.empty) extends MichelsonExpression
 
 /* Class representing an int constant */
 case class MichelsonIntConstant(int: Long) extends MichelsonExpression

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/dto/MichelsonInstruction.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/dto/MichelsonInstruction.scala
@@ -19,7 +19,9 @@ package tech.cryptonomic.conseil.tezos.michelson.dto
 sealed trait MichelsonInstruction extends MichelsonElement
 
 /* Class representing a simple Michelson instruction which can contains following expressions */
-case class MichelsonSingleInstruction(prim: String, embeddedElements: List[MichelsonElement] = List.empty) extends MichelsonInstruction
+case class MichelsonSingleInstruction(prim: String,
+                                      embeddedElements: List[MichelsonElement] = List.empty,
+                                      annotations: List[String] = List.empty) extends MichelsonInstruction
 
 /* Class representing a sequence of Michelson instructions */
 case class MichelsonInstructionSequence(instructions: List[MichelsonInstruction] = List.empty) extends MichelsonInstruction

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/renderer/MichelsonRenderer.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/renderer/MichelsonRenderer.scala
@@ -9,14 +9,14 @@ object MichelsonRenderer {
     def render(): String = self match {
 
       // instructions
-      case MichelsonSingleInstruction(prim, List()) => prim
-      case MichelsonSingleInstruction(prim, args) => s"$prim ${args.map(_.render()).mkString(" ")}"
+      case MichelsonSingleInstruction(prim, List(), List()) => prim
+      case MichelsonSingleInstruction(prim, args, annotations) => s"$prim ${(annotations ++ args.map(_.render())).mkString(" ")}"
       case MichelsonInstructionSequence(args) => s"{ ${args.map(_.render()).mkString(" ; ")} }"
       case MichelsonEmptyInstruction => "{}"
 
       // expressions
-      case MichelsonType(name, List()) => name
-      case MichelsonType(name, args) => s"($name ${args.map(_.render()).mkString(" ")})"
+      case MichelsonType(name, List(), List()) => name
+      case MichelsonType(name, args, annotations) => s"($name ${(annotations ++ args.map(_.render())).mkString(" ")})"
       case MichelsonIntConstant(constant) => constant.toString
       case MichelsonStringConstant(constant) => "\"%s\"".format(constant)
       case MichelsonEmptyExpression => "{}"

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParserSpec.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParserSpec.scala
@@ -64,6 +64,19 @@ class JsonParserSpec extends FlatSpec with Matchers {
           MichelsonType("int")))))))
   }
 
+  it should "parse MichelsonType with annotation" in {
+    val json =
+      """{
+        |  "prim": "int",
+        |  "annots": [
+        |    ":p"
+        |  ]
+        |}""".stripMargin
+
+    parse[MichelsonExpression](json) should equal(Right(
+      MichelsonType(prim = "int", annotations = List(":p"))))
+  }
+
   it should "parse MichelsonInstruction with only one simple instruction" in {
     val json = """{"prim": "DUP"}"""
 
@@ -83,6 +96,13 @@ class JsonParserSpec extends FlatSpec with Matchers {
 
     parse[MichelsonInstruction](json) should equal(Right(
       MichelsonSingleInstruction("NIL", List(MichelsonType("operation")))))
+  }
+
+  it should "parse MichelsonInstruction with annotation" in {
+    val json = """{"prim": "CAR", "annots": ["@pointcolor"]}"""
+
+    parse[MichelsonInstruction](json) should equal(Right(
+      MichelsonSingleInstruction(prim = "CAR", annotations = List("@pointcolor"))))
   }
 
   it should "parse complex MichelsonInstruction" in {

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/renderer/MichelsonRendererSpec.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/renderer/MichelsonRendererSpec.scala
@@ -26,6 +26,17 @@ class MichelsonRendererSpec extends FlatSpec with Matchers {
     MichelsonType("some", List(MichelsonStringConstant("testValue"))).render() shouldBe "(some \"testValue\")"
   }
 
+  it should "render MichelsonType with annotation" in {
+    val michelsonType = MichelsonType(
+      prim = "pair",
+      args = List(
+        MichelsonType("int", annotations = List("%x")),
+        MichelsonType("int", annotations = List("%y"))),
+      annotations = List(":point"))
+
+    michelsonType.render() shouldBe "(pair :point (int %x) (int %y))"
+  }
+
   it should "render complex MichelsonType" in {
     val michelsonType = MichelsonType("contract", List(MichelsonType("or", List(
       MichelsonType("option", List(
@@ -92,6 +103,12 @@ class MichelsonRendererSpec extends FlatSpec with Matchers {
 
   it should "render empty MichelsonSchema" in {
     MichelsonSchema.empty.render() shouldBe ""
+  }
+
+  it should "render MichelsonInstruction with an annotation" in {
+    val michelsonInstruction = MichelsonSingleInstruction(prim = "CAR", annotations = List("@pointcolor"))
+
+    michelsonInstruction.render() shouldBe "CAR @pointcolor"
   }
 
   it should "render complex MichelsonCode" in {


### PR DESCRIPTION
Brings annotations support to Michelson Parser.
Documentation for annotations: http://tezos.gitlab.io/mainnet/whitedoc/michelson.html#x-annotations