### PR TITLE
Conseil 322-1: parametric tezos rpc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,8 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots")
 )
 
+addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.0")
+
 libraryDependencies  ++=  Seq(
   "ch.qos.logback"                   % "logback-classic"               % "1.2.3",
   "com.typesafe"                     % "config"                        % "1.3.3",

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ val akkaHttpVersion = "10.1.8"
 val akkaHttpJsonVersion = "1.25.2"
 val slickVersion = "3.3.0"
 val catsVersion = "1.6.0"
+val catsEffectVersion = "1.2.0"
 val monocleVersion = "1.5.1-cats"
 val endpointsVersion = "0.9.0"
 val circeVersion = "0.11.1"
@@ -36,6 +37,7 @@ libraryDependencies  ++=  Seq(
   "com.fasterxml.jackson.module"    %% "jackson-module-scala"          % "2.9.6",
   "com.chuusai"                     %% "shapeless"                     % "2.3.3",
   "org.typelevel"                   %% "cats-core"                     % catsVersion,
+  "org.typelevel"                   %% "cats-effect"                   % catsEffectVersion,
   "org.typelevel"                   %% "mouse"                         % "0.20",
   "com.github.julien-truffaut"      %% "monocle-core"                  % monocleVersion exclude("org.typelevel.cats", "cats-core"),
   "com.github.julien-truffaut"      %% "monocle-macro"                 % monocleVersion exclude("org.typelevel.cats", "cats-core") exclude("org.typelevel.cats", "cats-macros"),

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataFetcher.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataFetcher.scala
@@ -2,8 +2,6 @@ package tech.cryptonomic.conseil.generic.chain
 
 import cats._
 import cats.data.Kleisli
-import cats.syntax.applicativeError._
-import cats.syntax.semigroupal._
 
 /** Contract for a generic combination of operations that get encoded data (usually json) from
   * some resource (e.g. the tezos node), then converts that to a value, batching multiple requests together.
@@ -71,7 +69,9 @@ trait DataFetcher[Eff[_], Coll[_], Err] {
   */
 object DataFetcher {
   import cats.syntax.foldable._
+  import cats.syntax.applicativeError._
   import cats.syntax.functorFilter._
+  import cats.syntax.semigroupal._
 
   /** using the combination of the provided fetcher functions we fetch all data with this general outline:
     * 1. get encoded (e.g. json) values from the node, given a traversable input collection

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/RemoteRpc.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/RemoteRpc.scala
@@ -1,0 +1,32 @@
+package tech.cryptonomic.conseil.generic.chain
+
+trait RemoteRpc[Eff[_], Req[_], Res[_]] {
+
+  type CallConfig
+  type PostPayload
+
+  def runGetCall[CallId](callConfig: CallConfig, request: Req[CallId], commandMap: CallId => String): Eff[Res[CallId]]
+
+  def runPostCall[CallId](callConfig: CallConfig, request: Req[CallId], commandMap: CallId => String, payload: Option[PostPayload]): Eff[Res[CallId]]
+
+}
+
+object RemoteRpc {
+
+  type Aux[Eff[_], Req[_], Res[_], Conf, Payload] = RemoteRpc[Eff, Req, Res] { type CallConfig = Conf; type PostPayload = Payload }
+
+  def apply[Eff[_], Req[_], Res[_], CC, PL](implicit remote: Aux[Eff, Req, Res, CC, PL]): Aux[Eff, Req, Res, CC, PL] = remote
+
+  def runGet[Eff[_], Req[_], Res[_], CallConfig, CallId](
+    callConfig: CallConfig, request: Req[CallId], commandMap: CallId => String
+  )(
+    implicit remote: Aux[Eff, Req, Res, CallConfig, _]
+  ): Eff[Res[CallId]] = remote.runGetCall(callConfig, request, commandMap)
+
+  def runPost[Eff[_], Req[_], Res[_], CallConfig, CallId, Payload](
+    callConfig: CallConfig, request: Req[CallId], commandMap: CallId => String, payload: Option[Payload] = None
+  )(
+    implicit remote: Aux[Eff, Req, Res, CallConfig, Payload]
+  ): Eff[Res[CallId]] = remote.runPostCall(callConfig, request, commandMap, payload)
+
+}

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/RemoteRpc.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/RemoteRpc.scala
@@ -7,26 +7,72 @@ trait RemoteRpc[Eff[_], Req[_], Res[_]] {
 
   def runGetCall[CallId](callConfig: CallConfig, request: Req[CallId], commandMap: CallId => String): Eff[Res[CallId]]
 
-  def runPostCall[CallId](callConfig: CallConfig, request: Req[CallId], commandMap: CallId => String, payload: Option[PostPayload]): Eff[Res[CallId]]
+  def runPostCall[CallId](callConfig: CallConfig, request: Req[CallId], commandMap: CallId => String, payload: Option[PostPayload] = None): Eff[Res[CallId]]
 
 }
 
 object RemoteRpc {
 
+  import cats.{Id, Functor}
+  import cats.data.Const
+  import cats.syntax.functor._
+
   type Aux[Eff[_], Req[_], Res[_], Conf, Payload] = RemoteRpc[Eff, Req, Res] { type CallConfig = Conf; type PostPayload = Payload }
 
-  def apply[Eff[_], Req[_], Res[_], CC, PL](implicit remote: Aux[Eff, Req, Res, CC, PL]): Aux[Eff, Req, Res, CC, PL] = remote
-
-  def runGet[Eff[_], Req[_], Res[_], CallConfig, CallId](
-    callConfig: CallConfig, request: Req[CallId], commandMap: CallId => String
-  )(
-    implicit remote: Aux[Eff, Req, Res, CallConfig, _]
-  ): Eff[Res[CallId]] = remote.runGetCall(callConfig, request, commandMap)
-
-  def runPost[Eff[_], Req[_], Res[_], CallConfig, CallId, Payload](
-    callConfig: CallConfig, request: Req[CallId], commandMap: CallId => String, payload: Option[Payload] = None
-  )(
+  def apply[Eff[_], Req[_], Res[_], CallConfig, Payload](
     implicit remote: Aux[Eff, Req, Res, CallConfig, Payload]
-  ): Eff[Res[CallId]] = remote.runPostCall(callConfig, request, commandMap, payload)
+  ): Aux[Eff, Req, Res, CallConfig, Payload] = remote
+
+  def runGet[Eff[_], CallId, Req[_], Res[_], CallConfig](
+    callConfig: CallConfig,
+    request: Req[CallId],
+    commandMap: CallId => String
+  )(implicit remote: Aux[Eff, Req, Res, CallConfig, _]): Eff[Res[CallId]] =
+    remote.runGetCall(callConfig, request, commandMap)
+
+  def runGet[Eff[_], CallId, Req[_], Res[_]](
+    request: Req[CallId],
+    commandMap: CallId => String
+  )(implicit remote: Aux[Eff, Req, Res, Any, _]): Eff[Res[CallId]] =
+    remote.runGetCall((), request, commandMap)
+
+  def runGet[Eff[_]: Functor, CallId, Res](
+    request: CallId,
+    commandMap: CallId => String
+  )(implicit remote: Aux[Eff, Id, Const[Res, ?], Any, _]): Eff[Res] =
+    remote.runGetCall((), request, commandMap).map(_.getConst)
+
+  def runGet[Eff[_]: Functor, Res](
+    command: String,
+  )(implicit remote: Aux[Eff, Id, Const[Res, ?], Any, _]): Eff[Res] =
+    remote.runGetCall((), (), (_: Any) => command).map(_.getConst)
+
+  def runPost[Eff[_], CallId, Req[_], Res[_], CallConfig, Payload](
+    callConfig: CallConfig,
+    request: Req[CallId],
+    commandMap: CallId => String,
+    payload: Option[Payload] = None
+  )(implicit remote: Aux[Eff, Req, Res, CallConfig, Payload]): Eff[Res[CallId]] =
+    remote.runPostCall(callConfig, request, commandMap, payload)
+
+  def runPost[Eff[_], CallId, Req[_], Res[_], Payload](
+    request: Req[CallId],
+    commandMap: CallId => String,
+    payload: Option[Payload]
+  )(implicit remote: Aux[Eff, Req, Res, Any, Payload]): Eff[Res[CallId]] =
+    remote.runPostCall((), request, commandMap, payload)
+
+  def runPost[Eff[_]: Functor, CallId, Res, Payload](
+    request: CallId,
+    commandMap: CallId => String,
+    payload: Option[Payload]
+  )(implicit remote: Aux[Eff, Id, Const[Res, ?], Any, Payload]): Eff[Res] =
+    remote.runPostCall((), request, commandMap, payload).map(_.getConst)
+
+  def runPost[Eff[_]: Functor, Res, Payload](
+    command: String,
+    payload: Option[Payload]
+  )(implicit remote: Aux[Eff, Id, Const[Res, ?], Any, Payload]): Eff[Res] =
+    remote.runPostCall((), (), (_: Any) => command, payload).map(_.getConst)
 
 }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -69,12 +69,12 @@ class TezosNodeOperator(val network: String, batchConf: BatchFetchConfiguration)
   with BlocksDataFetchers
   with AccountsDataFetchers {
   import TezosNodeOperator.isGenesis
-  import batchConf.{accountConcurrencyLevel, blockOperationsConcurrencyLevel, blockPageSize}
+  import batchConf.blockPageSize
 
   override implicit val actorMaterializer = ActorMaterializer()
 
-  override val fetchConcurrency = blockOperationsConcurrencyLevel
-  override val accountsFetchConcurrency = accountConcurrencyLevel
+  override val fetchConcurrency = batchConf.blockOperationsConcurrencyLevel
+  override val accountsFetchConcurrency = batchConf.accountConcurrencyLevel
 
   //use this alias to make signatures easier to read and kept in-sync
   type BlockFetchingResults = List[(Block, List[AccountId])]

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosRemotes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosRemotes.scala
@@ -22,7 +22,7 @@ object TezosRemoteInstances {
       tezosConfig: TezosConfiguration,
       requestConfig: NetworkCallsConfiguration,
       streamingConfig: HttpStreamingConfiguration
-    )(implicit system: ActorSystem) {
+    )(implicit val system: ActorSystem) {
 
       object ShutdownComplete extends ShutdownComplete
       private val rejectingCalls = new java.util.concurrent.atomic.AtomicBoolean(false)
@@ -58,14 +58,15 @@ object TezosRemoteInstances {
 
       type JustString[CallId] = Const[String, CallId]
 
-      implicit def futuresInstance(implicit context: RemoteContext, system: ActorSystem) =
+      implicit def futuresInstance(implicit context: RemoteContext) =
         new RemoteRpc[Future, Id, JustString] {
           import context._
 
           private val logger = Logger("Akka.Futures.RemoteRpc")
 
-          implicit val materializer = ActorMaterializer()
+          implicit val system = context.system
           implicit val dispatcher = system.dispatcher
+          implicit val materializer = ActorMaterializer()
 
           type CallConfig = Any
           type PostPayload = JsonString
@@ -134,14 +135,16 @@ object TezosRemoteInstances {
       }
 
 
-      implicit def streamsInstance(implicit context: RemoteContext, system: ActorSystem, mat: ActorMaterializer) =
+      implicit def streamsInstance(implicit context: RemoteContext) =
         new RemoteRpc[StreamSource, StreamSource, TaggedString] {
           import context._
           import context.tezosConfig.nodeConfig
 
           private val logger = Logger("Akka.Streams.RemoteRpc")
 
+          implicit val system = context.system
           implicit val dispatcher = system.dispatcher
+          implicit val materializer = ActorMaterializer()
 
           type PostPayload = Nothing
           type CallConfig = ConcurrencyLevel

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosRemotes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosRemotes.scala
@@ -1,0 +1,195 @@
+package tech.cryptonomic.conseil.tezos
+
+import tech.cryptonomic.conseil.config.{HttpStreamingConfiguration, NetworkCallsConfiguration}
+import tech.cryptonomic.conseil.config.Platforms.TezosConfiguration
+import tech.cryptonomic.conseil.generic.chain.RemoteRpc
+import tech.cryptonomic.conseil.util.JsonUtil.JsonString
+
+
+object TezosRemotesInstances {
+
+  object Akka {
+    import com.typesafe.scalalogging.Logger
+    import cats.Monoid
+    import scala.concurrent.Future
+    import akka.actor.ActorSystem
+    import akka.stream.ActorMaterializer
+    import akka.stream.scaladsl.Source
+    import akka.http.scaladsl.Http
+    import akka.http.scaladsl.model._
+
+    case class TezosNodeInterface(
+      config: TezosConfiguration,
+      requestConfig: NetworkCallsConfiguration,
+      streamingConfig: HttpStreamingConfiguration
+    )(implicit system: ActorSystem) {
+
+      object ShutdownComplete extends ShutdownComplete
+      private val rejectingCalls = new java.util.concurrent.atomic.AtomicBoolean(false)
+
+      def translateCommandToUrl(command: String): String = {
+        import config.nodeConfig._
+        s"$protocol://$hostname:$port/${pathPrefix}chains/main/$command"
+      }
+
+      def shutdown() = {
+        rejectingCalls.compareAndSet(false, true)
+        Http(system).shutdownAllConnectionPools().map(_ => this.ShutdownComplete)(system.dispatcher)
+      }
+
+      def withRejectionControl[T, Container[_]](call: => Container[T])(implicit mono: Monoid[Container[T]]): Container[T] =
+        if (rejectingCalls.get) mono.empty else call
+
+    }
+
+    trait Futures {
+      import cats.Id
+      import cats.data.Const
+      import cats.instances.future._
+      import cats.syntax.apply._
+      import scala.concurrent.ExecutionContext
+      import scala.util.control.NoStackTrace
+
+      //might be actually unlawful, but we won't use it for append, only for empty
+      private implicit def futureMonoid[T](implicit ec: ExecutionContext) = new Monoid[Future[T]] {
+        override def combine(x: Future[T], y: Future[T]) = x *> y
+        override def empty: Future[T] = Future.failed(new IllegalStateException("Tezos node requests will no longer be accepted.") with NoStackTrace)
+      }
+
+      type JustString[CallId] = Const[String, CallId]
+
+      implicit def remote(tezosInterface: TezosNodeInterface)(implicit system: ActorSystem) =
+        new RemoteRpc[Future, Id, JustString] {
+          import tezosInterface.{translateCommandToUrl, withRejectionControl}
+
+          private val logger = Logger("Akka.Futures.RemoteRpc")
+
+          implicit val materializer = ActorMaterializer()
+          implicit val dispatcher = system.dispatcher
+
+          type CallConfig = Any
+          type PostPayload = JsonString
+
+          def runGetCall[CallId](
+            callConfig: Any = (),
+            request: CallId,
+            commandMap: CallId => String
+          ): Future[JustString[CallId]] = withRejectionControl {
+
+            val url = (commandMap andThen translateCommandToUrl)(request)
+            val httpRequest = HttpRequest(HttpMethods.GET, url)
+            logger.debug("Async querying URL {} for platform Tezos and network {}", url, tezosInterface.config.network)
+
+            for {
+              response <- Http(system).singleRequest(httpRequest)
+              strict <- response.entity.toStrict(tezosInterface.requestConfig.GETResponseEntityTimeout)
+            } yield Const(JsonString sanitize strict.data.utf8String)
+
+          }
+
+          def runPostCall[CallId](
+            callConfig: Any = (),
+            request: CallId,
+            commandMap: CallId => String,
+            payload: Option[JsonString]
+          ): Future[JustString[CallId]] = withRejectionControl {
+
+            val url = (commandMap andThen translateCommandToUrl)(request)
+            logger.debug("Async querying URL {} for platform Tezos and network {} with payload {}", url, tezosInterface.config.network, payload)
+            val postedData = payload.getOrElse(JsonString.emptyObject)
+            val httpRequest = HttpRequest(
+              HttpMethods.POST,
+              url,
+              entity = HttpEntity(ContentTypes.`application/json`, postedData.json.getBytes())
+            )
+
+            for {
+              response <- Http(system).singleRequest(httpRequest)
+              strict <- response.entity.toStrict(tezosInterface.requestConfig.POSTResponseEntityTimeout)
+            } yield {
+              val responseBody = strict.data.utf8String
+              logger.debug("Query results: {}", responseBody)
+              Const(JsonString sanitize responseBody)
+            }
+          }
+        }
+    }
+
+    trait Streams {
+      import akka.http.scaladsl.settings.ConnectionPoolSettings
+
+      //might be actually unlawful, but we won't use it for append, only for empty
+      private implicit def sourceMonoid[T] = new Monoid[StreamSource[T]] {
+        override def combine(x: StreamSource[T], y: StreamSource[T]) = x ++ y
+        override def empty: StreamSource[T] = Source.empty[T]
+      }
+
+      type ConcurrencyLevel = Int
+      type StreamSource[A] = Source[A, akka.NotUsed]
+      type TaggedString[CallId] = (CallId, String)
+
+
+      implicit def remote(tezosInterface: TezosNodeInterface)(implicit system: ActorSystem) =
+        new RemoteRpc[StreamSource, StreamSource, TaggedString] {
+          import tezosInterface.{translateCommandToUrl, withRejectionControl}
+          import tezosInterface.config.nodeConfig
+
+          private val logger = Logger("Akka.Streams.RemoteRpc")
+
+          implicit val materializer = ActorMaterializer()
+          implicit val dispatcher = system.dispatcher
+
+          type PostPayload = Nothing
+          type CallConfig = ConcurrencyLevel
+
+          override def runGetCall[CallId](
+            callConfig: ConcurrencyLevel,
+            request: StreamSource[CallId],
+            commandMap: CallId => String
+          ): StreamSource[(CallId, String)] = withRejectionControl {
+            val convertIdToUrl = commandMap andThen translateCommandToUrl
+            val toRequest: ((String, CallId)) => (HttpRequest, CallId) = { case (url, id) => HttpRequest(uri = Uri(url)) -> id }
+
+            request.map(id => convertIdToUrl(id) -> id)
+              .map(toRequest)
+              .via(getHostPoolFlow)
+              .mapAsyncUnordered(callConfig) {
+                case (tried, id) =>
+                  Future.fromTry(tried)
+                    .flatMap(_.entity.toStrict(tezosInterface.requestConfig.GETResponseEntityTimeout))
+                    .map(content => id -> JsonString.sanitize(content.data.utf8String))
+              }
+          }
+
+          override def runPostCall[CallId](
+            callConfig: ConcurrencyLevel,
+            request: StreamSource[CallId],
+            commandMap: CallId => String,
+            payload: Option[Nothing]
+          ): StreamSource[(CallId, String)] =
+            ???
+
+          /* Connection pool settings customized for streaming requests */
+          private val streamingRequestsConnectionPooling: ConnectionPoolSettings = ConnectionPoolSettings(tezosInterface.streamingConfig.pool)
+
+          /* creates a connections pool based on the host network */
+          private[this] def getHostPoolFlow[T] = {
+            if (nodeConfig.protocol == "https")
+              Http(system).cachedHostConnectionPoolHttps[T](
+                host = nodeConfig.hostname,
+                port = nodeConfig.port,
+                settings = streamingRequestsConnectionPooling
+              )
+            else
+              Http(system).cachedHostConnectionPool[T](
+                host = nodeConfig.hostname,
+                port = nodeConfig.port,
+                settings = streamingRequestsConnectionPooling
+              )
+          }
+
+        }
+
+    }
+  }
+}

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTest.scala
@@ -51,8 +51,8 @@ class TezosNodeOperatorTest extends FlatSpec with MockFactory with Matchers with
       .returns(votesProposal)
 
     (tezosRPCInterface.runBatchedGetQuery[Any] _)
