### PR TITLE
Conseil 325: Include time to process accounts of each page block in the timeout

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -65,6 +65,12 @@ batchedFetches {
   #Used to paginate blocks read from tezos before each db storage
   blockPageSize = 500
 
+  #Used to specify the max-time allowed for each block-page to finish processing
+  #Currently takes into account the time to process all corresponding accounts for each page
+  blockPageProcessingTimeout = 15 minutes
+
+  #Used to specify the max-time allowed for each accounts-page to finish processing
+  accountPageProcessingTimeout = 5 minutes
 }
 
 # Settings for blockchains Conseil can connect to. Nested by blockchain name and network.

--- a/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
@@ -178,7 +178,7 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
             //wait for each page to load, before looking at the next, thus  starting the new computation
             val justDone = Await.result(
               processBlocksPage(nextPage) <* processTezosAccounts(),
-              atMost = 5.minutes)
+              atMost = batchingConf.blockPageProcessingTimeout)
             processed + justDone <| logProgress
         }
       })
@@ -268,7 +268,7 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
           pages.foldLeft(0) {
             (processed, nextPage) =>
               //wait for each page to load, before looking at the next, thus  starting the new computation
-              val justDone = Await.result(processAccountsPage(nextPage), atMost = 5.minutes)
+              val justDone = Await.result(processAccountsPage(nextPage), atMost = batchingConf.accountPageProcessingTimeout)
               processed + justDone <| logProgress
         }
 

--- a/src/main/scala/tech/cryptonomic/conseil/config/Shared.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/config/Shared.scala
@@ -19,7 +19,9 @@ final case class LorreConfiguration(
 final case class BatchFetchConfiguration(
   accountConcurrencyLevel: Int,
   blockOperationsConcurrencyLevel: Int,
-  blockPageSize: Int
+  blockPageSize: Int,
+  blockPageProcessingTimeout: FiniteDuration,
+  accountPageProcessingTimeout: FiniteDuration
 )
 
 /** configurations related to a chain-node network calls */

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTest.scala
@@ -8,11 +8,12 @@ import tech.cryptonomic.conseil.config.BatchFetchConfiguration
 import tech.cryptonomic.conseil.tezos.TezosTypes.BlockHash
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
 
 class TezosNodeOperatorTest extends FlatSpec with MockFactory with Matchers with LazyLogging with ScalaFutures with IntegrationPatience {
   import ExecutionContext.Implicits.global
 
-  val config = BatchFetchConfiguration(1, 1, 500)
+  val config = BatchFetchConfiguration(1, 1, 500, 10 seconds, 10 seconds)
 
   "getBlock" should "correctly fetch the genesis block" in {
     //given


### PR DESCRIPTION
fix #325 

 * define both timeouts for block-page processing and account-page
   processing at the configuration level
 * increase the default timeout for blocks

## required changes in the configuration

the `reference.conf` file now defines 2 extra entries that can be overridden , based on actual timing on each environment, the following excerpt _includes only the new entries_

```coffee
batchedFetches {
  #Used to specify the max-time allowed for each block-page to finish processing
  #Currently takes into account the time to process all corresponding accounts for each page
  blockPageProcessingTimeout = 15 minutes

  #Used to specify the max-time allowed for each accounts-page to finish processing
  accountPageProcessingTimeout = 5 minutes
}
```