### PR TITLE
#130 head hash parameter

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -16,7 +16,7 @@ lorre: {
   #Used to select how many fees should be averaged together
   numberOfFeesAveraged: 1000
   depth: newest,
-  headHash: "fad"
+  headHash: None
 }
 
 # Used for configuring Typesafe Slick. Replace database name, user and password in an env-specific config file.

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -15,6 +15,8 @@ lorre: {
   feeUpdateInterval: 20
   #Used to select how many fees should be averaged together
   numberOfFeesAveraged: 1000
+  depth: newest,
+  headHash: "fad"
 }
 
 # Used for configuring Typesafe Slick. Replace database name, user and password in an env-specific config file.

--- a/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
@@ -103,7 +103,7 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
 
     Await.result(attemptedProcessing, atMost = Duration.Inf)
 
-    tezosConf.depth match {
+    lorreConf.depth match {
       case Newest =>
         logger.info("Taking a nap")
         Thread.sleep(lorreConf.sleepInterval.toMillis)
@@ -128,10 +128,10 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
   private[this] def processTezosBlocks(): Future[Done] = {
     logger.info("Processing Tezos Blocks..")
 
-    val blockPagesToSynchronize = tezosConf.depth match {
+    val blockPagesToSynchronize = lorreConf.depth match {
       case Newest => tezosNodeOperator.getBlocksNotInDatabase()
       case Everything => tezosNodeOperator.getLatestBlocks()
-      case Custom(n) => tezosNodeOperator.getLatestBlocks(Some(n), tezosConf.headHash)
+      case Custom(n) => tezosNodeOperator.getLatestBlocks(Some(n), lorreConf.headHash)
     }
 
     /* will store a single page of block results */

--- a/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
@@ -131,7 +131,7 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
     val blockPagesToSynchronize = tezosConf.depth match {
       case Newest => tezosNodeOperator.getBlocksNotInDatabase()
       case Everything => tezosNodeOperator.getLatestBlocks()
-      case Custom(n) => tezosNodeOperator.getLatestBlocks(Some(n))
+      case Custom(n) => tezosNodeOperator.getLatestBlocks(Some(n), tezosConf.headHash)
     }
 
     /* will store a single page of block results */

--- a/src/main/scala/tech/cryptonomic/conseil/config/LorreAppConfig.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/config/LorreAppConfig.scala
@@ -2,12 +2,12 @@ package tech.cryptonomic.conseil.config
 
 import tech.cryptonomic.conseil.config.Platforms._
 import tech.cryptonomic.conseil.util.ConfigUtil.Pureconfig.loadAkkaStreamingClientConfig
-import pureconfig.{CamelCase, ConfigFieldMapping, loadConfig}
-import pureconfig.ConfigReader
+import pureconfig.{CamelCase, ConfigFieldMapping, ConfigReader, loadConfig}
 import pureconfig.error.ConfigReaderFailures
 import pureconfig.generic.{EnumCoproductHint, ProductHint}
 import pureconfig.generic.auto._
 import scopt.{OptionParser, Read}
+import tech.cryptonomic.conseil.tezos.TezosTypes.BlockHash
 
 /** wraps all configuration needed to run Lorre */
 trait LorreAppConfig {
@@ -23,7 +23,10 @@ trait LorreAppConfig {
     case _ => None
   }
 
-  private case class ArgumentsConfig(depth: Depth = Newest, verbose: Boolean = false, headHash: Option[String] = None, network: String = "")
+  /* used by scopt to parse the depth object */
+  implicit private val blockHashRead: Read[BlockHash] = Read.reads(BlockHash)
+
+  private case class ArgumentsConfig(depth: Depth = Newest, verbose: Boolean = false, headHash: Option[BlockHash] = None, network: String = "")
 
   private val argsParser = new OptionParser[ArgumentsConfig]("lorre") {
     arg[String]("network")
@@ -31,7 +34,7 @@ trait LorreAppConfig {
       .action( (x, c) => c.copy(network = x))
       .text("which network to use")
 
-    opt[Option[String]]('h', "headHash")
+    opt[Option[BlockHash]]('h', "headHash")
       .action( (x, c) => c.copy(headHash = x))
       .text("from which block to start. Default to actual head")
 

--- a/src/main/scala/tech/cryptonomic/conseil/config/Platforms.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/config/Platforms.scala
@@ -48,11 +48,10 @@ object Platforms extends LazyLogging {
   /** generic trait for any platform configuration, where each instance corresponds to a network available on that chain */
   sealed trait PlatformConfiguration extends Product with Serializable {
     def network: String
-    def depth: Depth
   }
 
   /** collects all config related to a tezos network */
-  final case class TezosConfiguration(network: String, depth: Depth = Newest, nodeConfig: TezosNodeConfiguration, headHash: Option[String] = None) extends PlatformConfiguration
+  final case class TezosConfiguration(network: String, nodeConfig: TezosNodeConfiguration) extends PlatformConfiguration
 
   /** unexpected or yet to define platform */
   final case class UnknownPlatformConfiguration(network: String = "", depth: Depth = Newest) extends PlatformConfiguration

--- a/src/main/scala/tech/cryptonomic/conseil/config/Platforms.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/config/Platforms.scala
@@ -52,7 +52,7 @@ object Platforms extends LazyLogging {
   }
 
   /** collects all config related to a tezos network */
-  final case class TezosConfiguration(network: String, depth: Depth = Newest, nodeConfig: TezosNodeConfiguration) extends PlatformConfiguration
+  final case class TezosConfiguration(network: String, depth: Depth = Newest, nodeConfig: TezosNodeConfiguration, headHash: Option[String] = None) extends PlatformConfiguration
 
   /** unexpected or yet to define platform */
   final case class UnknownPlatformConfiguration(network: String = "", depth: Depth = Newest) extends PlatformConfiguration

--- a/src/main/scala/tech/cryptonomic/conseil/config/Shared.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/config/Shared.scala
@@ -9,7 +9,9 @@ final case class LorreConfiguration(
   bootupRetryInterval: FiniteDuration,
   bootupConnectionCheckTimeout: FiniteDuration,
   feeUpdateInterval: Int,
-  numberOfFeesAveraged: Int
+  numberOfFeesAveraged: Int,
+  depth: Depth,
+  headHash: Option[String]
 )
 
 final case class BatchFetchConfiguration(

--- a/src/main/scala/tech/cryptonomic/conseil/config/Shared.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/config/Shared.scala
@@ -1,5 +1,7 @@
 package tech.cryptonomic.conseil.config
 
+import tech.cryptonomic.conseil.tezos.TezosTypes.BlockHash
+
 import scala.concurrent.duration.FiniteDuration
 
 final case class ServerConfiguration(hostname: String, port: Int)
@@ -11,7 +13,7 @@ final case class LorreConfiguration(
   feeUpdateInterval: Int,
   numberOfFeesAveraged: Int,
   depth: Depth,
-  headHash: Option[String]
+  headHash: Option[BlockHash]
 )
 
 final case class BatchFetchConfiguration(

--- a/src/main/scala/tech/cryptonomic/conseil/io/MainOutputs.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/io/MainOutputs.scala
@@ -111,7 +111,6 @@ object MainOutputs {
         platform.name,
         platformConf.network,
         showPlatformConfiguration(platformConf),
-        platformConf.depth,
         ignoreFailures._2.getOrElse("yes"),
         showDatabaseConfiguration,
         ignoreFailures._1
@@ -161,7 +160,7 @@ object MainOutputs {
 
   /* custom display of each configuration type */
   private val showPlatformConfiguration: PartialFunction[PlatformConfiguration, String] = {
-    case TezosConfiguration(_, _, TezosNodeConfiguration(host, port, protocol, prefix), _) =>
+    case TezosConfiguration(_, TezosNodeConfiguration(host, port, protocol, prefix)) =>
       s"node $protocol://$host:$port/$prefix"
     case _ =>
       "a non-descript platform configuration"

--- a/src/main/scala/tech/cryptonomic/conseil/io/MainOutputs.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/io/MainOutputs.scala
@@ -161,7 +161,7 @@ object MainOutputs {
 
   /* custom display of each configuration type */
   private val showPlatformConfiguration: PartialFunction[PlatformConfiguration, String] = {
-    case TezosConfiguration(_, _, TezosNodeConfiguration(host, port, protocol, prefix)) =>
+    case TezosConfiguration(_, _, TezosNodeConfiguration(host, port, protocol, prefix), _) =>
       s"node $protocol://$host:$port/$prefix"
     case _ =>
       "a non-descript platform configuration"

--- a/src/main/scala/tech/cryptonomic/conseil/scripts/NodeStreamingBenchmarks.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/scripts/NodeStreamingBenchmarks.scala
@@ -53,7 +53,7 @@ package scripts {
       reqConf <- loadConfig[NetworkCallsConfiguration]("")
       nodeConf <- loadConfig[TezosNodeConfiguration](namespace = s"platform.tezos.$network.node")
       clientConf <- loadAkkaStreamingClientConfig(namespace = "akka.tezos-streaming-client")
-    } yield (TezosConfiguration(network, Newest, nodeConf), reqConf, clientConf)
+    } yield (TezosConfiguration(network, nodeConf), reqConf, clientConf)
 
     loadedConf.foreach {
       conf =>

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -329,9 +329,9 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
     * @param headHash   Hash of a block from which to start, None to start from a real head
     * @return           Blocks and Account hashes involved
     */
-  def getLatestBlocks(depth: Option[Int] = None, headHash: Option[String] = None): Future[PaginatedBlocksResults] = {
+  def getLatestBlocks(depth: Option[Int] = None, headHash: Option[BlockHash] = None): Future[PaginatedBlocksResults] = {
     headHash
-      .map(it => getBlock(BlockHash(it)))
+      .map(getBlock(_))
       .getOrElse(getBlockHead())
       .map {
         head =>

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -50,10 +50,11 @@ object TezosNodeOperator {
 
 /**
   * Operations run against Tezos nodes, mainly used for collecting chain data for later entry into a database.
-  * @param node      Tezos node connection object
-  * @param network   Which Tezos network to go against
-  * @param batchConf configuration for batched download of node data
-  * @param executionContext thread context for async operations
+  *
+  * @param node               Tezos node connection object
+  * @param network            Which Tezos network to go against
+  * @param batchConf          configuration for batched download of node data
+  * @param fetchFutureContext thread context for async operations
   */
 class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchConf: BatchFetchConfiguration)(implicit val fetchFutureContext: ExecutionContext)
   extends LazyLogging
@@ -325,19 +326,24 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
   /**
     * Gets last `depth` blocks.
     * @param depth      Number of latest block to fetch, `None` to get all
+    * @param headHash   Hash of a block from which to start, None to start from a real head
     * @return           Blocks and Account hashes involved
     */
-  def getLatestBlocks(depth: Option[Int] = None): Future[PaginatedBlocksResults] =
-    getBlockHead().map {
-      head =>
-        val headLevel = head.data.header.level
-        val headHash = head.data.hash
-        val minLevel = depth.fold(1)(d => max(1, headLevel - d + 1))
-        val pagedResults = partitionBlocksRanges(minLevel to headLevel).map(
-          page => getBlocks((headHash, headLevel), page)
-        )
-        (pagedResults, headLevel - minLevel + 1)
-    }
+  def getLatestBlocks(depth: Option[Int] = None, headHash: Option[String] = None): Future[PaginatedBlocksResults] = {
+    headHash
+      .map(it => getBlock(BlockHash(it)))
+      .getOrElse(getBlockHead())
+      .map {
+        head =>
+          val headLevel = head.data.header.level
+          val headHash = head.data.hash
+          val minLevel = depth.fold(1)(d => max(1, headLevel - d + 1))
+          val pagedResults = partitionBlocksRanges(minLevel to headLevel).map(
+            page => getBlocks((headHash, headLevel), page)
+          )
+          (pagedResults, headLevel - minLevel + 1)
+      }
+  }
 
   /**
     * Gets block from Tezos Blockchains, as well as their associated operation, from minLevel to maxLevel.

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -334,9 +334,9 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
       .map(getBlock(_))
       .getOrElse(getBlockHead())
       .map {
-        head =>
-          val headLevel = head.data.header.level
-          val headHash = head.data.hash
+        maxHead =>
+          val headLevel = maxHead.data.header.level
+          val headHash = maxHead.data.hash
           val minLevel = depth.fold(1)(d => max(1, headLevel - d + 1))
           val pagedResults = partitionBlocksRanges(minLevel to headLevel).map(
             page => getBlocks((headHash, headLevel), page)

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -1,8 +1,8 @@
 package tech.cryptonomic.conseil.tezos
 
-import monocle.{Prism, Traversal}
+import monocle.Traversal
 import monocle.function.all._
-import monocle.macros.GenLens
+import monocle.macros.{GenLens, GenPrism}
 import monocle.std.option._
 
 /**
@@ -15,8 +15,8 @@ object TezosTypes {
     private val operationGroups = GenLens[Block](_.operationGroups)
     private val operations = GenLens[OperationsGroup](_.contents)
 
-    private val origination = Prism.partial[Operation, Origination]{case it: Origination => it}(identity)
-    private val transaction = Prism.partial[Operation, Transaction]{case it: Transaction => it}(identity)
+    private val origination = GenPrism[Operation, Origination]
+    private val transaction = GenPrism[Operation, Transaction]
 
     private val script = GenLens[Origination](_.script)
     private val parameters = GenLens[Transaction](_.parameters)

--- a/src/main/scala/tech/cryptonomic/conseil/util/ConfigUtil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/util/ConfigUtil.scala
@@ -99,7 +99,7 @@ object ConfigUtil {
                 .left.map(ExceptionThrown)
                 .flatMap(readAndFailWithFailureReason[TezosNodeConfiguration])
                 //creates the whole config entry
-                .map(TezosConfiguration(network, Newest, _))
+                .map(TezosConfiguration(network, _))
           }
           foldReadResults(parsed) {
             _.toList

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DataTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DataTest.scala
@@ -86,7 +86,7 @@ class DataTest extends WordSpec with Matchers with ScalatestRouteTest with Scala
   val fakeQPP: DataPlatform = new DataPlatform(Map("tezos" -> fakeQPO))
   val cfg = PlatformsConfiguration(
     platforms = Map(
-      Tezos -> List(TezosConfiguration("alphanet", Newest, TezosNodeConfiguration(protocol = "http", hostname = "localhost", port = 8732)))
+      Tezos -> List(TezosConfiguration("alphanet", TezosNodeConfiguration(protocol = "http", hostname = "localhost", port = 8732)))
     )
   )
   val postRoute: Route = new Data(cfg, fakeQPP)(ec).postRoute

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTest.scala
@@ -148,19 +148,19 @@ class TezosNodeOperatorTest extends FlatSpec with MockFactory with Matchers with
     val votesProposal = Future.successful(TezosResponseBuilder.votesProposal)
 
     (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/BMB9MF19hpLsnLQfiJYKPdDaikv5DuWJeWamx1yHoihk5QTqJw8~")
+      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c~")
       .returns(blockResponse)
     (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/BMB9MF19hpLsnLQfiJYKPdDaikv5DuWJeWamx1yHoihk5QTqJw8/operations")
+      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c/operations")
       .returns(operationsResponse)
     (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/BMB9MF19hpLsnLQfiJYKPdDaikv5DuWJeWamx1yHoihk5QTqJw8~/votes/current_period_kind")
+      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c~/votes/current_period_kind")
       .returns(votesPeriodKind)
     (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/BMB9MF19hpLsnLQfiJYKPdDaikv5DuWJeWamx1yHoihk5QTqJw8~/votes/current_quorum")
+      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c~/votes/current_quorum")
       .returns(votesQuorum)
     (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/BMB9MF19hpLsnLQfiJYKPdDaikv5DuWJeWamx1yHoihk5QTqJw8~/votes/current_proposal")
+      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c~/votes/current_proposal")
       .returns(votesProposal)
 
     (tezosRPCInterface.runBatchedGetQuery[Any] _)
@@ -185,7 +185,7 @@ class TezosNodeOperatorTest extends FlatSpec with MockFactory with Matchers with
     val nodeOp: TezosNodeOperator = new TezosNodeOperator(tezosRPCInterface, "zeronet", config)
 
     //when
-    val blockPages: Future[nodeOp.PaginatedBlocksResults] = nodeOp.getLatestBlocks(Some(1), Some(BlockHash("BMB9MF19hpLsnLQfiJYKPdDaikv5DuWJeWamx1yHoihk5QTqJw8")))
+    val blockPages: Future[nodeOp.PaginatedBlocksResults] = nodeOp.getLatestBlocks(Some(1), Some(BlockHash("BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c")))
 
     //then
     val (pages, total) = blockPages.futureValue

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTest.scala
@@ -148,19 +148,19 @@ class TezosNodeOperatorTest extends FlatSpec with MockFactory with Matchers with
     val votesProposal = Future.successful(TezosResponseBuilder.votesProposal)
 
     (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c~")
+      .when("zeronet", "blocks/BMB9MF19hpLsnLQfiJYKPdDaikv5DuWJeWamx1yHoihk5QTqJw8~")
       .returns(blockResponse)
     (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c/operations")
+      .when("zeronet", "blocks/BMB9MF19hpLsnLQfiJYKPdDaikv5DuWJeWamx1yHoihk5QTqJw8/operations")
       .returns(operationsResponse)
     (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c~/votes/current_period_kind")
+      .when("zeronet", "blocks/BMB9MF19hpLsnLQfiJYKPdDaikv5DuWJeWamx1yHoihk5QTqJw8~/votes/current_period_kind")
       .returns(votesPeriodKind)
     (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c~/votes/current_quorum")
+      .when("zeronet", "blocks/BMB9MF19hpLsnLQfiJYKPdDaikv5DuWJeWamx1yHoihk5QTqJw8~/votes/current_quorum")
       .returns(votesQuorum)
     (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c~/votes/current_proposal")
+      .when("zeronet", "blocks/BMB9MF19hpLsnLQfiJYKPdDaikv5DuWJeWamx1yHoihk5QTqJw8~/votes/current_proposal")
       .returns(votesProposal)
 
     (tezosRPCInterface.runBatchedGetQuery[Any] _)
@@ -185,7 +185,7 @@ class TezosNodeOperatorTest extends FlatSpec with MockFactory with Matchers with
     val nodeOp: TezosNodeOperator = new TezosNodeOperator(tezosRPCInterface, "zeronet", config)
 
     //when
-    val blockPages: Future[nodeOp.PaginatedBlocksResults] = nodeOp.getLatestBlocks(Some(1), Some("BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c"))
+    val blockPages: Future[nodeOp.PaginatedBlocksResults] = nodeOp.getLatestBlocks(Some(1), Some(BlockHash("BMB9MF19hpLsnLQfiJYKPdDaikv5DuWJeWamx1yHoihk5QTqJw8")))
 
     //then
     val (pages, total) = blockPages.futureValue

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTest.scala
@@ -108,7 +108,7 @@ class TezosNodeOperatorTest extends FlatSpec with MockFactory with Matchers with
 
     (tezosRPCInterface.runBatchedGetQuery[Any] _)
       .when("zeronet", *, *, *)
-      .onCall( (_, input, command, _) =>
+      .onCall((_, input, command, _) =>
         Future.successful(List(
           //dirty trick to find the type of input content and provide the appropriate response
           input match {
@@ -136,6 +136,63 @@ class TezosNodeOperatorTest extends FlatSpec with MockFactory with Matchers with
     val results = pages.toList
     results should have length 1
     results.head.futureValue should have length 1
- }
+  }
+
+  "getLatestBlocks" should "correctly fetch blocks starting from a given head" in {
+    //given
+    val tezosRPCInterface = stub[TezosRPCInterface]
+    val blockResponse = Future.successful(TezosResponseBuilder.blockResponse)
+    val operationsResponse = Future.successful(TezosResponseBuilder.operationsResponse)
+    val votesPeriodKind = Future.successful(TezosResponseBuilder.votesPeriodKind)
+    val votesQuorum = Future.successful(TezosResponseBuilder.votesQuorum)
+    val votesProposal = Future.successful(TezosResponseBuilder.votesProposal)
+
+    (tezosRPCInterface.runAsyncGetQuery _)
+      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c~")
+      .returns(blockResponse)
+    (tezosRPCInterface.runAsyncGetQuery _)
+      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c/operations")
+      .returns(operationsResponse)
+    (tezosRPCInterface.runAsyncGetQuery _)
+      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c~/votes/current_period_kind")
+      .returns(votesPeriodKind)
+    (tezosRPCInterface.runAsyncGetQuery _)
+      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c~/votes/current_quorum")
+      .returns(votesQuorum)
+    (tezosRPCInterface.runAsyncGetQuery _)
+      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c~/votes/current_proposal")
+      .returns(votesProposal)
+
+    (tezosRPCInterface.runBatchedGetQuery[Any] _)
+      .when("zeronet", *, *, *)
+      .onCall((_, input, command, _) =>
+        Future.successful(List(
+          //dirty trick to find the type of input content and provide the appropriate response
+          input match {
+            case (_: Int) :: tail => (0, TezosResponseBuilder.batchedGetBlockQueryResponse)
+            case (hash: BlockHash) :: tail if command(hash) endsWith "operations" =>
+              (hash, TezosResponseBuilder.batchedGetOperationsQueryResponse)
+            case (hash: BlockHash) :: tail if command(hash) endsWith "votes/current_period_kind" =>
+              (hash, TezosResponseBuilder.votesPeriodKind)
+            case (hash: BlockHash) :: tail if command(hash) endsWith "votes/current_quorum" =>
+              (hash, TezosResponseBuilder.votesQuorum)
+            case (hash: BlockHash) :: tail if command(hash) endsWith "votes/current_proposal" =>
+              (hash, TezosResponseBuilder.votesProposal)
+          }
+        ))
+      )
+
+    val nodeOp: TezosNodeOperator = new TezosNodeOperator(tezosRPCInterface, "zeronet", config)
+
+    //when
+    val blockPages: Future[nodeOp.PaginatedBlocksResults] = nodeOp.getLatestBlocks(Some(1), Some("BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c"))
+
+    //then
+    val (pages, total) = blockPages.futureValue
+    total shouldBe 1
+    val results = pages.toList
+    results should have length 1
+    results.head.futureValue should have length 1
+  }
 
 }

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
@@ -35,7 +35,7 @@ class TezosPlatformDiscoveryOperationsTest
     "return list with one element" in {
       val config = PlatformsConfiguration(
         platforms = Map(
-          Tezos -> List(TezosConfiguration("alphanet", Newest, TezosNodeConfiguration(protocol = "http", hostname = "localhost", port = 8732)))
+          Tezos -> List(TezosConfiguration("alphanet", TezosNodeConfiguration(protocol = "http", hostname = "localhost", port = 8732)))
         )
       )
 
@@ -48,12 +48,10 @@ class TezosPlatformDiscoveryOperationsTest
           Tezos -> List(
             TezosConfiguration(
               "alphanet",
-              Newest,
               TezosNodeConfiguration(protocol = "http", hostname = "localhost", port = 8732)
             ),
             TezosConfiguration(
               "alphanet-staging",
-              Newest,
               TezosNodeConfiguration(protocol = "https", hostname = "nautilus.cryptonomic.tech", port = 8732, pathPrefix = "tezos/alphanet/")
             )
           )

--- a/src/test/scala/tech/cryptonomic/conseil/util/ConfigUtilTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/util/ConfigUtilTest.scala
@@ -69,12 +69,10 @@ class ConfigUtilTest extends WordSpec with Matchers {
       platforms.values.flatten should contain only (
         TezosConfiguration(
           "alphanet",
-          Newest,
           TezosNodeConfiguration(hostname = "localhost", port = 8732, protocol = "http")
         ),
         TezosConfiguration(
           "alphanet-staging",
-          Newest,
           TezosNodeConfiguration(hostname = "nautilus.cryptonomic.tech", port = 8732, protocol = "https", pathPrefix = "tezos/alphanet/")
         )
       )
@@ -114,7 +112,6 @@ class ConfigUtilTest extends WordSpec with Matchers {
       platforms.values.flatten should contain only (
         TezosConfiguration(
           "alphanet",
-          Newest,
           TezosNodeConfiguration(hostname = "localhost", port = 8732, protocol = "http")
         ),
         UnknownPlatformConfiguration("some-network")


### PR DESCRIPTION
I followed @vishakh's advice to create ``--headHash`` parameter because I couldn't find a method in Tezos API to get a block by level.

This PR introduces ``--headHash`` to Lorre option which changes the default head block to a given one. Alongside with ``--depth`` it enables to fetch a given range of blocks in the middle of the chain.