-      .when("zeronet", *, *, *)
-      .onCall( (_, input, command, _) =>
+      .when("zeronet", *, *, *, *)
+      .onCall((_, input, command, _, _) =>
         Future.successful(List(
           //dirty trick to find the type of input content and provide the appropriate response
           input match {
@@ -107,8 +107,8 @@ class TezosNodeOperatorTest extends FlatSpec with MockFactory with Matchers with
       .returns(votesProposal)
 
     (tezosRPCInterface.runBatchedGetQuery[Any] _)
-      .when("zeronet", *, *, *)
-      .onCall((_, input, command, _) =>
+      .when("zeronet", *, *, *, *)
+      .onCall((_, input, command, _, _) =>
         Future.successful(List(
           //dirty trick to find the type of input content and provide the appropriate response
           input match {
@@ -164,8 +164,8 @@ class TezosNodeOperatorTest extends FlatSpec with MockFactory with Matchers with
       .returns(votesProposal)
 
     (tezosRPCInterface.runBatchedGetQuery[Any] _)
-      .when("zeronet", *, *, *)
-      .onCall((_, input, command, _) =>
+      .when("zeronet", *, *, *, *)
+      .onCall((_, input, command, _, _) =>
         Future.successful(List(
           //dirty trick to find the type of input content and provide the appropriate response
           input match {


### PR DESCRIPTION
## This is a multi-step rewrite to finally create a more flexible design of the node operator, allowing for different "backends" to implement the rpc calls and tezos fetch logic

### It is not meant to be merged as-is but to provide material for progressive review of the whole refactor

The "pluggable-backend" approach will make it easier to try streaming designs, based on different implementations than akka-stream and plain scala futures
The long-term plan is to open a discussion to evaluate the switch to cats-effects/monix/fs2

---
The current step introduces a type class design for the Tezos RPC calls, enabling a simpler interface that can accommodate different implementations.
This makes it easy to create sync, async, streaming rpc calls.

We define RPC callers for both `Future` and `akka.stream`-`Source` (the latter supports only GET calls actually)

The future rpc is used directly by Node Operator to individually fetch data from single endpoints.
The streaming rpc is now internally required by the async DataFetchers, providing multiple endpoint calls in the NodeOperator.