### PR TITLE
Conseil-322: Use the fetchers as actual type classes

### DIFF
--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
@@ -540,9 +540,6 @@ class TezosDatabaseOperationsTest
     }
 
     "fetch existing operations with their group on a existing hash" in {
-      import DatabaseConversions._
-      import tech.cryptonomic.conseil.util.Conversion.Syntax._
-
       implicit val randomSeed = RandomSeed(testReferenceTimestamp.getTime)
 
       val block = generateBlockRows(1, testReferenceTimestamp).head
@@ -565,8 +562,6 @@ class TezosDatabaseOperationsTest
     }
 
     "compute correct average fees from stored operations" in {
-      import DatabaseConversions._
-      import tech.cryptonomic.conseil.util.Conversion.Syntax._
       //generate data
       implicit val randomSeed = RandomSeed(testReferenceTimestamp.getTime)
       val block = generateBlockRows(1, testReferenceTimestamp).head
@@ -608,8 +603,6 @@ class TezosDatabaseOperationsTest
     }
 
     "return None when computing average fees for a kind with no data" in {
-      import DatabaseConversions._
-      import tech.cryptonomic.conseil.util.Conversion.Syntax._
       //generate data
       implicit val randomSeed = RandomSeed(testReferenceTimestamp.getTime)
       val block = generateBlockRows(1, testReferenceTimestamp).head
@@ -634,8 +627,6 @@ class TezosDatabaseOperationsTest
     }
 
     "compute average fees only using the selected operation kinds" in {
-      import DatabaseConversions._
-      import tech.cryptonomic.conseil.util.Conversion.Syntax._
       //generate data
       implicit val randomSeed = RandomSeed(testReferenceTimestamp.getTime)
       val block = generateBlockRows(1, testReferenceTimestamp).head


### PR DESCRIPTION
This opens the door for future MTL-style definition of DataFetchers, and arguably makes the code easier to understand.
I made this initial separate PR to prepare for better handling of finer-grained fetches (using a streaming variant)

The code logic don't change.
The specific data fetchers used for blocks and accounts are now marked implicit and the `fetch` operation use those implicitly.

At call site, now we simply call `fetch` with specific type arguments, and the type inference drives the implicit resolution to use the correct data-fetcher.

This last part is more canonical in type class usage and allows the code to be more amenable to be converted to generically typed definitions, with final tagless style and MTL libraries.