### PR TITLE
Bug fixes and backwards compatibility measures for v1 API

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/routes/DataHelpers.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/DataHelpers.scala
@@ -61,9 +61,11 @@ trait DataHelpers extends QueryStringListsServer with Validation with akkahttp.s
     case x: java.lang.Integer => Json.fromInt(x)
     case x: java.sql.Timestamp => Json.fromLong(x.getTime)
     case x: java.lang.Boolean => Json.fromBoolean(x)
-    case x: scala.collection.immutable.Vector[Tables.OperationGroupsRow] => x.map(_.asJson(operationGroupsRowSchema.encoder)).asJson
+    case x: scala.collection.immutable.Vector[Any] => x.map(_.asJson(anyEncoder)).asJson //Due to type erasure, a recursive call is made here.
     case x: Tables.BlocksRow => x.asJson(blocksRowSchema.encoder)
     case x: Tables.AccountsRow => x.asJson(accountsRowSchema.encoder)
+    case x: Tables.OperationGroupsRow => x.asJson(operationGroupsRowSchema.encoder)
+    case x: Tables.OperationsRow => x.asJson(operationsRowSchema.encoder)
     case x: java.math.BigDecimal => Json.fromBigDecimal(x)
     case x => Json.fromString(x.toString)
   }

--- a/src/main/scala/tech/cryptonomic/conseil/routes/DataHelpers.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/DataHelpers.scala
@@ -63,6 +63,7 @@ trait DataHelpers extends QueryStringListsServer with Validation with akkahttp.s
     case x: java.lang.Boolean => Json.fromBoolean(x)
     case x: scala.collection.immutable.Vector[Tables.OperationGroupsRow] => x.map(_.asJson(operationGroupsRowSchema.encoder)).asJson
     case x: Tables.BlocksRow => x.asJson(blocksRowSchema.encoder)
