### PR TITLE
Fixes for between operation being used on the datetime fields and fix for transforming milis to Timestamp format

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
@@ -1,8 +1,6 @@
 package tech.cryptonomic.conseil.generic.chain
 
 import java.sql.Timestamp
-import java.time.format.DateTimeFormatter
-import java.time.ZoneOffset
 
 import tech.cryptonomic.conseil.generic.chain.DataTypes.AggregationType.AggregationType
 import tech.cryptonomic.conseil.generic.chain.DataTypes.OperationType.OperationType
@@ -47,7 +45,7 @@ object DataTypes {
         maybeAttributes.flatMap { attributes =>
           attributes.find(_.name == predicate.field).map {
             case attribute if attribute.dataType == DataType.DateTime =>
-              predicate.copy(set = predicate.set.map(x => formatToIso(x.toString.toLong)))
+              predicate.copy(set = predicate.set.map(x => new Timestamp(x.toString.toLong).toString))
             case _ => predicate
           }
         }.toList
@@ -55,10 +53,6 @@ object DataTypes {
     }.sequence.map(pred => query.copy(predicates = pred.flatten))
   }
 
-  /** Method formatting millis to ISO format */
-  def formatToIso(epochMillis: Long): String = {
-    DateTimeFormatter.ISO_INSTANT.format(new Timestamp(epochMillis).toInstant)
-  }
   /** Helper method for finding fields used in query that don't exist in the database */
   private def findNonExistingFields(query: Query, entity: String, tezosPlatformDiscovery: TezosPlatformDiscoveryOperations)
     (implicit ec: ExecutionContext): Future[List[QueryValidationError]] = {

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
@@ -57,11 +57,7 @@ object DataTypes {
 
   /** Method formatting millis to ISO format */
   def formatToIso(epochMillis: Long): String = {
-    // time needs to be adjusted with toLocalDateTime
-    new Timestamp(epochMillis)
-      .toLocalDateTime
-      .atZone(ZoneOffset.UTC)
-      .format(DateTimeFormatter.ISO_INSTANT)
+    DateTimeFormatter.ISO_INSTANT.format(new Timestamp(epochMillis).toInstant)
   }
   /** Helper method for finding fields used in query that don't exist in the database */
   private def findNonExistingFields(query: Query, entity: String, tezosPlatformDiscovery: TezosPlatformDiscoveryOperations)

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
@@ -1,7 +1,8 @@
 package tech.cryptonomic.conseil.generic.chain
 
-import java.time.format.DateTimeFormatter.ISO_INSTANT
-import java.time.{Instant, ZoneOffset}
+import java.sql.Timestamp
+import java.time.format.DateTimeFormatter
+import java.time.ZoneOffset
 
 import tech.cryptonomic.conseil.generic.chain.DataTypes.AggregationType.AggregationType
 import tech.cryptonomic.conseil.generic.chain.DataTypes.OperationType.OperationType
@@ -55,11 +56,13 @@ object DataTypes {
   }
 
   /** Method formatting millis to ISO format */
-  def formatToIso(epochMillis: Long): String =
-    Instant.ofEpochMilli(epochMillis)
+  def formatToIso(epochMillis: Long): String = {
+    // time needs to be adjusted with toLocalDateTime
+    new Timestamp(epochMillis)
+      .toLocalDateTime
       .atZone(ZoneOffset.UTC)
-      .format(ISO_INSTANT)
-
+      .format(DateTimeFormatter.ISO_INSTANT)
+  }
   /** Helper method for finding fields used in query that don't exist in the database */
   private def findNonExistingFields(query: Query, entity: String, tezosPlatformDiscovery: TezosPlatformDiscoveryOperations)
     (implicit ec: ExecutionContext): Future[List[QueryValidationError]] = {

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
@@ -421,7 +421,7 @@ object ApiOperations extends DataOperations with MetadataOperations {
 
   /** Sanitizes string to be viable to paste into plain SQL */
   def sanitizeForSql(str: String): String = {
-    val supportedCharacters = Set('_', '.', '+', ':', '-')
+    val supportedCharacters = Set('_', '.', '+', ':', '-', ' ')
     str.filter(c => c.isLetterOrDigit || supportedCharacters.contains(c))
   }
 

--- a/src/main/scala/tech/cryptonomic/conseil/util/DatabaseUtil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/util/DatabaseUtil.scala
@@ -186,7 +186,7 @@ object DatabaseUtil {
     /** maps operation type to SQL operation */
     private def mapOperationToSQL(operation: OperationType, inverse: Boolean, vals: List[String]): SQLActionBuilder = {
       val op = operation match {
-        case OperationType.between => sql"BETWEEN #${vals.head} AND #${vals(1)}"
+        case OperationType.between => sql"BETWEEN '#${vals.head}' AND '#${vals(1)}'"
         case OperationType.in => concatenateSqlActions(sql"IN ", insertValuesIntoSqlAction(vals))
         case OperationType.like => sql"LIKE '%#${vals.head}%'"
         case OperationType.lt | OperationType.before => sql"< '#${vals.head}'"

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
@@ -267,7 +267,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
       val result = query.validate("test", tpdo)
 
-      result.futureValue.right.get shouldBe Query(predicates = List(Predicate(field = "valid", operation = OperationType.in, set = List("1973-11-29T21:33:09Z"))))
+      result.futureValue.right.get shouldBe Query(predicates = List(Predicate(field = "valid", operation = OperationType.in, set = List("1973-11-29 22:33:09.0"))))
     }
   }
 

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
@@ -267,7 +267,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
       val result = query.validate("test", tpdo)
 
-      result.futureValue.right.get shouldBe Query(predicates = List(Predicate(field = "valid", operation = OperationType.in, set = List("1973-11-29T21:33:09Z"))))
+      result.futureValue.right.get shouldBe Query(predicates = List(Predicate(field = "valid", operation = OperationType.in, set = List("1973-11-29T22:33:09Z"))))
     }
   }
 

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
@@ -267,7 +267,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
       val result = query.validate("test", tpdo)
 
-      result.futureValue.right.get shouldBe Query(predicates = List(Predicate(field = "valid", operation = OperationType.in, set = List("1973-11-29T22:33:09Z"))))
+      result.futureValue.right.get shouldBe Query(predicates = List(Predicate(field = "valid", operation = OperationType.in, set = List("1973-11-29T21:33:09Z"))))
     }
   }
 

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
@@ -1,5 +1,7 @@
 package tech.cryptonomic.conseil.tezos
 
+import java.sql.Timestamp
+
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Matchers, WordSpec}
@@ -267,7 +269,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
       val result = query.validate("test", tpdo)
 
