### PR TITLE
Filtering null values when fetching attribute values

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
@@ -303,7 +303,7 @@ object TezosDatabaseOperations extends LazyLogging {
     * @return       distinct elements in given column as a list
     */
   def selectDistinct(table: String, column: String)(implicit ec: ExecutionContext): DBIO[List[String]] = {
-    sql"""SELECT DISTINCT #$column FROM #$table""".as[String].map(_.toList)
+    sql"""SELECT DISTINCT #$column FROM #$table WHERE #$column IS NOT NULL""".as[String].map(_.toList)
   }
 
   /**
@@ -315,7 +315,7 @@ object TezosDatabaseOperations extends LazyLogging {
     * @return               distinct elements in given column as a list
     */
   def selectDistinctLike(table: String, column: String, matchingString: String)(implicit ec: ExecutionContext): DBIO[List[String]] = {
-    sql"""SELECT DISTINCT #$column FROM #$table WHERE #$column LIKE '%#$matchingString%'""".as[String].map(_.toList)
+    sql"""SELECT DISTINCT #$column FROM #$table WHERE #$column LIKE '%#$matchingString%' AND #$column IS NOT NULL""".as[String].map(_.toList)
   }
 
   /**


### PR DESCRIPTION
As reported by @umurb, certain API v2 queries for fetching attribute values, e.g. `/v2/metadata/tezos/alphanet/operations/delegatable`, keep failing. The underlying reason is the database query for fetching these values returns nulls and this causes a NullPointerException during the JSON encoding of the results. I have a made simple tweaks to the corresponding SQL statements so that nulls are never fetched from the database. 