### PR TITLE
Conseil cleanup dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,14 @@
 name := "Conseil"
 scalaVersion := "2.12.8"
 
-val akkaHttpVersion = "10.1.0"
-val akkaVersion = "2.5.19"
+val akkaVersion = "2.5.21"
+val akkaHttpVersion = "10.1.8"
+val akkaHttpJsonVersion = "1.25.2"
 val slickVersion = "3.3.0"
-val circeVersion = "0.11.0"
-val endpointsVersion = "0.8.0"
 val catsVersion = "1.6.0"
 val monocleVersion = "1.5.1-cats"
+val endpointsVersion = "0.9.0"
+val circeVersion = "0.11.1"
 
 scapegoatVersion in ThisBuild := "1.3.8"
 parallelExecution in Test := false
@@ -19,50 +20,52 @@ resolvers ++= Seq(
 )
 
 libraryDependencies  ++=  Seq(
-  "ch.qos.logback"                % "logback-classic"               % "1.2.3",
-  "com.typesafe"                  % "config"                        % "1.3.2",
-  "com.typesafe.scala-logging"   %% "scala-logging"                 % "3.7.2",
-  "com.typesafe.akka"            %% "akka-http"                     % akkaHttpVersion exclude("com.typesafe", "config"),
-  "com.typesafe.akka"            %% "akka-stream"                   % akkaVersion exclude("com.typesafe", "config"),
-  "com.typesafe.akka"            %% "akka-actor"                    % akkaVersion exclude("com.typesafe", "config"),
-  "de.heikoseeberger"            %% "akka-http-jackson"             % "1.22.0",
-  "ch.megard"                    %% "akka-http-cors"                % "0.3.0",
-  "org.scalaj"                   %% "scalaj-http"                   % "2.3.0",
-  "com.github.pureconfig"        %% "pureconfig"                    % "0.10.2",
-  "com.fasterxml.jackson.core"    % "jackson-databind"              % "2.9.0",
-  "com.fasterxml.jackson.module" %% "jackson-module-scala"          % "2.9.0",
-  "org.typelevel"                %% "cats-core"                     % catsVersion,
-  "com.github.julien-truffaut"   %% "monocle-core"                  % monocleVersion,
-  "com.github.julien-truffaut"   %% "monocle-macro"                 % monocleVersion,
-  "org.typelevel"                %% "mouse"                         % "0.20",
-  "com.kubukoz"                  %% "slick-effect"                  % "0.1.0",
-  "io.circe"                     %% "circe-core"                    % circeVersion,
-  "io.circe"                     %% "circe-parser"                  % circeVersion,
-  "io.circe"                     %% "circe-generic"                 % circeVersion,
-  "io.circe"                     %% "circe-generic-extras"          % circeVersion,
-  "de.heikoseeberger"            %% "akka-http-circe"               % "1.23.0" exclude("com.typesafe.akka", "akka-http"),
-  "org.julienrf"                 %% "endpoints-algebra"             % endpointsVersion,
-  "org.julienrf"                 %% "endpoints-openapi"             % endpointsVersion,
-  "org.julienrf"                 %% "endpoints-json-schema-generic" % endpointsVersion,
-  "org.julienrf"                 %% "endpoints-akka-http-server"    % endpointsVersion,
-  "com.chuusai"                  %% "shapeless"                     % "2.3.3",
-  "com.typesafe.slick"           %% "slick"                         % slickVersion exclude("org.reactivestreams", "reactive-streams") exclude("com.typesafe", "config") exclude("org.slf4j", "slf4j-api"),
-  "com.typesafe.slick"           %% "slick-hikaricp"                % slickVersion exclude("org.slf4j", "slf4j-api"),
-  "com.typesafe.slick"           %% "slick-codegen"                 % slickVersion,
-  "org.postgresql"                % "postgresql"                    % "42.1.4",
-  "com.madgag.spongycastle"       % "core"                          % "1.58.0.0",
-  "org.scorexfoundation"         %% "scrypto"                       % "2.0.0",
-  "com.muquit.libsodiumjna"       % "libsodium-jna"                 % "1.0.4" exclude("org.slf4j", "slf4j-log4j12") exclude("org.slf4j", "slf4j-api"),
-  "com.github.alanverbner"       %% "bip39"                         % "0.1",
-  "com.github.scopt"             %% "scopt"                         % "4.0.0-RC2",
-  "io.scalaland"                 %% "chimney"                       % "0.3.0",
-  "com.github.julien-truffaut"   %% "monocle-core"                  % monocleVersion,
-  "com.github.julien-truffaut"   %% "monocle-macro"                 % monocleVersion,
-  "org.scalatest"                %% "scalatest"                     % "3.0.4" % Test,
-  "com.stephenn"                 %% "scalatest-json-jsonassert"     % "0.0.3" % Test,
-  "org.scalamock"                %% "scalamock"                     % "4.0.0" % Test,
-  "ru.yandex.qatools.embed"       % "postgresql-embedded"           % "2.10" % Test,
-  "com.typesafe.akka"            %% "akka-http-testkit"             % akkaHttpVersion % Test exclude("com.typesafe", "config")
+  "ch.qos.logback"                   % "logback-classic"               % "1.2.3",
+  "com.typesafe"                     % "config"                        % "1.3.3",
+  "com.typesafe.scala-logging"      %% "scala-logging"                 % "3.7.2",
+  "com.typesafe.akka"               %% "akka-actor"                    % akkaVersion exclude("com.typesafe", "config"),
+  "com.typesafe.akka"               %% "akka-stream"                   % akkaVersion exclude("com.typesafe", "config"),
+  "com.typesafe.akka"               %% "akka-http"                     % akkaHttpVersion exclude("com.typesafe", "config"),
+  "com.typesafe.akka"               %% "akka-http-caching"             % akkaHttpVersion exclude("com.typesafe", "config"),
+  "de.heikoseeberger"               %% "akka-http-circe"               % akkaHttpJsonVersion exclude("com.typesafe.akka", "akka-http"),
+  "de.heikoseeberger"               %% "akka-http-jackson"             % akkaHttpJsonVersion exclude("com.fasterxml.jackson.core","jackson-databind") exclude("com.typesafe.akka", "akka-http"),
+  "ch.megard"                       %% "akka-http-cors"                % "0.3.4" exclude("com.typesafe.akka", "akka-http"),
+  "org.scalaj"                      %% "scalaj-http"                   % "2.4.1",
+  "com.github.pureconfig"           %% "pureconfig"                    % "0.10.2",
+  "com.fasterxml.jackson.core"       % "jackson-databind"              % "2.9.6" exclude("com.fasterxml.jackson.core", "jackson-annotations"),
+  "com.fasterxml.jackson.module"    %% "jackson-module-scala"          % "2.9.6",
+  "com.chuusai"                     %% "shapeless"                     % "2.3.3",
+  "org.typelevel"                   %% "cats-core"                     % catsVersion,
+  "org.typelevel"                   %% "mouse"                         % "0.20",
+  "com.github.julien-truffaut"      %% "monocle-core"                  % monocleVersion exclude("org.typelevel.cats", "cats-core"),
+  "com.github.julien-truffaut"      %% "monocle-macro"                 % monocleVersion exclude("org.typelevel.cats", "cats-core") exclude("org.typelevel.cats", "cats-macros"),
+  "org.julienrf"                    %% "endpoints-algebra"             % endpointsVersion,
+  "org.julienrf"                    %% "endpoints-openapi"             % endpointsVersion,
+  "org.julienrf"                    %% "endpoints-json-schema-generic" % endpointsVersion,
+  "org.julienrf"                    %% "endpoints-json-schema-circe"   % endpointsVersion,
+  "org.julienrf"                    %% "endpoints-akka-http-server"    % endpointsVersion,
+  "org.postgresql"                   % "postgresql"                    % "42.1.4",
+  "io.circe"                        %% "circe-core"                    % circeVersion,
+  "io.circe"                        %% "circe-parser"                  % circeVersion,
+  "io.circe"                        %% "circe-generic"                 % circeVersion,
+  "io.circe"                        %% "circe-generic-extras"          % circeVersion,
+  "com.typesafe.slick"              %% "slick"                         % slickVersion exclude("org.reactivestreams", "reactive-streams") exclude("com.typesafe", "config") exclude("org.slf4j", "slf4j-api"),
+  "com.typesafe.slick"              %% "slick-hikaricp"                % slickVersion exclude("org.slf4j", "slf4j-api"),
+  "com.typesafe.slick"              %% "slick-codegen"                 % slickVersion,
+  "com.kubukoz"                     %% "slick-effect"                  % "0.1.0" exclude("com.typesafe.slick", "slick"),
+  "org.postgresql"                   % "postgresql"                    % "42.1.4",
+  "com.github.scopt"                %% "scopt"                         % "4.0.0-RC2",
+  "io.scalaland"                    %% "chimney"                       % "0.3.1",
+  "com.madgag.spongycastle"          % "core"                          % "1.58.0.0",
+  "org.scorexfoundation"            %% "scrypto"                       % "2.0.0",
+  "com.muquit.libsodiumjna"          % "libsodium-jna"                 % "1.0.4" exclude("org.slf4j", "slf4j-log4j12") exclude("org.slf4j", "slf4j-api"),
+  "com.github.alanverbner"          %% "bip39"                         % "0.1",
+  "com.typesafe.akka"               %% "akka-testkit"                  % akkaVersion % Test exclude("com.typesafe", "config"),
+  "com.typesafe.akka"               %% "akka-http-testkit"             % akkaHttpVersion % Test exclude("com.typesafe", "config"),
+  "org.scalatest"                   %% "scalatest"                     % "3.0.5" % Test,
+  "com.stephenn"                    %% "scalatest-json-jsonassert"     % "0.0.3" % Test,
+  "org.scalamock"                   %% "scalamock"                     % "4.0.0" % Test,
+  "ru.yandex.qatools.embed"          % "postgresql-embedded"           % "2.10" % Test
 )
 
 excludeDependencies ++= Seq(

--- a/src/main/scala/tech/cryptonomic/conseil/Conseil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Conseil.scala
@@ -83,9 +83,7 @@ object Conseil extends App with LazyLogging with EnableCORSDirectives with Conse
       pathPrefix("swagger-ui") {
         getFromResourceDirectory("web/swagger-ui/")
       } ~
-      path("openapi.json") {
-        complete(OpenApiDoc.openapiJson)
-      }
+      Docs.route
 
       val bindingFuture = Http().bindAndHandle(route, server.hostname, server.port)
       displayInfo(server)

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
@@ -16,9 +16,6 @@ import scala.concurrent.{ExecutionContext, Future}
 object DataTypes {
   import io.scalaland.chimney.dsl._
 
-  /** Type representing Map[String, Any] */
-  type AnyMap = Map[String, Any]
-
   /** Type representing Map[String, Option[Any]] for query response */
   type QueryResponse = Map[String, Option[Any]]
   /** Default value of limit parameter */

--- a/src/main/scala/tech/cryptonomic/conseil/routes/Data.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/Data.scala
@@ -40,6 +40,7 @@ class Data(config: PlatformsConfiguration, queryProtocolPlatform: DataPlatform, 
    * as long as it doesn't create issues or performance degradation
    */
   override val asyncApiFiltersExecutionContext: ExecutionContext = apiExecutionContext
+
   /** V2 Route implementation for query endpoint */
   val postRoute: Route = queryEndpoint.implementedByAsync {
     case ((platform, network, entity), apiQuery, _) =>

--- a/src/main/scala/tech/cryptonomic/conseil/routes/DataHelpers.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/DataHelpers.scala
@@ -1,21 +1,22 @@
 package tech.cryptonomic.conseil.routes
 
-import java.sql.Timestamp
-
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.util.ByteString
 import cats.Functor
-import endpoints.akkahttp
+import endpoints.akkahttp.server
 import endpoints.algebra.Documentation
 import tech.cryptonomic.conseil.generic.chain.DataTypes._
-import tech.cryptonomic.conseil.routes.openapi.{DataEndpoints, QueryStringListsServer, Validation}
+import tech.cryptonomic.conseil.routes.openapi.{DataEndpoints, Validation}
 import tech.cryptonomic.conseil.tezos.Tables
 
 /** Trait with helpers needed for data routes */
-trait DataHelpers extends QueryStringListsServer with Validation with akkahttp.server.Endpoints
-  with akkahttp.server.JsonSchemaEntities with DataEndpoints {
+trait DataHelpers
+  extends Validation
+  with server.Endpoints
+  with server.JsonSchemaEntities
+  with DataEndpoints {
 
   import io.circe._
   import io.circe.syntax._
@@ -94,19 +95,4 @@ trait DataHelpers extends QueryStringListsServer with Validation with akkahttp.s
       override def decoder: Decoder[List[QueryResponse]] = ???
     }
 
-  /** Blocks by hash JSON schema implementation */
-  override implicit def blocksByHashSchema: JsonSchema[AnyMap] = new JsonSchema[AnyMap] {
-    override def encoder: Encoder[AnyMap] = (a: AnyMap) => Json.obj(a.map {
-      case (k, v) => (k, v.asJson(anyEncoder))
-    }.toList: _*)
-
-    override def decoder: Decoder[AnyMap] = ???
-  }
-
-  /** Timestamp JSON schema implementation */
-  override implicit def timestampSchema: JsonSchema[Timestamp] = new JsonSchema[Timestamp] {
-    override def encoder: Encoder[Timestamp] = (a: Timestamp) => a.getTime.asJson
-
-    override def decoder: Decoder[Timestamp] = ???
-  }
 }

--- a/src/main/scala/tech/cryptonomic/conseil/routes/Docs.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/Docs.scala
@@ -1,0 +1,21 @@
+package tech.cryptonomic.conseil.routes
+
+import tech.cryptonomic.conseil.routes.openapi.OpenApiDoc
+import endpoints.akkahttp.server
+import endpoints.openapi.model
+
+/** implements a server endpoint to provide
+  * the openapi definition as a json file
+  */
+object Docs
+  extends server.Endpoints
+  with model.OpenApiSchemas
+  with server.JsonSchemaEntities {
+
+  val route = endpoint(
+    request = get(
+      url = path / "openapi.json"
+    ),
+    response = jsonResponse[model.OpenApi]()
+  ).implementedBy(_ => OpenApiDoc.openapi)
+}

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/ApiFilterFromQueryString.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/ApiFilterFromQueryString.scala
@@ -6,7 +6,7 @@ import endpoints.algebra
 import tech.cryptonomic.conseil.tezos.ApiOperations.Filter
 
 /** Trait containing helper functions which are necessary for parsing query parameter strings as Filter  */
-trait ApiFilterFromQueryString extends QueryStringLists { self: algebra.JsonSchemaEntities =>
+trait ApiFilterFromQueryString { self: algebra.JsonSchemaEntities =>
   import tech.cryptonomic.conseil.routes.openapi.TupleFlattenHelper._
   import FlattenHigh._
 
@@ -35,21 +35,21 @@ trait ApiFilterFromQueryString extends QueryStringLists { self: algebra.JsonSche
   /** Function for extracting query string with query params */
   private def filterQs: QueryString[QueryParams] = {
     val raw =
-      optQs[Int]("limit") &
-        qsList[String]("block_id") &
-        qsList[Int]("block_level") &
-        qsList[String]("block_netid") &
-        qsList[String]("block_protocol") &
-        qsList[String]("operation_id") &
-        qsList[String]("operation_source") &
-        qsList[String]("operation_destination") &
-        qsList[String]("operation_participant") &
-        qsList[String]("operation_kind") &
-        qsList[String]("account_id") &
-        qsList[String]("account_manager") &
-        qsList[String]("account_delegate") &
-        optQs[String]("sort_by") &
-        optQs[String]("order")
+      qs[Option[Int]]("limit") &
+      qs[List[String]]("block_id") &
+      qs[List[Int]]("block_level") &
+      qs[List[String]]("block_netid") &
+      qs[List[String]]("block_protocol") &
+      qs[List[String]]("operation_id") &
+      qs[List[String]]("operation_source") &
+      qs[List[String]]("operation_destination") &
+      qs[List[String]]("operation_participant") &
+      qs[List[String]]("operation_kind") &
+      qs[List[String]]("account_id") &
+      qs[List[String]]("account_manager") &
+      qs[List[String]]("account_delegate") &
+      qs[Option[String]]("sort_by") &
+      qs[Option[String]]("order")
     raw map (flatten(_))
   }
 

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/AppInfoJsonSchemas.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/AppInfoJsonSchemas.scala
@@ -1,10 +1,10 @@
 package tech.cryptonomic.conseil.routes.openapi
 
-import endpoints.{algebra, generic}
+import endpoints.generic
 import tech.cryptonomic.conseil.routes.AppInfo.Info
 
 /** Trait containing AppInfo schema */
-trait AppInfoJsonSchemas extends algebra.JsonSchemas with generic.JsonSchemas {
+trait AppInfoJsonSchemas extends generic.JsonSchemas {
   /** AppInfo JSON schema */
   implicit def appInfoSchema: JsonSchema[Info] =
     genericJsonSchema[Info]

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/AppInfoJsonSchemas.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/AppInfoJsonSchemas.scala
@@ -6,6 +6,6 @@ import tech.cryptonomic.conseil.routes.AppInfo.Info
 /** Trait containing AppInfo schema */
 trait AppInfoJsonSchemas extends generic.JsonSchemas {
   /** AppInfo JSON schema */
-  implicit def appInfoSchema: JsonSchema[Info] =
+  implicit lazy val appInfoSchema: JsonSchema[Info] =
     genericJsonSchema[Info]
 }

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataEndpoints.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataEndpoints.scala
@@ -2,7 +2,7 @@ package tech.cryptonomic.conseil.routes.openapi
 
 import endpoints.algebra
 import tech.cryptonomic.conseil.generic.chain.DataTypes._
-import tech.cryptonomic.conseil.tezos.ApiOperations.Filter
+import tech.cryptonomic.conseil.tezos.ApiOperations.{Filter, BlockResult, OperationGroupResult, AccountResult}
 import tech.cryptonomic.conseil.tezos.FeeOperations.AverageFees
 import tech.cryptonomic.conseil.tezos.Tables
 import tech.cryptonomic.conseil.tezos.Tables.BlocksRow
@@ -52,12 +52,12 @@ trait DataEndpoints
     )
 
   /** V2 Blocks by hash endpoint definition */
-  def blockByHashEndpoint: Endpoint[((String, String, String), String), Option[AnyMap]] =
+  def blockByHashEndpoint: Endpoint[((String, String, String), String), Option[BlockResult]] =
     endpoint(
       request = get(
         url = commonPath / "blocks" / segment[String](name = "hash"),
         headers = header("apiKey")),
-      response = compatibilityQuery[AnyMap]("block by hash"),
+      response = compatibilityQuery[BlockResult]("block by hash"),
       tags = List("Blocks")
     )
 
@@ -72,12 +72,12 @@ trait DataEndpoints
     )
 
   /** V2 Accounts by ID endpoint definition */
-  def accountByIdEndpoint: Endpoint[((String, String, String), String), Option[AnyMap]] =
+  def accountByIdEndpoint: Endpoint[((String, String, String), String), Option[AccountResult]] =
     endpoint(
       request = get(
         url = path / "v2" / "data" / segment[String](name = "platform") / segment[String](name = "network") / "accounts" / segment[String](name = "accountId"),
         headers = header("apiKey")),
-      response = compatibilityQuery[AnyMap]("account"),
+      response = compatibilityQuery[AccountResult]("account"),
       tags = List("Accounts")
     )
 
@@ -92,12 +92,12 @@ trait DataEndpoints
     )
 
   /** V2 Operation groups by ID endpoint definition */
-  def operationGroupByIdEndpoint: Endpoint[((String, String, String), String), Option[AnyMap]] =
+  def operationGroupByIdEndpoint: Endpoint[((String, String, String), String), Option[OperationGroupResult]] =
     endpoint(
       request = get(
         url = commonPath / "operation_groups" / segment[String](name = "operationGroupId"),
         headers = header("apiKey")),
-      response = compatibilityQuery[AnyMap]("operation group"),
+      response = compatibilityQuery[OperationGroupResult]("operation group"),
       tags = List("Operation groups")
     )
 

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataJsonSchemas.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataJsonSchemas.scala
@@ -10,31 +10,31 @@ import tech.cryptonomic.conseil.tezos.Tables.{AccountsRow, BlocksRow, OperationG
 trait DataJsonSchemas extends generic.JsonSchemas {
 
   /** API query schema */
-  implicit def queryRequestSchema: JsonSchema[ApiQuery] =
+  implicit lazy val queryRequestSchema: JsonSchema[ApiQuery] =
     genericJsonSchema[ApiQuery]
 
   /** Query predicate schema */
-  implicit def queryPredicateSchema: JsonSchema[Predicate] =
+  implicit lazy val queryPredicateSchema: JsonSchema[Predicate] =
     genericJsonSchema[Predicate]
 
   /** Query ordering operation schema */
-  implicit def queryOrderingOperationSchema: JsonSchema[OperationType.Value] =
+  implicit lazy val queryOrderingOperationSchema: JsonSchema[OperationType.Value] =
     enumeration(OperationType.values.toSeq)(_.toString)
 
   /** Query ordering schema */
-  implicit def queryOrderingSchema: JsonSchema[QueryOrdering] =
+  implicit lazy val queryOrderingSchema: JsonSchema[QueryOrdering] =
     genericJsonSchema[QueryOrdering]
 
   /** Query ordering direction schema */
-  implicit def queryOrderingDirectionSchema: JsonSchema[OrderDirection.Value] =
+  implicit lazy val queryOrderingDirectionSchema: JsonSchema[OrderDirection.Value] =
     enumeration(OrderDirection.values.toSeq)(_.toString)
 
   /** Query output schema */
-  implicit def queryOutputSchema: JsonSchema[OutputType.Value] =
+  implicit lazy val queryOutputSchema: JsonSchema[OutputType.Value] =
     enumeration(OutputType.values.toSeq)(_.toString)
 
   /** Timestamp schema */
-  implicit def timestampSchema: JsonSchema[java.sql.Timestamp] = {
+  implicit lazy val timestampSchema: JsonSchema[java.sql.Timestamp] = {
     xmapJsonSchema[Long, java.sql.Timestamp](
       implicitly[JsonSchema[Long]],
       millisFromEpoch => new java.sql.Timestamp(millisFromEpoch),
@@ -43,15 +43,15 @@ trait DataJsonSchemas extends generic.JsonSchemas {
   }
 
   /** Blocks row schema */
-  implicit def blocksRowSchema: JsonSchema[BlocksRow] =
+  implicit lazy val blocksRowSchema: JsonSchema[BlocksRow] =
     genericJsonSchema[BlocksRow]
 
   /** Operation groups row schema */
-  implicit def operationGroupsRowSchema: JsonSchema[OperationGroupsRow] =
+  implicit lazy val operationGroupsRowSchema: JsonSchema[OperationGroupsRow] =
     genericJsonSchema[OperationGroupsRow]
 
   /** Average fees schema */
-  implicit def avgFeeSchema: JsonSchema[AverageFees] =
+  implicit lazy val avgFeeSchema: JsonSchema[AverageFees] =
     genericJsonSchema[AverageFees]
 
   /** Any schema */
@@ -64,23 +64,23 @@ trait DataJsonSchemas extends generic.JsonSchemas {
   implicit def queryResponseSchemaWithOutputType: JsonSchema[QueryResponseWithOutput]
 
   /** Operation row schema */
-  implicit def operationRowSchema: JsonSchema[OperationsRow] =
+  implicit lazy val operationsRowSchema: JsonSchema[OperationsRow] =
     genericJsonSchema[OperationsRow]
 
   /** Accounts row schema */
-  implicit def accountsRowSchema: JsonSchema[AccountsRow] =
+  implicit lazy val accountsRowSchema: JsonSchema[AccountsRow] =
     genericJsonSchema[AccountsRow]
 
   /** api operation results schema for blocks */
-  implicit def blockResultSchema: JsonSchema[BlockResult] =
+  implicit lazy val blockResultSchema: JsonSchema[BlockResult] =
     genericJsonSchema[BlockResult]
 
   /** api operation results schema for operation groups */
-  implicit def operationGroupResultSchema: JsonSchema[OperationGroupResult] =
+  implicit lazy val operationGroupResultSchema: JsonSchema[OperationGroupResult] =
     genericJsonSchema[OperationGroupResult]
 
   /** api operation results schema for accounts */
-  implicit def accountResultSchema: JsonSchema[AccountResult] =
+  implicit lazy val accountResultSchema: JsonSchema[AccountResult] =
     genericJsonSchema[AccountResult]
 
 }

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataJsonSchemas.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataJsonSchemas.scala
@@ -1,12 +1,13 @@
 package tech.cryptonomic.conseil.routes.openapi
 
-import endpoints.{algebra, generic}
+import endpoints.generic
 import tech.cryptonomic.conseil.generic.chain.DataTypes._
 import tech.cryptonomic.conseil.tezos.FeeOperations.AverageFees
+import tech.cryptonomic.conseil.tezos.ApiOperations.{BlockResult, OperationGroupResult, AccountResult}
 import tech.cryptonomic.conseil.tezos.Tables.{AccountsRow, BlocksRow, OperationGroupsRow, OperationsRow}
 
 /** Trait containing Data endpoints JSON schemas */
-trait DataJsonSchemas extends algebra.JsonSchemas with generic.JsonSchemas {
+trait DataJsonSchemas extends generic.JsonSchemas {
 
   /** API query schema */
   implicit def queryRequestSchema: JsonSchema[ApiQuery] =
@@ -32,9 +33,14 @@ trait DataJsonSchemas extends algebra.JsonSchemas with generic.JsonSchemas {
   implicit def queryOutputSchema: JsonSchema[OutputType.Value] =
     enumeration(OutputType.values.toSeq)(_.toString)
 
-
   /** Timestamp schema */
-  implicit def timestampSchema: JsonSchema[java.sql.Timestamp]
+  implicit def timestampSchema: JsonSchema[java.sql.Timestamp] = {
+    xmapJsonSchema[Long, java.sql.Timestamp](
+      implicitly[JsonSchema[Long]],
+      millisFromEpoch => new java.sql.Timestamp(millisFromEpoch),
+      ts => ts.getTime
+    )
+  }
 
   /** Blocks row schema */
   implicit def blocksRowSchema: JsonSchema[BlocksRow] =
@@ -57,15 +63,24 @@ trait DataJsonSchemas extends algebra.JsonSchemas with generic.JsonSchemas {
   /** Query response schema with output type */
   implicit def queryResponseSchemaWithOutputType: JsonSchema[QueryResponseWithOutput]
 
-  /** AnyMap schema */
-  implicit def blocksByHashSchema: JsonSchema[AnyMap]
-
   /** Operation row schema */
-  implicit def operationsRowSchema: JsonSchema[OperationsRow] =
+  implicit def operationRowSchema: JsonSchema[OperationsRow] =
     genericJsonSchema[OperationsRow]
 
   /** Accounts row schema */
   implicit def accountsRowSchema: JsonSchema[AccountsRow] =
     genericJsonSchema[AccountsRow]
+
+  /** api operation results schema for blocks */
+  implicit def blockResultSchema: JsonSchema[BlockResult] =
+    genericJsonSchema[BlockResult]
+
+  /** api operation results schema for operation groups */
+  implicit def operationGroupResultSchema: JsonSchema[OperationGroupResult] =
+    genericJsonSchema[OperationGroupResult]
+
+  /** api operation results schema for accounts */
+  implicit def accountResultSchema: JsonSchema[AccountResult] =
+    genericJsonSchema[AccountResult]
 
 }

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/OpenApiDoc.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/OpenApiDoc.scala
@@ -3,22 +3,16 @@ package tech.cryptonomic.conseil.routes.openapi
 import cats.Functor
 import endpoints.algebra.Documentation
 import endpoints.openapi
-import endpoints.openapi.model._
-import io.circe.Json
-import io.circe.syntax._
+import endpoints.openapi.model.{MediaType, Schema, Info, OpenApi}
 
 /** OpenAPI documentation object */
 object OpenApiDoc extends DataEndpoints
   with PlatformDiscoveryEndpoints
   with TezosEndpoints
   with AppInfoEndpoint
-  with openapi.Endpoints
+  with openapi.model.OpenApiSchemas
   with openapi.JsonSchemaEntities
   with openapi.BasicAuthentication {
-
-  /** OpenAPI JSON */
-  def openapiJson: Json =
-    openapi.asJson
 
   /** OpenAPI definition */
   def openapi: OpenApi = openApi(Info("Conseil API", "0.0.1"))(
@@ -58,7 +52,7 @@ object OpenApiDoc extends DataEndpoints
       status = 400,
       documentation = invalidDocs.getOrElse(""),
       content = Map(
-        "application/json" -> MediaType(schema = Some(Schema.Array(Schema.simpleString)))
+        "application/json" -> MediaType(schema = Some(Schema.Array(Schema.simpleString, None)))
       )
     ) :+ OpenApiDoc.DocumentedResponse(
       status = 200,
@@ -75,23 +69,10 @@ object OpenApiDoc extends DataEndpoints
   /** Documented JSON schema for query response */
   override implicit def queryResponseSchema: DocumentedJsonSchema = DocumentedJsonSchema.Primitive("Any - not yet supported")
 
-  /** Documented query string for query string list */
-  override def qsList[A: QueryStringParam](name: String, docs: Option[String]): DocumentedQueryString = DocumentedQueryString(
-    List(
-      DocumentedParameter(name, required = false, docs, Schema.Array(implicitly[QueryStringParam[A]]))
-    )
-  )
-
   /** Documented query string for functor */
   override implicit def qsFunctor: Functor[QueryString] = new Functor[QueryString] {
     override def map[From, To](f: OpenApiDoc.DocumentedQueryString)(map: From => To): OpenApiDoc.DocumentedQueryString = f
   }
 
-  /** Documented JSON schema for timestamp */
-  override implicit def timestampSchema: DocumentedJsonSchema = DocumentedJsonSchema.Primitive("integer")
-
-  /** Documented JSON schema for blocks by hash */
-  override implicit def blocksByHashSchema: DocumentedJsonSchema = DocumentedJsonSchema.Primitive("Any - not yet supported")
-
-  override implicit def queryResponseSchemaWithOutputType: OpenApiDoc.DocumentedJsonSchema = DocumentedJsonSchema.Primitive("Any - not yet supported")
+  override implicit def queryResponseSchemaWithOutputType: DocumentedJsonSchema = DocumentedJsonSchema.Primitive("Any - not yet supported")
 }

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/PlatformDiscoveryJsonSchemas.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/PlatformDiscoveryJsonSchemas.scala
@@ -7,26 +7,26 @@ import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes._
 trait PlatformDiscoveryJsonSchemas extends generic.JsonSchemas {
 
   /** Platform JSON schema */
-  implicit def platformSchema: JsonSchema[Platform] =
+  implicit lazy val platformSchema: JsonSchema[Platform] =
     genericJsonSchema[Platform]
 
   /** Network JSON schema */
-  implicit def networkSchema: JsonSchema[Network] =
+  implicit lazy val networkSchema: JsonSchema[Network] =
     genericJsonSchema[Network]
 
   /** Entity JSON schema */
-  implicit def entitySchema: JsonSchema[Entity] =
+  implicit lazy val entitySchema: JsonSchema[Entity] =
     genericJsonSchema[Entity]
 
   /** Attribute JSON schema */
-  implicit def attributeSchema: JsonSchema[Attribute] =
+  implicit lazy val attributeSchema: JsonSchema[Attribute] =
     genericJsonSchema[Attribute]
 
   /** Data type JSON schema */
-  implicit def dataTypeSchema: JsonSchema[DataType.Value] =
+  implicit lazy val dataTypeSchema: JsonSchema[DataType.Value] =
     enumeration(DataType.values.toSeq)(_.toString)
 
   /** Key type JSON schema */
-  implicit def keyTypeSchema: JsonSchema[KeyType.Value] =
+  implicit lazy val keyTypeSchema: JsonSchema[KeyType.Value] =
     enumeration(KeyType.values.toSeq)(_.toString)
 }

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/PlatformDiscoveryJsonSchemas.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/PlatformDiscoveryJsonSchemas.scala
@@ -1,10 +1,10 @@
 package tech.cryptonomic.conseil.routes.openapi
 
-import endpoints.{algebra, generic}
+import endpoints.generic
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes._
 
 /** Trait containing metadata endpoints JSON schemas */
-trait PlatformDiscoveryJsonSchemas extends algebra.JsonSchemas with generic.JsonSchemas {
+trait PlatformDiscoveryJsonSchemas extends generic.JsonSchemas {
 
   /** Platform JSON schema */
   implicit def platformSchema: JsonSchema[Platform] =

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/QueryStringLists.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/QueryStringLists.scala
@@ -1,7 +1,0 @@
-package tech.cryptonomic.conseil.routes.openapi
-
-/** Trait adding parsing query strings as a lists */
-trait QueryStringLists { self: endpoints.algebra.Urls =>
-  /** Method for adding parsing query strings as a lists */
-  def qsList[A: QueryStringParam](name: String, docs: Option[String] = None): QueryString[List[A]]
-}

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/QueryStringListsServer.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/QueryStringListsServer.scala
@@ -1,9 +1,0 @@
-package tech.cryptonomic.conseil.routes.openapi
-import akka.http.scaladsl.server.Directives._
-
-/** Trait providing query string list implementation for akka-http server */
-trait QueryStringListsServer extends QueryStringLists with endpoints.akkahttp.server.Endpoints {
-  /** Implementation of the query string list parsing for query params */
-  def qsList[A: QueryStringParam](name: String, docs: Option[String] = None): QueryString[List[A]] =
-    new QueryString[List[A]](parameter(name.as[A].*).map(_.toList))
-}

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/TezosEndpoints.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/TezosEndpoints.scala
@@ -1,7 +1,6 @@
 package tech.cryptonomic.conseil.routes.openapi
 
 import endpoints.algebra
-import tech.cryptonomic.conseil.generic.chain.DataTypes.AnyMap
 import tech.cryptonomic.conseil.tezos.ApiOperations
 import tech.cryptonomic.conseil.tezos.FeeOperations.AverageFees
 import tech.cryptonomic.conseil.tezos.Tables.{AccountsRow, BlocksRow, OperationGroupsRow, OperationsRow}
@@ -31,12 +30,12 @@ trait TezosEndpoints extends algebra.Endpoints with DataJsonSchemas with ApiFilt
     )
 
   /** Blocks by hash endpoint definition */
-  def blockByHashEndpointV1: Endpoint[(String, String, String), Option[AnyMap]] =
+  def blockByHashEndpointV1: Endpoint[(String, String, String), Option[ApiOperations.BlockResult]] =
     endpoint(
       request = get(
         url = commonPath / "blocks" / segment[String](name = "hash"),
         headers = header("apiKey")),
-      response = jsonResponse[AnyMap](docs = Some("Endpoint for block")).orNotFound(Some("Not found")),
+      response = jsonResponse[ApiOperations.BlockResult](docs = Some("Endpoint for block")).orNotFound(Some("Not found")),
       tags = List("Blocks")
     )
 
@@ -51,12 +50,12 @@ trait TezosEndpoints extends algebra.Endpoints with DataJsonSchemas with ApiFilt
     )
 
   /** Accounts by ID endpoint definition */
-  def accountByIdEndpointV1: Endpoint[(String, String, String), Option[AnyMap]] =
+  def accountByIdEndpointV1: Endpoint[(String, String, String), Option[ApiOperations.AccountResult]] =
     endpoint(
       request = get(
         url = commonPath / "accounts" / segment[String](name = "accountId"),
         headers = header("apiKey")),
-      response = jsonResponse[AnyMap](docs = Some("Endpoint for account")).orNotFound(Some("Not found")),
+      response = jsonResponse[ApiOperations.AccountResult](docs = Some("Endpoint for account")).orNotFound(Some("Not found")),
       tags = List("Accounts")
     )
 
@@ -71,12 +70,12 @@ trait TezosEndpoints extends algebra.Endpoints with DataJsonSchemas with ApiFilt
     )
 
   /** Operation groups by ID endpoint definition */
-  def operationGroupByIdEndpointV1: Endpoint[(String, String, String), Option[AnyMap]] =
+  def operationGroupByIdEndpointV1: Endpoint[(String, String, String), Option[ApiOperations.OperationGroupResult]] =
     endpoint(
       request = get(
         url = commonPath / "operation_groups" / segment[String](name = "operationGroupId"),
         headers = header("apiKey")),
-      response = jsonResponse[AnyMap](docs = Some("Endpoint for operation group")).orNotFound(Some("Not found")),
+      response = jsonResponse[ApiOperations.OperationGroupResult](docs = Some("Endpoint for operation group")).orNotFound(Some("Not found")),
       tags = List("Operation groups")
     )
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
@@ -331,7 +331,7 @@ object ApiOperations extends DataOperations with MetadataOperations {
 
     dbHandle.run(fetchOperation).map{
       accounts =>
-        accounts.headOption.map(AccountResult(_))
+        accounts.headOption.map(AccountResult)
     }
   }
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -10,7 +10,6 @@ import tech.cryptonomic.conseil.tezos.TezosTypes.Lenses._
 import tech.cryptonomic.conseil.tezos.michelson.JsonToMichelson.convert
 import tech.cryptonomic.conseil.tezos.michelson.dto.{MichelsonCode, MichelsonElement, MichelsonExpression, MichelsonSchema}
 import tech.cryptonomic.conseil.tezos.michelson.parser.JsonParser.Parser
-import tech.cryptonomic.conseil.generic.chain.DataTypes.AnyMap
 
 import cats.instances.future._
 import cats.syntax.applicative._
@@ -423,6 +422,9 @@ class TezosNodeSenderOperator(override val node: TezosRPCInterface, network: Str
   import com.muquit.libsodiumjna.{SodiumKeyPair, SodiumLibrary, SodiumUtils}
   import TezosNodeOperator._
 
+  /** Type representing Map[String, Any] */
+  type AnyMap = Map[String, Any]
+
   //used in subsequent operations using Sodium
   SodiumLibrary.setLibraryPath(sodiumConf.libraryPath)
 
@@ -459,7 +461,7 @@ class TezosNodeSenderOperator(override val node: TezosRPCInterface, network: Str
   def forgeOperations(
     blockHead: Block,
     account: Account,
-    operations: List[Map[String,Any]],
+    operations: List[AnyMap],
     keyStore: KeyStore,
     fee: Option[Float]): Future[String] = {
     val payload: AnyMap = fee match {

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
@@ -1466,6 +1466,8 @@ class TezosDatabaseOperationsTest
     }
 
     "return the same results for the same query" in {
+      type AnyMap = Map[String, Any]
+
       import tech.cryptonomic.conseil.util.DatabaseUtil.QueryBuilder._
       val columns = List("level", "proto", "protocol", "hash")
       val tableName = Tables.Blocks.baseTableRow.tableName


### PR DESCRIPTION
Bumps all stale versions in the dependencies, and "excludes" all conflicting cases.

- The change opened the opportunity to remove some custom code for the endpoints definitions and to make some return value more precisely typed.
- There were conflicting mix-in if we tried to define the open-api main file and to expose it as json in the same endpoint interpreter, so now we have splitted the publishing in a separately-defined route interpreter