-      result.futureValue.right.get shouldBe Query(predicates = List(Predicate(field = "valid", operation = OperationType.in, set = List("1973-11-29 22:33:09.0"))))
+      result.futureValue.right.get shouldBe Query(predicates = List(Predicate(field = "valid", operation = OperationType.in, set = List(new Timestamp(123456789000L).toString))))
     }
   }
 

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
@@ -1790,8 +1790,8 @@ class TezosDatabaseOperationsTest
         field = "timestamp",
         operation = OperationType.between,
         set = List(
-          DataTypes.formatToIso(1),
-          DataTypes.formatToIso(3)
+          new Timestamp(1),
+          new Timestamp(3)
         )
       )
 

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
@@ -1778,7 +1778,6 @@ class TezosDatabaseOperationsTest
       )
     }
 
-
     "should correctly check use between in the timestamps" in {
       val feesTmp = List(
         FeesRow(0, 2, 4, new Timestamp(0), "kind"),

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
@@ -1,8 +1,6 @@
 package tech.cryptonomic.conseil.tezos
 
 import java.sql.Timestamp
-import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
 
 import com.typesafe.scalalogging.LazyLogging
 import org.scalamock.scalatest.MockFactory
@@ -1810,8 +1808,8 @@ class TezosDatabaseOperationsTest
 
       val result = dbHandler.run(populateAndTest.transactionally).futureValue
 
-      result.map(_.values.map(_.map(_.asInstanceOf[Timestamp]))) shouldBe List(
-        List(Some(new Timestamp(2)))
+      result.flatMap(_.values.map(_.map(_.asInstanceOf[Timestamp]))) shouldBe List(
+        Some(new Timestamp(2))
       )
     }
 


### PR DESCRIPTION
fixed behaviour of `between` operation, so it can be used on the DateTime fields, changed the datetime formatting because of inconsistency I've found between results from DB and trying to query them. Probably I need to do some more fixes as timezones in my local container and in the Travis do not match. 
Probably we should think of using `timestamp with timezone` in the DB types.