+    case x: Tables.AccountsRow => x.asJson(accountsRowSchema.encoder)
     case x: java.math.BigDecimal => Json.fromBigDecimal(x)
     case x => Json.fromString(x.toString)
   }

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/ApiFilterFromQueryString.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/ApiFilterFromQueryString.scala
@@ -36,19 +36,19 @@ trait ApiFilterFromQueryString extends QueryStringLists { self: algebra.JsonSche
   private def filterQs: QueryString[QueryParams] = {
     val raw =
       optQs[Int]("limit") &
-        qsList[String]("blockIDs") &
-        qsList[Int]("levels") &
-        qsList[String]("chainIDs") &
-        qsList[String]("protocols") &
-        qsList[String]("operationGroupIDs") &
-        qsList[String]("operationSources") &
-        qsList[String]("operationDestinations") &
-        qsList[String]("operationParticipants") &
-        qsList[String]("operationKinds") &
-        qsList[String]("accountIDs") &
-        qsList[String]("accountManagers") &
-        qsList[String]("accountDelegates") &
-        optQs[String]("sortBy") &
+        qsList[String]("block_id") &
+        qsList[Int]("block_level") &
+        qsList[String]("block_netid") &
+        qsList[String]("block_protocol") &
+        qsList[String]("operation_id") &
+        qsList[String]("operation_source") &
+        qsList[String]("operation_destination") &
+        qsList[String]("operation_participant") &
+        qsList[String]("operation_kind") &
+        qsList[String]("account_id") &
+        qsList[String]("account_manager") &
+        qsList[String]("account_delegate") &
+        optQs[String]("sort_by") &
         optQs[String]("order")
     raw map (flatten(_))
   }

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataJsonSchemas.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataJsonSchemas.scala
@@ -44,10 +44,6 @@ trait DataJsonSchemas extends algebra.JsonSchemas with generic.JsonSchemas {
   implicit def operationGroupsRowSchema: JsonSchema[OperationGroupsRow] =
     genericJsonSchema[OperationGroupsRow]
 
-  /** Operation groups row schema */
-  implicit def operationsRowSchema: JsonSchema[OperationsRow] =
-    genericJsonSchema[OperationsRow]
-
   /** Average fees schema */
   implicit def avgFeeSchema: JsonSchema[AverageFees] =
     genericJsonSchema[AverageFees]
@@ -64,8 +60,8 @@ trait DataJsonSchemas extends algebra.JsonSchemas with generic.JsonSchemas {
   /** AnyMap schema */
   implicit def blocksByHashSchema: JsonSchema[AnyMap]
 
-  /** Operation schema */
-  implicit def operationSchema: JsonSchema[OperationsRow] =
+  /** Operation groups row schema */
+  implicit def operationsRowSchema: JsonSchema[OperationsRow] =
     genericJsonSchema[OperationsRow]
 
   /** Accounts row schema */

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataJsonSchemas.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataJsonSchemas.scala
@@ -60,7 +60,7 @@ trait DataJsonSchemas extends algebra.JsonSchemas with generic.JsonSchemas {
   /** AnyMap schema */
   implicit def blocksByHashSchema: JsonSchema[AnyMap]
 
-  /** Operation groups row schema */
+  /** Operation row schema */
   implicit def operationsRowSchema: JsonSchema[OperationsRow] =
     genericJsonSchema[OperationsRow]
 

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataJsonSchemas.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataJsonSchemas.scala
@@ -44,6 +44,10 @@ trait DataJsonSchemas extends algebra.JsonSchemas with generic.JsonSchemas {
   implicit def operationGroupsRowSchema: JsonSchema[OperationGroupsRow] =
     genericJsonSchema[OperationGroupsRow]
 
+  /** Operation groups row schema */
+  implicit def operationsRowSchema: JsonSchema[OperationsRow] =
+    genericJsonSchema[OperationsRow]
+
   /** Average fees schema */
   implicit def avgFeeSchema: JsonSchema[AverageFees] =
     genericJsonSchema[AverageFees]

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/TezosEndpoints.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/TezosEndpoints.scala
@@ -80,11 +80,6 @@ trait TezosEndpoints extends algebra.Endpoints with DataJsonSchemas with ApiFilt
       tags = List("Operation groups")
     )
 
-  /** Operation groups row schema */
-  /** Pasted here because somehow it is not being pulled in from DataJsonSchemas at all. */
-  override implicit def operationsRowSchema: JsonSchema[OperationsRow] =
-    genericJsonSchema[OperationsRow]
-
   /** Operations endpoint definition */
   def operationsEndpointV1: Endpoint[(String, ApiOperations.Filter, String), Seq[OperationsRow]] =
     endpoint(

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/TezosEndpoints.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/TezosEndpoints.scala
@@ -80,15 +80,10 @@ trait TezosEndpoints extends algebra.Endpoints with DataJsonSchemas with ApiFilt
       tags = List("Operation groups")
     )
 
-  /** Average fees endpoint definition */
-  def avgFeesEndpointV1: Endpoint[(String, ApiOperations.Filter, String), Option[AverageFees]] =
-    endpoint(
-      request = get(
-        url = commonPath / "operations" / "avgFees" /? qsFilter,
-        headers = header("apiKey")),
-      response = jsonResponse[AverageFees](docs = Some("Endpoint for average fees")).orNotFound(Some("Not found")),
-      tags = List("Fees")
-    )
+  /** Operation groups row schema */
+  /** Pasted here because somehow it is not being pulled in from DataJsonSchemas at all. */
+  override implicit def operationsRowSchema: JsonSchema[OperationsRow] =
+    genericJsonSchema[OperationsRow]
 
   /** Operations endpoint definition */
   def operationsEndpointV1: Endpoint[(String, ApiOperations.Filter, String), Seq[OperationsRow]] =
@@ -100,4 +95,13 @@ trait TezosEndpoints extends algebra.Endpoints with DataJsonSchemas with ApiFilt
       tags = List("Operations")
     )
 
+  /** Average fees endpoint definition */
+  def avgFeesEndpointV1: Endpoint[(String, ApiOperations.Filter, String), Option[AverageFees]] =
+    endpoint(
+      request = get(
+        url = commonPath / "operations" / "avgFees" /? qsFilter,
+        headers = header("apiKey")),
+      response = jsonResponse[AverageFees](docs = Some("Endpoint for average fees")).orNotFound(Some("Not found")),
+      tags = List("Fees")
+    )
 }


### PR DESCRIPTION
As released versions of the Tezori / Galleon wallet for Tezos are using the v1 Conseil API, we must ensure the v1 API is working as expected in the current codebase. This PR addresses three issues.

For #307, a missing JSON encoder for accounts has been added (37015f1439bf443d3c5842c844cf6f5c60ac8bd9). 

Related to #307, I found the encoding of operation groups and operations was incorrect and fixed them (a2f0e3633b2e129fd93d025220ee482921bf5f9f).

For #306, I reverted the query parameter names back to the old ones so released wallets don't break when this code is pushed out (b5fd2fd9b7cf61688aa272e7192b55117dfe12d3). 

I had some trouble with one implicit function and left a corresponding comment for others' review. 