### PR TITLE
Conseil 291: handle errors on account processing

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
@@ -262,10 +262,10 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
           * Such future will be actually started only as the page iterator is scanned, one element at the time
           */
           pages.foldLeft(0) {
-          (processed, nextPage) =>
-            //wait for each page to load, before looking at the next, thus  starting the new computation
-            val justDone = Await.result(processAccountsPage(nextPage), atMost = 5.minutes)
-            processed + justDone <| logProgress
+            (processed, nextPage) =>
+              //wait for each page to load, before looking at the next, thus  starting the new computation
+              val justDone = Await.result(processAccountsPage(nextPage), atMost = 5.minutes)
+              processed + justDone <| logProgress
         }
 
         checkpoints

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
@@ -47,12 +47,12 @@ object DatabaseConversions {
         Tables.AccountsRow(
           accountId = id.id,
           blockId = hash.value,
-          manager = manager,
+          manager = manager.value,
           spendable = spendable,
           delegateSetable = delegate.setable,
-          delegateValue = delegate.value,
+          delegateValue = delegate.value.map(_.value),
           counter = counter,
-          script = script.map(_.toString),
+          script = script.map(_.code.toString),
           balance = balance,
           blockLevel = level
         )

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/JsonDecoders.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/JsonDecoders.scala
@@ -196,6 +196,16 @@ object JsonDecoders {
 
     }
 
+    /* Collects definitions to decode accounts and their components */
+    object Accounts {
+      private implicit val conf = tezosDerivationConfig
+
+      implicit val scriptDecoder: Decoder[AccountScript] =
+        Decoder.decodeJson.map(json => AccountScript(json.noSpaces))
+      implicit val delegateDecoder: Decoder[AccountDelegate] = deriveDecoder
+      implicit val accountDecoder: Decoder[Account] = deriveDecoder
+    }
+
   }
 
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeFetchers.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeFetchers.scala
@@ -3,7 +3,8 @@ package tech.cryptonomic.conseil.tezos
 import cats._
 import cats.data.Kleisli
 import com.typesafe.scalalogging.LazyLogging
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 import scala.util.control.NonFatal
 import tech.cryptonomic.conseil.generic.chain.DataFetcher
 import tech.cryptonomic.conseil.util.JsonUtil
