### PR TITLE
Aggregation and DateTime fixes

### DIFF
--- a/doc/MetadataAndQuery.md
+++ b/doc/MetadataAndQuery.md
@@ -4,7 +4,8 @@ Description of endpoints with example usages. Probably all of those request will
 
 ## Query interface
 
-Query interface is using `POST` for passing the query
+Query interface is using `POST` for passing the query. Keep in mind that `DateTime` fields are represented as Unix timestamps in milliseconds.
+
 
 #### Example query
 ```

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
@@ -1,6 +1,7 @@
 package tech.cryptonomic.conseil.generic.chain
 
-import java.util.Date
+import java.time.{Instant, ZoneOffset}
+import java.time.format.DateTimeFormatter.ISO_INSTANT
 
 import tech.cryptonomic.conseil.generic.chain.DataTypes.AggregationType.AggregationType
 import tech.cryptonomic.conseil.generic.chain.DataTypes.OperationType.OperationType
@@ -37,7 +38,7 @@ object DataTypes {
         maybeAttributes.flatMap { attributes =>
           attributes.find(_.name == predicate.field).map {
             case attribute if attribute.dataType == DataType.DateTime =>
-              predicate.copy(set = predicate.set.map(x => dateToIso(new Date(x.toString.toLong))))
+              predicate.copy(set = predicate.set.map(x => formatToIso(x.toString.toLong)))
             case _ => predicate
           }
         }.toList
@@ -182,13 +183,11 @@ object DataTypes {
     }
   }
 
-  private def dateToIso(date: Date): String = {
-    import java.text.SimpleDateFormat
-    import java.util.TimeZone
-    val sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
-    sdf.setTimeZone(TimeZone.getTimeZone("CET"))
-    sdf.format(date)
-  }
+  /** Method formatting millis to ISO format */
+  def formatToIso(epochMillis: Long): String =
+    Instant.ofEpochMilli(epochMillis)
+      .atZone(ZoneOffset.UTC)
+      .format(ISO_INSTANT)
 
   /** Enumeration for output types */
   object OutputType extends Enumeration {

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
@@ -22,7 +22,12 @@ object DataTypes {
   /** Type representing Map[String, Option[Any]] for query response */
   type QueryResponse = Map[String, Option[Any]]
   /** Method checks if type can be aggregated */
-  lazy val canBeAggregated: DataType => Boolean = Set(DataType.Decimal, DataType.Int, DataType.LargeInt, DataType.DateTime)
+  def canBeAggregated(dataType:DataType, aggregationType: AggregationType): Boolean = {
+      if(aggregationType != AggregationType.count) {
+        Set(DataType.Decimal, DataType.Int, DataType.LargeInt, DataType.DateTime)(dataType)
+      } else true
+  }
+
   /** Default value of limit parameter */
   val defaultLimitValue: Int = 10000
   /** Max value of limit parameter */
@@ -58,7 +63,7 @@ object DataTypes {
           attributesOpt.flatMap { attributes =>
             attributes
               .find(_.name == aggregation.field)
-              .map(attribute => canBeAggregated(attribute.dataType) -> aggregation.field)
+              .map(attribute => canBeAggregated(attribute.dataType, aggregation.function) -> aggregation.field)
           }
         }
       }

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DataTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DataTest.scala
@@ -6,7 +6,6 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Matchers, WordSpec}
-import tech.cryptonomic.conseil.config.Newest
 import tech.cryptonomic.conseil.config.Platforms.{PlatformsConfiguration, Tezos, TezosConfiguration, TezosNodeConfiguration}
 import tech.cryptonomic.conseil.generic.chain.DataTypes.{Query, QueryResponse}
 import tech.cryptonomic.conseil.generic.chain.{DataOperations, DataPlatform}
@@ -100,6 +99,7 @@ class DataTest extends WordSpec with Matchers with ScalatestRouteTest with Scala
 
     "return a correct response with OK status code with POST" in {
       (tezosPlatformDiscoveryOperationsStub.isAttributeValid _).when(*, *).returns(Future.successful(true))
+      (tezosPlatformDiscoveryOperationsStub.getTableAttributesWithoutUpdatingCache _).when(*).returns(Future.successful(None))
       val postRequest = HttpRequest(
         HttpMethods.POST,
         uri = "/v2/data/tezos/alphanet/accounts",
@@ -115,6 +115,7 @@ class DataTest extends WordSpec with Matchers with ScalatestRouteTest with Scala
 
     "return 404 NotFound status code for request for the not supported platform with POST" in {
       (tezosPlatformDiscoveryOperationsStub.isAttributeValid _).when(*, *).returns(Future.successful(true))
+      (tezosPlatformDiscoveryOperationsStub.getTableAttributesWithoutUpdatingCache _).when(*).returns(Future.successful(None))
       val postRequest = HttpRequest(
         HttpMethods.POST,
         uri = "/v2/data/notSupportedPlatform/alphanet/accounts",
@@ -126,6 +127,7 @@ class DataTest extends WordSpec with Matchers with ScalatestRouteTest with Scala
 
     "return 404 NotFound status code for request for the not supported network with POST" in {
       (tezosPlatformDiscoveryOperationsStub.isAttributeValid _).when(*, *).returns(Future.successful(true))
+      (tezosPlatformDiscoveryOperationsStub.getTableAttributesWithoutUpdatingCache _).when(*).returns(Future.successful(None))
       val postRequest = HttpRequest(
         HttpMethods.POST,
         uri = "/v2/data/tezos/notSupportedNetwork/accounts",

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
@@ -267,7 +267,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
       val result = query.validate("test", tpdo)
 
-      result.futureValue.right.get shouldBe Query(predicates = List(Predicate(field = "valid", operation = OperationType.in, set = List("1973-11-29T22:33:09.000+01:00"))))
+      result.futureValue.right.get shouldBe Query(predicates = List(Predicate(field = "valid", operation = OperationType.in, set = List("1973-11-29T21:33:09Z"))))
     }
   }
 

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
@@ -216,7 +216,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
       result.futureValue.left.get should contain theSameElementsAs List(InvalidAggregationField("invalid"), InvalidAggregationFieldForType("invalid"))
     }
 
-    "correctly validate aggregation when COUNT function is used" in {
+    "successfully validates aggregation for any dataType when COUNT function is used" in {
       val attribute = Attribute(
         name = "valid",
         displayName = "Valid",
@@ -267,7 +267,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
       val result = query.validate("test", tpdo)
 
-      result.futureValue.right.get shouldBe Query(predicates = List(Predicate(field = "valid", operation = OperationType.in, set = List("1973-11-29T21:33:09Z"))))
+      result.futureValue.right.get shouldBe Query(predicates = List(Predicate(field = "valid", operation = OperationType.in, set = List("1973-11-29T22:33:09.000+01:00"))))
     }
   }
 

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
@@ -50,7 +50,16 @@ import scala.concurrent.ExecutionContext.Implicits.global
     }
 
     "validate correct predicate field" in {
+      val attribute = Attribute(
+        name = "valid",
+        displayName = "valid",
+        dataType = DataType.Int,
+        cardinality = None,
+        keyType = KeyType.NonKey,
+        entity = "test"
+      )
       (tpdo.isAttributeValid _).when("test", "valid").returns(Future.successful(true))
+      (tpdo.getTableAttributesWithoutUpdatingCache _).when("test").returns(Future.successful(Some(List(attribute))))
 
       val query = ApiQuery(
         fields = None,
@@ -67,7 +76,16 @@ import scala.concurrent.ExecutionContext.Implicits.global
     }
 
     "return error with incorrect predicate fields" in {
+      val attribute = Attribute(
+        name = "valid",
+        displayName = "valid",
+        dataType = DataType.Int,
+        cardinality = None,
+        keyType = KeyType.NonKey,
+        entity = "test"
+      )
       (tpdo.isAttributeValid _).when("test", "invalid").returns(Future.successful(false))
+      (tpdo.getTableAttributesWithoutUpdatingCache _).when("test").returns(Future.successful(Some(List(attribute))))
 
       val query = ApiQuery(
         fields = None,
@@ -223,6 +241,33 @@ import scala.concurrent.ExecutionContext.Implicits.global
       val result = query.validate("test", tpdo)
 
       result.futureValue.right.get shouldBe Query(fields = List("valid"), aggregation = Some(Aggregation(field = "valid", function = AggregationType.count)))
+    }
+
+    "correctly transform predicate DateTime field as Long into ISO" in {
+      val attribute = Attribute(
+        name = "valid",
+        displayName = "Valid",
+        dataType = DataType.DateTime, // only COUNT function can be used on types other than numeric and DateTime
+        cardinality = None,
+        keyType = KeyType.NonKey,
+        entity = "test"
+      )
+
+      (tpdo.isAttributeValid _).when("test", "valid").returns(Future.successful(true))
+      (tpdo.getTableAttributesWithoutUpdatingCache _).when("test").returns(Future.successful(Some(List(attribute))))
+
+      val query = ApiQuery(
+        fields = None,
+        predicates = Some(List(Predicate(field = "valid", operation = OperationType.in, set = List(123456789000L)))),
+        orderBy = None,
+        limit = None,
+        output = None,
+        aggregation = None
+      )
+
+      val result = query.validate("test", tpdo)
+
+      result.futureValue.right.get shouldBe Query(predicates = List(Predicate(field = "valid", operation = OperationType.in, set = List("1973-11-29T21:33:09Z"))))
     }
   }
 


### PR DESCRIPTION
There were two issues:

- all aggregation functions were only handling Numeric/DateTime fields, but `COUNT` function should be available for all the fields - after this PR it will be.

- predicates with DateTime field type were compared in the DB with the timestamp representation in milliseconds - after this PR predicate with DateTime type will be have `set` mapped to `Instant` and then to sting so it could be correctly recognised in DB.