### PR TITLE
Wait on accounts checkpoints cleanup

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
@@ -280,7 +280,9 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
       //additional cleanup, that can fail with no downsides
       case Success(checkpoints) =>
         val processed = Some(checkpoints.keySet)
-        db.run(TezosDb.cleanAccountsCheckpoint(processed))
+        logger.debug("Cleaning checkpointed accounts..")
+        Await.result(db.run(TezosDb.cleanAccountsCheckpoint(processed)), atMost = batchingConf.accountPageProcessingTimeout)
+        logger.debug("Done cleaning checkpointed accounts.")
       case _ =>
         ()
     }.transform {


### PR DESCRIPTION
As part of #320, account fetching was interleaved with block fetching. This exposed a bug whose severity has now increased. Once the blocks to be fetched are divided into pages, the current logic blocks on both block fetching and account fetching. However, the next page iteration is not blocked on the cleanup of accounts checkpoints. 

[lorre4.log](https://github.com/Cryptonomic/Conseil/files/3057085/lorre4.log)

In the attached file, line 13,203 onwards shows the following:
(i) A delete of certain accounts from the checkpoints table is prepared
(ii) The fetch of checkpointed accounts from the next iteration is already kicked off
(iii) The results of (ii) come back and include accounts which should have been deleted
(iv) The delete seems to be finally done with the statement `Execution of prepared update took 2s` indicating the operation took much longer than usual (compared to earlier such statements in the log). 

```
21:21:48.376 [conseildb-2] DEBUG slick.jdbc.JdbcBackend.statement - Executing prepared update: HikariProxyPreparedStatement@1147204624 wrapping delete from "accounts_checkpoint" where "accounts_checkpoint"."account_id" in ('KT1VozgUaotRiVU9g4G8ntJSq6jPQTuWurPB', 'tz1Tnjaxk6tbAeC2TmMApPh8UsrEVQvhHvx5', 'KT1W7Fh8fKV3C4y7uxCh42dYn3kvCqzDCN62', 'tz1R99mCjwTv6uH9L4gXjSApBLk77NMojBz8')
21:21:48.376 [conseildb-2] DEBUG s.j.J.statementAndParameter - Executing prepared update: HikariProxyPreparedStatement@1147204624 wrapping delete from "accounts_checkpoint" where "accounts_checkpoint"."account_id" in ('KT1VozgUaotRiVU9g4G8ntJSq6jPQTuWurPB', 'tz1Tnjaxk6tbAeC2TmMApPh8UsrEVQvhHvx5', 'KT1W7Fh8fKV3C4y7uxCh42dYn3kvCqzDCN62', 'tz1R99mCjwTv6uH9L4gXjSApBLk77NMojBz8')
21:21:48.376 [lorre-system-akka.actor.default-dispatcher-16] DEBUG slick.basic.BasicBackend.action - #1: result [select distinct "account_id" from "accounts_checkpoint"]
21:21:48.376 [lorre-system-akka.actor.default-dispatcher-16] DEBUG tech.cryptonomic.conseil.Lorre$ - Selecting all accounts touched in the checkpoint table, this might take a while...
21:21:48.376 [conseildb-6] DEBUG slick.jdbc.JdbcBackend.statement - Preparing statement: select distinct "account_id" from "accounts_checkpoint"
21:21:48.376 [conseildb-6] DEBUG slick.jdbc.JdbcBackend.statement - Executing prepared statement: HikariProxyPreparedStatement@100327611 wrapping select distinct "account_id" from "accounts_checkpoint"
21:21:48.376 [conseildb-6] DEBUG s.j.J.statementAndParameter - Executing prepared statement: HikariProxyPreparedStatement@100327611 wrapping select distinct "account_id" from "accounts_checkpoint"
21:21:48.377 [conseildb-6] DEBUG slick.jdbc.JdbcBackend.benchmark - Execution of prepared statement took 467µs
21:21:48.377 [conseildb-6] DEBUG slick.jdbc.StatementInvoker.result - /----------------------\
21:21:48.377 [conseildb-6] DEBUG slick.jdbc.StatementInvoker.result - | 1                    |
21:21:48.377 [conseildb-6] DEBUG slick.jdbc.StatementInvoker.result - | account_id           |
21:21:48.377 [conseildb-6] DEBUG slick.jdbc.StatementInvoker.result - |----------------------|
21:21:48.377 [conseildb-6] DEBUG slick.jdbc.StatementInvoker.result - | KT1VozgUaotRiVU9g... |
21:21:48.377 [conseildb-6] DEBUG slick.jdbc.StatementInvoker.result - | tz3RDC3Jdn4j15J7b... |
21:21:48.377 [conseildb-6] DEBUG slick.jdbc.StatementInvoker.result - | tz1Tnjaxk6tbAeC2T... |
21:21:48.377 [conseildb-6] DEBUG slick.jdbc.StatementInvoker.result - | tz1aEvwbBptpWJiVk... |
21:21:48.377 [conseildb-6] DEBUG slick.jdbc.StatementInvoker.result - | tz1PZZ8sQP7sd4vnq... |
21:21:48.377 [conseildb-6] DEBUG slick.jdbc.StatementInvoker.result - \----------------------/
21:21:48.383 [conseildb-6] DEBUG slick.jdbc.StatementInvoker.result - 5 more rows read (10 total)
21:21:51.108 [conseildb-2] DEBUG slick.jdbc.JdbcBackend.benchmark - Execution of prepared update took 2s
```

Futher down the log, on line 19,376 we see that the current iteration is now looking for a deleted account from the checkpoints table and the program fails:

```
21:21:51.243 [conseildb-8] DEBUG slick.jdbc.JdbcBackend.statement - Executing prepared statement: HikariProxyPreparedStatement@195011606 wrapping select "account_id", "block_id", "block_level" from "accounts_checkpoint" where "account_id" = 'KT1VozgUaotRiVU9g4G8ntJSq6jPQTuWurPB' order by "block_level" desc limit 1
21:21:51.243 [conseildb-8] DEBUG s.j.J.statementAndParameter - Executing prepared statement: HikariProxyPreparedStatement@195011606 wrapping select "account_id", "block_id", "block_level" from "accounts_checkpoint" where "account_id" = 'KT1VozgUaotRiVU9g4G8ntJSq6jPQTuWurPB' order by "block_level" desc limit 1
21:21:51.243 [conseildb-8] DEBUG slick.jdbc.JdbcBackend.benchmark - Execution of prepared statement took 564µs
21:21:51.244 [conseildb-8] DEBUG slick.jdbc.StatementInvoker.result - /------------+----------+-------------\
21:21:51.244 [conseildb-8] DEBUG slick.jdbc.StatementInvoker.result - | 1          | 2        | 3           |
21:21:51.244 [conseildb-8] DEBUG slick.jdbc.StatementInvoker.result - | account_id | block_id | block_level |
21:21:51.244 [conseildb-8] DEBUG slick.jdbc.StatementInvoker.result - |------------+----------+-------------|
21:21:51.244 [conseildb-8] DEBUG slick.jdbc.StatementInvoker.result - \------------+----------+-------------/
21:21:51.244 [lorre-system-akka.actor.default-dispatcher-3] ERROR tech.cryptonomic.conseil.Lorre$ - I failed to fetch accounts from client and update them
java.util.NoSuchElementException: Invoker.first
	at slick.jdbc.Invoker.first(Invoker.scala:33)
	at slick.jdbc.Invoker.first$(Invoker.scala:29)
	at slick.jdbc.StatementInvoker.first(StatementInvoker.scala:15)
	at slick.jdbc.StreamingInvokerAction$HeadAction.run(StreamingInvokerAction.scala:52)
	at slick.jdbc.StreamingInvokerAction$HeadAction.run(StreamingInvokerAction.scala:51)
	at slick.dbio.DBIOAction$$anon$1.$anonfun$run$1(DBIOAction.scala:186)
	at scala.collection.Iterator.foreach(Iterator.scala:941)
	at scala.collection.Iterator.foreach$(Iterator.scala:941)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1429)
	at scala.collection.IterableLike.foreach(IterableLike.scala:74)
	at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
	at slick.dbio.DBIOAction$$anon$1.run(DBIOAction.scala:186)
	at slick.dbio.DBIOAction$$anon$1.run(DBIOAction.scala:183)
	at slick.basic.BasicBackend$DatabaseDef$$anon$3.liftedTree1$1(BasicBackend.scala:275)
	at slick.basic.BasicBackend$DatabaseDef$$anon$3.run(BasicBackend.scala:275)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

The fix therefore is to ensure we wait on the accounts checkpoint table to be cleaned up before the next blocks page is handled.

Please note this is a good-enough solution for now and a subsequent PR should be created to more cleanly implement a fix.