@@ -15,7 +16,6 @@ import TezosTypes._
 trait BlocksDataFetchers {
   //we require the cabability to log
   self: LazyLogging =>
-  import scala.concurrent.Future
   import cats.instances.future._
   import cats.syntax.applicativeError._
   import cats.syntax.applicative._
@@ -288,6 +288,57 @@ trait BlocksDataFetchers {
             //we recover parsing failures with an empty result, as we have no optionality here to lean on
             case NonFatal(_) => List.empty
           }
+    }
+  }
+
+}
+
+/** Defines intances of `DataFetcher` for accounts-related data */
+trait AccountsDataFetchers {
+  //we require the cabability to log
+  self: LazyLogging =>
+  import cats.instances.future._
+  import cats.syntax.applicativeError._
+  import cats.syntax.applicative._
+  import tech.cryptonomic.conseil.util.JsonUtil.fromJson
+
+  implicit def fetchFutureContext: ExecutionContext
+
+  /** the tezos network to connect to */
+  def network: String
+  /** the tezos interface to query */
+  def node: TezosRPCInterface
+  /** parallelism in the multiple requests decoding on the RPC interface */
+  def accountsFetchConcurrency: Int
+
+  //common type alias to simplify signatures
+  private type FutureFetcher = DataFetcher[Future, List, Throwable]
+
+  def accountFetcher(referenceBlock: BlockHash) = new FutureFetcher {
+    type Encoded = String
+    type In = AccountId
+    type Out = Option[Account]
+
+    val makeUrl = (id: AccountId) => s"blocks/${referenceBlock.value}/context/contracts/${id.id}"
+
+    override val fetchData = Kleisli(
+      ids =>
+        node.runBatchedGetQuery(network, ids, makeUrl, accountsFetchConcurrency)
+          .onError {
+            case err =>
+              logger.error("I encountered problems while fetching account data from {}, for ids {}. The error says {}",
+                network,
+                ids.map(_.id).mkString(", "),
+                err.getMessage
+              ).pure[Future]
+          }
+      )
+
+    override def decodeData = Kleisli {
+      json =>
+        val parsed = Try(fromJson[Account](json))
+        parsed.failed.foreach(err => logger.error(s"I fetched account json from tezos node that I'm unable to decode: $json", err))
+        parsed.toOption.pure[Future]
     }
   }
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -126,7 +126,7 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
   def getAccountsForBlock(accountIds: List[AccountId], blockHash: BlockHash = blockHeadHash): Future[Map[AccountId, Account]] = {
     import cats.instances.future._
     import cats.instances.list._
-    import TezosOptics.Accounts.optionalScript
+    import TezosOptics.Accounts.optionalScriptCode
 
     /*tries decoding but simply returns the input unchanged on failure*/
     def parseScript(code: String): String = Try(toMichelsonScript[MichelsonCode](code)).getOrElse(code)
@@ -136,7 +136,7 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
       .map(
         indexedAccounts =>
           indexedAccounts.collect {
-            case (accountId, Some(account)) => accountId -> optionalScript.modify(parseScript)(account)
+            case (accountId, Some(account)) => accountId -> optionalScriptCode.modify(parseScript)(account)
           }.toMap
     )
   }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -57,11 +57,13 @@ object TezosNodeOperator {
   */
 class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchConf: BatchFetchConfiguration)(implicit val fetchFutureContext: ExecutionContext)
   extends LazyLogging
-  with BlocksDataFetchers {
+  with BlocksDataFetchers
+  with AccountsDataFetchers {
   import TezosNodeOperator.isGenesis
   import batchConf.{accountConcurrencyLevel, blockOperationsConcurrencyLevel, blockPageSize}
 
   override val fetchConcurrency = blockOperationsConcurrencyLevel
+  override val accountsFetchConcurrency = accountConcurrencyLevel
 
   //use this alias to make signatures easier to read and kept in-sync
   type BlockFetchingResults = List[(Block, List[AccountId])]
@@ -75,21 +77,21 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
   /**
     * Fetches a specific account for a given block.
     * @param blockHash  Hash of given block
-    * @param accountID  Account ID
+    * @param accountId  Account ID
     * @return           The account
     */
-  def getAccountForBlock(blockHash: BlockHash, accountID: AccountId): Future[Account] =
-    node.runAsyncGetQuery(network, s"blocks/${blockHash.value}/context/contracts/${accountID.id}")
+  def getAccountForBlock(blockHash: BlockHash, accountId: AccountId): Future[Account] =
+    node.runAsyncGetQuery(network, s"blocks/${blockHash.value}/context/contracts/${accountId.id}")
       .map(fromJson[Account])
 
   /**
     * Fetches the manager of a specific account for a given block.
     * @param blockHash  Hash of given block
-    * @param accountID  Account ID
+    * @param accountId  Account ID
     * @return           The account
     */
-  def getAccountManagerForBlock(blockHash: BlockHash, accountID: AccountId): Future[ManagerKey] =
-    node.runAsyncGetQuery(network, s"blocks/${blockHash.value}/context/contracts/${accountID.id}/manager_key")
+  def getAccountManagerForBlock(blockHash: BlockHash, accountId: AccountId): Future[ManagerKey] =
+    node.runAsyncGetQuery(network, s"blocks/${blockHash.value}/context/contracts/${accountId.id}/manager_key")
       .map(fromJson[ManagerKey])
 
   /**
@@ -100,42 +102,40 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
   def getAllAccountsForBlock(blockHash: BlockHash): Future[Map[AccountId, Account]] =
     for {
       jsonEncodedAccounts <- node.runAsyncGetQuery(network, s"blocks/${blockHash.value}/context/contracts")
-      accountIDs = fromJson[List[String]](jsonEncodedAccounts).map(AccountId)
-      accounts <- getAccountsForBlock(accountIDs, blockHash)
+      accountIds = fromJson[List[String]](jsonEncodedAccounts).map(AccountId)
+      accounts <- getAccountsForBlock(accountIds, blockHash)
     } yield accounts
 
   /**
     * Fetches the accounts identified by id, lazily paginating the results
     *
-    * @param accountIDs the ids
+    * @param accountIds the ids
     * @param blockHash  the block storing the accounts, the head block if not specified
     * @return           the list of accounts wrapped in a [[Future]], indexed by AccountId
     */
-  def getPaginatedAccountsForBlock(accountIDs: List[AccountId], blockHash: BlockHash = blockHeadHash): Iterator[Future[Map[AccountId, Account]]] =
-    partitionAccountIds(accountIDs).map(ids => getAccountsForBlock(ids, blockHash))
-
+  def getPaginatedAccountsForBlock(accountIds: List[AccountId], blockHash: BlockHash = blockHeadHash): Iterator[Future[Map[AccountId, Account]]] =
+    partitionAccountIds(accountIds).map(ids => getAccountsForBlock(ids, blockHash))
 
   /**
     * Fetches the accounts identified by id
     *
-    * @param accountIDs the ids
+    * @param accountIds the ids
     * @param blockHash  the block storing the accounts, the head block if not specified
     * @return           the list of accounts wrapped in a [[Future]], indexed by AccountId
     */
-  def getAccountsForBlock(accountIDs: List[AccountId], blockHash: BlockHash = blockHeadHash): Future[Map[AccountId, Account]] =
-    node
-    .runBatchedGetQuery(network, accountIDs, (id: AccountId) => s"blocks/${blockHash.value}/context/contracts/${id.id}", accountConcurrencyLevel)
-    .map(
-      responseList =>
-        responseList.collect {
-          case (id, json) =>
-            val accountTry: Try[(AccountId, Account)] = Try(fromJson[Account](json)).map((id, _))
-            accountTry.failed.foreach(_ => logger.error("Failed to convert json to an Account for id {}. The content was {}.", id, json))
-            accountTry
-              .toOption
-              .map { case (accountId, account) => (accountId, account.copy(script = account.script.map(toMichelsonScript[MichelsonCode]))) }
-        }.flatten.toMap)
+  def getAccountsForBlock(accountIds: List[AccountId], blockHash: BlockHash = blockHeadHash): Future[Map[AccountId, Account]] = {
+    import cats.instances.future._
+    import cats.instances.list._
 
+    accountFetcher(blockHash).fetch
+      .run(accountIds)
+      .map(
+        indexedAccounts =>
+          indexedAccounts.collect {
+            case (accountId, Some(account)) => accountId -> account.copy(script = account.script.map(toMichelsonScript[MichelsonCode]))
+          }.toMap
+    )
+  }
   /**
     * Get accounts for all the identifiers passed-in with the corresponding block
     * @param accountsBlocksIndex a map from unique id to the [latest] block reference

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosOptics.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosOptics.scala
@@ -14,6 +14,7 @@ object TezosOptics {
 
   object Blocks {
 
+    //basic building blocks to reach into the block's structure
     val blockData = GenLens[Block](_.data)
     val dataHeader = GenLens[BlockData](_.header)
     val metadata = GenLens[BlockData](_.metadata)
@@ -22,11 +23,23 @@ object TezosOptics {
     val metadataBalances = GenLens[BlockHeaderMetadata](_.balance_updates)
 
 
+    /** An optional lens allowing to reach into balances for blocks' metadata */
     val blockBalances: Optional[Block, List[BalanceUpdate]] =
       blockData composeLens metadata composePrism metadataType composeLens metadataBalances
 
+    /** a function to set the header timestamp for a block, returning the modified block */
     val setTimestamp: ZonedDateTime => Block => Block = blockData composeLens dataHeader composeLens headerTimestamp set _
+    /** a function to set metadata balance updates in a block, returning the modified block */
     val setBalances: List[BalanceUpdate] => Block => Block = blockBalances set _
+  }
+
+  object Accounts {
+
+    //basic building blocks to reach into the account's structure
+    val accountScript = GenLens[Account](_.script)
+
+    /** an optional lens allowing to reach into the script field of an account*/
+    val optionalScript = Optional[Account, String](accountScript.get)(newScript => accountScript.set(Some(newScript)))
   }
 
 }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosOptics.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosOptics.scala
@@ -37,9 +37,13 @@ object TezosOptics {
 
     //basic building blocks to reach into the account's structure
     val accountScript = GenLens[Account](_.script)
+    val scriptCode = GenLens[AccountScript](_.code)
 
-    /** an optional lens allowing to reach into the script field of an account*/
-    val optionalScript = Optional[Account, String](accountScript.get)(newScript => accountScript.set(Some(newScript)))
+    private val optionalScript =
+      Optional[Account, AccountScript](accountScript.get)(script => accountScript.set(Some(script)))
+
+    /** an optional lens allowing to reach into the script code field of an account*/
+    val optionalScriptCode = optionalScript composeLens scriptCode
   }
 
 }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosOptics.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosOptics.scala
