### PR TITLE
#256 bytes support

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/dto/MichelsonExpression.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/dto/MichelsonExpression.scala
@@ -43,5 +43,8 @@ case class MichelsonIntConstant(int: Long) extends MichelsonExpression
 /* Class representing a string constant */
 case class MichelsonStringConstant(string: String) extends MichelsonExpression
 
+/* Class representing a bytes constant */
+case class MichelsonBytesConstant(bytes: String) extends MichelsonExpression
+
 /* Class representing an empty expression */
 case object MichelsonEmptyExpression extends MichelsonExpression

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParser.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParser.scala
@@ -89,6 +89,16 @@ object JsonParser {
   }
 
   /*
+   * Wrapper for bytes constant
+   *
+   * {"bytes": "0500"}
+   *
+   * */
+  case class JsonBytesConstant(bytes: String) extends JsonExpression {
+    override def toMichelsonExpression = MichelsonBytesConstant(bytes)
+  }
+
+  /*
    * Wrapper for instruction
    *
    * [{"prim": "DIP", "args": [[{"prim": "DUP"}]]}, [{"prim": "DIP", "args": [[{"prim": "NIL", "args": [{"prim": "operation"}]}]]}]]
@@ -161,7 +171,8 @@ object JsonParser {
       List[Decoder[JsonExpression]](
         Decoder[JsonType].widen,
         Decoder[JsonIntConstant].widen,
-        Decoder[JsonStringConstant].widen
+        Decoder[JsonStringConstant].widen,
+        Decoder[JsonBytesConstant].widen
       ).reduceLeft(_ or _)
 
     val decodeInstructionSequence: Decoder[JsonInstructionSequence] = _.as[List[JsonInstruction]].map(JsonInstructionSequence)

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/renderer/MichelsonRenderer.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/renderer/MichelsonRenderer.scala
@@ -26,6 +26,7 @@ object MichelsonRenderer {
       case MichelsonType(name, args, annotations) => s"($name ${(annotations ++ args.map(_.render())).mkString(" ")})"
       case MichelsonIntConstant(constant) => constant.toString
       case MichelsonStringConstant(constant) => "\"%s\"".format(constant)
+      case MichelsonBytesConstant(constant) => s"0x$constant"
       case MichelsonEmptyExpression => "{}"
 
       // code

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParserSpec.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParserSpec.scala
@@ -156,6 +156,26 @@ class JsonParserSpec extends FlatSpec with Matchers {
                 MichelsonStringConstant("0")))))))
   }
 
+  it should "parse MichelsonInstruction typed with bytes data" in {
+    val json =
+      """{
+        |  "prim": "PUSH",
+        |  "args": [
+        |    {
+        |      "prim": "bytes"
+        |    },
+        |    {
+        |      "bytes": "0500"
+        |    }
+        |  ]
+        |}""".stripMargin
+
+    parse[MichelsonInstruction](json) should equal(Right(
+      MichelsonSingleInstruction("PUSH", List(
+        MichelsonType("bytes"),
+        MichelsonBytesConstant("0500")))))
+  }
+
   it should "parse double embedded MichelsonInstruction" in {
     val json =
       """[

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/renderer/MichelsonRendererSpec.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/renderer/MichelsonRendererSpec.scala
@@ -26,6 +26,10 @@ class MichelsonRendererSpec extends FlatSpec with Matchers {
     MichelsonType("some", List(MichelsonStringConstant("testValue"))).render() shouldBe "(some \"testValue\")"
   }
 
+  it should "render MichelsonType with bytes constant" in {
+    MichelsonType("some", List(MichelsonBytesConstant("0500"))).render() shouldBe "(some 0x0500)"
+  }
+
   it should "render MichelsonType with annotation" in {
     val michelsonType = MichelsonType(
       prim = "pair",


### PR DESCRIPTION
During tests against ``mainnet`` I found following structure which wasn't handled by Michelson parser:
```
{
  "prim": "PUSH",
  "args": [
    {
      "prim": "bytes"
    },
    {
      "bytes": "0500"
    }
  ]
}
```

This PR adds support for this data type.