### PR TITLE
Stripping backspaces from Tezos node JSON.

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/util/JsonUtil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/util/JsonUtil.scala
@@ -56,7 +56,7 @@ object JsonUtil {
     lazy val emptyObject = JsonString("{}")
 
     /** add standard cleaning for input json */
-    def sanitize(s: String): String = s.filterNot(_.isControl)
+    def sanitize(s: String): String = s.filterNot(_.isControl).replaceAll("\\\\", "backslash")
 
   }
 

--- a/src/test/scala/tech/cryptonomic/conseil/util/JsonUtilTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/util/JsonUtilTest.scala
@@ -69,6 +69,12 @@ class JsonUtilTest extends WordSpec with Matchers with JsonMatchers {
 
     }
 
+    "sanitize unwanted input, by removing any string-encoded ISO control chars from the json string" in {
+      val invalid: String = "demo\\u0000"
+      (JsonString sanitize invalid) shouldBe "demobackslashu0000"
+
+    }
+
     "convert a simple map to json" in {
       val result = JsonUtil.toJson(Map("key1" -> "value1", "key2" -> "value2")).json
       result should matchJson("""{"key1": "value1", "key2": "value2"}""")


### PR DESCRIPTION
This addresses #293. 

The previous solutions tried to strip out all control characters, assuming the source strings actually contained those characters. However, the Tezos node data actually contained string-encoded control characters:

![image](https://user-images.githubusercontent.com/931163/55050936-9b3f2a00-5029-11e9-9a3b-02f4c6b07da8.png)

Thus, stripping out the control characters did not actually remove the anomalous data. This blew up down the line as the database persistence logic somehow converted the `\u0000` into an actual null character, which Postgres did not like.

In this solution, the backspace symbol is replaced by the string `backspace` so no mischief is possible down the line. The replacement string is an actual word so in the future developers can easily trace cases where the database data does not match the data returned by the node, i.e. by grepping the source code for the word `backspace`. 