@@ -36,11 +36,12 @@ object TezosOptics {
   object Accounts {
 
     //basic building blocks to reach into the account's structure
-    val accountScript = GenLens[Account](_.script)
-    val scriptCode = GenLens[AccountScript](_.code)
+    private val accountScript = GenLens[Account](_.script)
 
-    private val optionalScript =
+    val optionalScript =
       Optional[Account, AccountScript](accountScript.get)(script => accountScript.set(Some(script)))
+
+    val scriptCode = GenLens[AccountScript](_.code)
 
     /** an optional lens allowing to reach into the script code field of an account*/
     val optionalScriptCode = optionalScript composeLens scriptCode

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -10,6 +10,7 @@ import monocle.std.option._
   */
 object TezosTypes {
 
+  /*Reminder: we might want to move this to TezosOptics object*/
   object Lenses {
     private val operationGroups = GenLens[Block](_.operationGroups)
     private val operations = GenLens[OperationsGroup](_.contents)
@@ -326,34 +327,37 @@ object TezosTypes {
                                            )
 
   final case class AppliedOperationResultStatus(
-                                   status: String,
-                                   errors: Option[List[String]],
-                                   storage: Option[Any],
-                                   balanceUpdates: Option[AppliedOperationBalanceUpdates],
-                                   originatedContracts: Option[String],
-                                   consumedGas: Option[Int],
-                                   storageSizeDiff: Option[Int]
-                                   )
+    status: String,
+    errors: Option[List[String]],
+    storage: Option[Any],
+    balanceUpdates: Option[AppliedOperationBalanceUpdates],
+    originatedContracts: Option[String],
+    consumedGas: Option[Int],
+    storageSizeDiff: Option[Int]
+  )
 
   final case class AccountDelegate(
-                            setable: Boolean,
-                            value: Option[String]
-                            )
+    setable: Boolean,
+    value: Option[PublicKeyHash]
+  )
+
+  //represents unparsed micheline json
+  final case class AccountScript(code: String) extends AnyVal
 
   final case class Account(
-                    manager: String,
-                    balance: scala.math.BigDecimal,
-                    spendable: Boolean,
-                    delegate: AccountDelegate,
-                    script: Option[String],
-                    counter: Int
-                    )
+    manager: PublicKeyHash,
+    balance: scala.math.BigDecimal,
+    spendable: Boolean,
+    delegate: AccountDelegate,
+    script: Option[AccountScript],
+    counter: Int
+  )
 
   final case class BlockAccounts(
-                    blockHash: BlockHash,
-                    blockLevel: Int,
-                    accounts: Map[AccountId, Account] = Map.empty
-                  )
+      blockHash: BlockHash,
+      blockLevel: Int,
+      accounts: Map[AccountId, Account] = Map.empty
+  )
 
   object VotingPeriod extends Enumeration {
     type Kind = Value

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTest.scala
@@ -1,12 +1,16 @@
 package tech.cryptonomic.conseil.tezos
 
-import org.scalatest.{WordSpec, Matchers, EitherValues}
+import org.scalatest.{WordSpec, Matchers, EitherValues, OptionValues}
 import TezosTypes._
 import tech.cryptonomic.conseil.util.JsonUtil.adaptManagerPubkeyField
 
-class JsonDecodersTest extends WordSpec with Matchers with EitherValues {
+class JsonDecodersTest extends WordSpec
+  with Matchers
+  with EitherValues
+  with OptionValues {
 
   import JsonDecoders.Circe._
+  import JsonDecoders.Circe.Accounts._
   import JsonDecoders.Circe.Operations._
   import JsonDecoders.Circe.Votes._
   import io.circe.parser.decode
@@ -418,6 +422,21 @@ class JsonDecodersTest extends WordSpec with Matchers with EitherValues {
       failedBallot shouldBe 'left
     }
 
+    "decode accounts" in new AccountsJsonData {
+      val decoded = decode[Account](accountJson)
+      decoded shouldBe 'right
+
+      val account = decoded.right.value
+      account shouldEqual expectedAccount
+    }
+
+    "decode account scripts as wrapped and unparsed text, instead of a json object" in new AccountsJsonData {
+      val decoded = decode[Account](accountScriptedJson)
+      decoded shouldBe 'right
+
+      val account = decoded.right.value
+      account.script.value shouldEqual expectedScript
+    }
   }
 
 }

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTestFixtures.scala
@@ -2,6 +2,69 @@ package tech.cryptonomic.conseil.tezos
 
 import TezosTypes._
 
+/* defines example tezos json definitions of accounts and typed counterparts used in the tests */
+trait AccountsJsonData {
+  val accountJson =
+    """{
+    |  "balance": "2921522468",
+    |  "counter": "0",
+    |  "delegate": {
+    |      "setable": false,
+    |      "value": "tz1LdZ6S8ScNMgaCLqrekDvbBWhLqtUebk23"
+    |  },
+    |  "manager": "tz1Tzqh3CWLdPoH4kHSqcePatkBVKTwifCHY",
+    |  "spendable": true
+    |}""".stripMargin
+
+  val expectedAccount =
+    Account(
+      manager = PublicKeyHash("tz1Tzqh3CWLdPoH4kHSqcePatkBVKTwifCHY"),
+      balance = 2921522468L,
+      spendable = true,
+      delegate = AccountDelegate(
+        setable = false,
+        value = Some(PublicKeyHash("tz1LdZ6S8ScNMgaCLqrekDvbBWhLqtUebk23"))
+      ),
+      script = None,
+      counter = 0
+    )
+
+  val scriptJson =
+    """{
+    |  "code": [
+    |      {
+    |          "prim": "parameter",
+    |          "args": [
+    |              {
+    |                  "prim": "string"
+    |              }
+    |          ]
+    |      }
+    |  ],
+    |  "storage": {
+    |      "string": "hello"
+    |  }
+    |}""".stripMargin
+
+  val expectedScript = AccountScript(
+    """{"code":[{"prim":"parameter","args":[{"prim":"string"}]}],"storage":{"string":"hello"}}"""
+  )
+
+  val accountScriptedJson =
+   s"""{
+    |  "balance": "2921522468",
+    |  "counter": "0",
+    |  "delegate": {
+    |      "setable": false,
+    |      "value": "tz1LdZ6S8ScNMgaCLqrekDvbBWhLqtUebk23"
+    |  },
+    |  "script": $scriptJson,
+    |  "manager": "tz1Tzqh3CWLdPoH4kHSqcePatkBVKTwifCHY",
+    |  "spendable": true
+    |}""".stripMargin
+
+}
+
 /* defines example tezos json definitions of operations and typed counterparts used in the tests */
 trait OperationsJsonData {
   import OperationMetadata.BalanceUpdate

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
@@ -285,12 +285,12 @@ class TezosDatabaseOperationsTest
         case (row, (id, account)) =>
           row.accountId shouldEqual id.id
           row.blockId shouldEqual block.hash
-          row.manager shouldEqual account.manager
+          row.manager shouldEqual account.manager.value
           row.spendable shouldEqual account.spendable
           row.delegateSetable shouldEqual account.delegate.setable
-          row.delegateValue shouldEqual account.delegate.value
+          row.delegateValue shouldEqual account.delegate.value.map(_.value)
           row.counter shouldEqual account.counter
-          row.script shouldEqual account.script.map(_.toString)
+          row.script shouldEqual account.script.map(_.code.toString)
           row.balance shouldEqual account.balance
           row.blockLevel shouldEqual block.level
       }
@@ -314,7 +314,7 @@ class TezosDatabaseOperationsTest
 
       //generate data
       val blocks @ (second :: first :: genesis :: Nil) = generateBlockRows(toLevel = 2, startAt = testReferenceTimestamp)
-      val account = generateAccountRows(1, blocks.head).head
+      val account = generateAccountRows(1, first).head
 
       val populate =
         DBIO.seq(
@@ -326,7 +326,7 @@ class TezosDatabaseOperationsTest
 
       //prepare new accounts
       val accountChanges = 2
-      val (hashUpdate, levelUpdate) = (first.hash, first.level)
+      val (hashUpdate, levelUpdate) = (second.hash, second.level)
       val accountsInfo = generateAccounts(accountChanges, BlockHash(hashUpdate), levelUpdate)
 
       //double-check for the identifier existence
@@ -353,12 +353,12 @@ class TezosDatabaseOperationsTest
         case (row, (id, account)) =>
           row.accountId shouldEqual id.id
           row.blockId shouldEqual hashUpdate
-          row.manager shouldEqual account.manager
+          row.manager shouldEqual account.manager.value
           row.spendable shouldEqual account.spendable
           row.delegateSetable shouldEqual account.delegate.setable
-          row.delegateValue shouldEqual account.delegate.value
+          row.delegateValue shouldEqual account.delegate.value.map(_.value)
           row.counter shouldEqual account.counter
-          row.script shouldEqual account.script.map(_.toString)
+          row.script shouldEqual account.script.map(_.code.toString)
           row.balance shouldEqual account.balance
           row.blockLevel shouldEqual levelUpdate
       }

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
@@ -42,11 +42,11 @@ trait TezosDataGeneration extends RandomGenerationKit {
       currentId =>
         (AccountId(String valueOf currentId),
           Account(
-            manager = "manager",
+            manager = PublicKeyHash("manager"),
             balance = rnd.nextInt,
             spendable = true,
-            delegate = AccountDelegate(setable = false, value = Some("delegate-value")),
-            script = Some("script"),
+            delegate = AccountDelegate(setable = false, value = Some(PublicKeyHash("delegate-value"))),
+            script = Some(AccountScript("script")),
             counter = currentId
           )
         )


### PR DESCRIPTION
closes #291 
Now the accounts are taken using a data-fetcher and decoded with a custom circe decoder that would not try to parse micheline scripts, too.
This allows to separate that into a second step, after accounts are loaded.
Failure to parse the script, would simply log a warn and store the micheline as-is instead of converting to michelson format.
