### PR TITLE
Conseil 301: Interleave the account processing with block batches

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
@@ -79,7 +79,6 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
     val noOp = Future.successful(())
     val processing = for {
       _ <- processTezosBlocks()
-      _ <- processTezosAccounts()
       _ <-
         if (iteration % lorreConf.feeUpdateInterval == 0)
           FeeOperations.processTezosAverageFees(lorreConf.numberOfFeesAveraged)
@@ -126,6 +125,9 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
     * Additionally stores account references that needs updating, too
     */
   private[this] def processTezosBlocks(): Future[Done] = {
+    import cats.instances.future._
+    import cats.syntax.apply._
+
     logger.info("Processing Tezos Blocks..")
 
     val blockPagesToSynchronize = tezosConf.depth match {
@@ -174,7 +176,9 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
         pages.foldLeft(0) {
           (processed, nextPage) =>
             //wait for each page to load, before looking at the next, thus  starting the new computation
-            val justDone = Await.result(processBlocksPage(nextPage), atMost = 5.minutes)
+            val justDone = Await.result(
+              processBlocksPage(nextPage) <* processTezosAccounts(),
+              atMost = 5.minutes)
             processed + justDone <| logProgress
         }
       })
@@ -251,7 +255,7 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
 
     val saveAccounts = db.run(TezosDb.getLatestAccountsFromCheckpoint) map {
       checkpoints =>
-        logger.info("I loaded all stored account references and will proceed to fetch updated information from the chain")
+        logger.debug("I loaded all stored account references and will proceed to fetch updated information from the chain")
         val (pages, total) = tezosNodeOperator.getAccountsForBlocks(checkpoints)
         //custom progress tracking for accounts
         val logProgress = logProcessingProgress(entityName = "account", totalToProcess = total, processStartNanos = System.nanoTime()) _
@@ -271,7 +275,7 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
         checkpoints
     }
 
-    logger.info("Selecting all accounts touched in the checkpoint table, this might take a while...")
+    logger.debug("Selecting all accounts touched in the checkpoint table, this might take a while...")
     saveAccounts.andThen {
       //additional cleanup, that can fail with no downsides
       case Success(checkpoints) =>


### PR DESCRIPTION
fix #301 
Instead of handling accounts after all blocks are synced, now we do it after each page of new blocks is done.

This way, for long-running syncs -- as in bootstrapping a new db -- we process accounts more often than actually needed, overwriting the results as each new block page is synced.
Yet the marginal impact should be relatively minor, considered the upsides:
1. querying for all updated accounts is now a reasonable operation, given the size is limited to how many accounts might be updated for a single block page (500 blocks, but configurable)
2. after each block batch is done, accounts are processed too, so an interrupted execution can probably leave the database consistent with the block level reached up-to-failure, including account data
3. lemma of 2 is that the accounts are updated in real-time while lorre is executing, which might give a visual cue to anyone running a client, instead of an empty balance
4. the progress shown by the logs can now be considered valid for the whole sync operation, which will complete soon after blocks are done 100%, and will give an ETA on the whole completion

Marginal Note: I left the paged processing for accounts too, considering that
- they can be a consistent number for each block batch too, probably growing with more recent blocks
- the block paging size is configurable, so the accounts loaded per step can grow too