### PR TITLE
[DONT-MERGE-YET] Conseil 322 support finer logging fetchers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ val akkaHttpVersion = "10.1.8"
 val akkaHttpJsonVersion = "1.25.2"
 val slickVersion = "3.3.0"
 val catsVersion = "1.6.0"
+val catsEffectVersion = "1.2.0"
 val monocleVersion = "1.5.1-cats"
 val endpointsVersion = "0.9.0"
 val circeVersion = "0.11.1"
@@ -36,6 +37,7 @@ libraryDependencies  ++=  Seq(
   "com.fasterxml.jackson.module"    %% "jackson-module-scala"          % "2.9.6",
   "com.chuusai"                     %% "shapeless"                     % "2.3.3",
   "org.typelevel"                   %% "cats-core"                     % catsVersion,
+  "org.typelevel"                   %% "cats-effect"                   % catsEffectVersion,
   "org.typelevel"                   %% "mouse"                         % "0.20",
   "com.github.julien-truffaut"      %% "monocle-core"                  % monocleVersion exclude("org.typelevel.cats", "cats-core"),
   "com.github.julien-truffaut"      %% "monocle-macro"                 % monocleVersion exclude("org.typelevel.cats", "cats-core") exclude("org.typelevel.cats", "cats-macros"),

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataFetcher.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataFetcher.scala
@@ -2,8 +2,6 @@ package tech.cryptonomic.conseil.generic.chain
 
 import cats._
 import cats.data.Kleisli
-import cats.syntax.applicativeError._
-import cats.syntax.semigroupal._
 
 /** Contract for a generic combination of operations that get encoded data (usually json) from
   * some resource (e.g. the tezos node), then converts that to a value, batching multiple requests together.
@@ -71,7 +69,9 @@ trait DataFetcher[Eff[_], Coll[_], Err] {
   */
 object DataFetcher {
   import cats.syntax.foldable._
+  import cats.syntax.applicativeError._
   import cats.syntax.functorFilter._
+  import cats.syntax.semigroupal._
 
   /** using the combination of the provided fetcher functions we fetch all data with this general outline:
     * 1. get encoded (e.g. json) values from the node, given a traversable input collection

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTest.scala
@@ -51,8 +51,8 @@ class TezosNodeOperatorTest extends FlatSpec with MockFactory with Matchers with
       .returns(votesProposal)
 
     (tezosRPCInterface.runBatchedGetQuery[Any] _)
-      .when("zeronet", *, *, *)
-      .onCall( (_, input, command, _) =>
+      .when("zeronet", *, *, *, *)
+      .onCall((_, input, command, _, _) =>
         Future.successful(List(
           //dirty trick to find the type of input content and provide the appropriate response
           input match {
@@ -107,8 +107,8 @@ class TezosNodeOperatorTest extends FlatSpec with MockFactory with Matchers with
       .returns(votesProposal)
 
     (tezosRPCInterface.runBatchedGetQuery[Any] _)
-      .when("zeronet", *, *, *)
-      .onCall((_, input, command, _) =>
+      .when("zeronet", *, *, *, *)
+      .onCall((_, input, command, _, _) =>
         Future.successful(List(
           //dirty trick to find the type of input content and provide the appropriate response
           input match {
@@ -164,8 +164,8 @@ class TezosNodeOperatorTest extends FlatSpec with MockFactory with Matchers with
       .returns(votesProposal)
 
     (tezosRPCInterface.runBatchedGetQuery[Any] _)
-      .when("zeronet", *, *, *)
-      .onCall((_, input, command, _) =>
+      .when("zeronet", *, *, *, *)
+      .onCall((_, input, command, _, _) =>
         Future.successful(List(
           //dirty trick to find the type of input content and provide the appropriate response
           input match {


### PR DESCRIPTION
Adds handlers for errors within the batchedGetQuery, defaulting to no-op.
This allows all data-fetchers to provide logging of errors on each failed element.

Before merging, I need to do more local testing.
Also the base branch should be moved to `master`, once the current base one is merged via PR #327