### PR TITLE
Fix for the decimal json encoding

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/routes/DataHelpers.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/DataHelpers.scala
@@ -63,6 +63,7 @@ trait DataHelpers extends QueryStringListsServer with Validation with akkahttp.s
     case x: java.lang.Boolean => Json.fromBoolean(x)
     case x: scala.collection.immutable.Vector[Tables.OperationGroupsRow] => x.map(_.asJson(operationGroupsRowSchema.encoder)).asJson
     case x: Tables.BlocksRow => x.asJson(blocksRowSchema.encoder)
+    case x: java.math.BigDecimal => Json.fromBigDecimal(x)
     case x => Json.fromString(x.toString)
   }
 


### PR DESCRIPTION
The issue with treating some numbers as strings was that decimal type from database was not handled correct way - decimal columns were encoded as strings. Added correct encoding.