### PR TITLE
Conseil 322-2: tagless final node operator

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/Conseil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Conseil.scala
@@ -15,7 +15,6 @@ import tech.cryptonomic.conseil.io.MainOutputs.ConseilOutput
 import tech.cryptonomic.conseil.config.ConseilAppConfig
 import tech.cryptonomic.conseil.directives.EnableCORSDirectives
 import tech.cryptonomic.conseil.routes._
-import tech.cryptonomic.conseil.routes.openapi.OpenApiDoc
 import tech.cryptonomic.conseil.tezos.TezosPlatformDiscoveryOperations.{AttributesCache, EntitiesCache}
 import tech.cryptonomic.conseil.tezos.{ApiOperations, TezosPlatformDiscoveryOperations}
 

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataFetcher.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataFetcher.scala
@@ -95,7 +95,7 @@ object DataFetcher {
    * Example: the fetcher for tezos blocks might have type `Aux[Future, List, Throwable, Int, BlockData, String]
    * where the Int is for the offset from a given block, and String is a representation of a json value.
    */
-  private type Aux[Eff[_], Coll[_], Err, Input, Output, Encoding] = DataFetcher[Eff, Coll, Err] {
+  type Aux[Eff[_], Coll[_], Err, Input, Output, Encoding] = DataFetcher[Eff, Coll, Err] {
       type In = Input
       type Out = Output
       type Encoded = Encoding

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/RemoteRpc.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/RemoteRpc.scala
@@ -1,13 +1,39 @@
 package tech.cryptonomic.conseil.generic.chain
 
+/** describes remote calls, adding extra things on top
+  * `Eff` is the container effect for the call response
+  * `Req` is a wrapper around the call input parameter, to allow variations from a single element call
+  * `Res` is a response type that will include the call parameter too, to express a correlation from input to output
+  *   when the call values are wrapped themselves
+  */
 trait RemoteRpc[Eff[_], Req[_], Res[_]] {
 
+  /** defines the type of extra call parameters,
+    *  sometimes needed to implement specific features without bolting
+    * hard-coded configuration values
+    */
   type CallConfig
+  /** the type of a Post payload, when needed*/
   type PostPayload
 
+  /** make a GET
+    * @param callConfig extra call params needed by specific implementations (e.g. concurrency level), can be ignored if not needed
+    * @param request a container `Req` of sort, for one or more input id (of type `CallId`), allow multiple requests for example
+    * @param commandMap a function that, given the input `CallId` will generate the endpoint to call, essentially a url
+    * @return a response embedded in a effect `Eff`, with a type that can include a relation to the input id `CallId`, e.g. a simple tuple `(CallId, ReturnValue)`
+    * @tparam CallId the type of each specific endpoint call input, or correlation id for the call, it's highly dependent on each endpoint call type
+    */
   def runGetCall[CallId](callConfig: CallConfig, request: Req[CallId], commandMap: CallId => String): Eff[Res[CallId]]
 
-  def runPostCall[CallId](callConfig: CallConfig, request: Req[CallId], commandMap: CallId => String, payload: Option[PostPayload] = None): Eff[Res[CallId]]
+  /** make a POST
+    * @param callConfig extra call params needed by specific implementations (e.g. concurrency level), can be ignored if not needed
+    * @param request a container `Req` of sort, for one or more input id (of type `CallId`), allow multiple requests for example
+    * @param commandMap a function that, given the input `CallId` will generate the endpoint to call, essentially a url
+    * @param payload an optional post payload, of a type that the implementation can eventually handle
+    * @return a response embedded in a effect `Eff`, with a type that can include a relation to the input id `CallId`, e.g. a simple tuple `(CallId, ReturnValue)`
+    * @tparam CallId the type of each specific endpoint call input, or correlation id for the call, it's highly dependent on each endpoint call type
+    */
+    def runPostCall[CallId](callConfig: CallConfig, request: Req[CallId], commandMap: CallId => String, payload: Option[PostPayload] = None): Eff[Res[CallId]]
 
 }
 
@@ -17,7 +43,8 @@ object RemoteRpc {
   import cats.syntax.functor._
 
   /* type aliases */
-  /** the complete signature applies to
+
+  /** The complete signature applies to
     * - wrapped input values
     * - an output which depends on the input value, for correlation
     * - a complex call configuration parameter, including extra information to execute the call
@@ -25,13 +52,15 @@ object RemoteRpc {
     */
   type Aux[Eff[_], Req[_], Res[_], Conf, Payload] = RemoteRpc[Eff, Req, Res] { type CallConfig = Conf; type PostPayload = Payload }
 
-  /** support calls with no input wrapping (i.e. single values), and a simply-typed output, independent of the input value */
+  /** Support calls with no input wrapping (i.e. single values), and a simply-typed output, independent of the input value */
   type Basic[Eff[_], Result, Payload] = RemoteRpc.Aux[Eff, Id, Const[Result, ?], Any, Payload]
 
+  /** Factory method based on an implicit instance available in scope */
   def apply[Eff[_], Req[_], Res[_], CallConfig, Payload](
     implicit remote: Aux[Eff, Req, Res, CallConfig, Payload]
   ): Aux[Eff, Req, Res, CallConfig, Payload] = remote
 
+  /** A static call that uses the implicit `RemoteRpc` instance available for the expected paramter types */
   def runGet[Eff[_], CallId, Req[_], Res[_], CallConfig](
     callConfig: CallConfig,
     request: Req[CallId],
@@ -39,23 +68,33 @@ object RemoteRpc {
   )(implicit remote: Aux[Eff, Req, Res, CallConfig, _]): Eff[Res[CallId]] =
     remote.runGetCall(callConfig, request, commandMap)
 
+  /** Simplified get call, doesn't require any extra call configuration parameter */
   def runGet[Eff[_], CallId, Req[_], Res[_]](
     request: Req[CallId],
     commandMap: CallId => String
   )(implicit remote: Aux[Eff, Req, Res, Any, _]): Eff[Res[CallId]] =
     remote.runGetCall((), request, commandMap)
 
+  /** Simplified get call, doesn't require any extra call configuration parameter
+    * and will make a single rpc call on the input `CallId` value
+    */
   def runGet[Eff[_]: Functor, CallId, Res](
     request: CallId,
     commandMap: CallId => String
   )(implicit remote: Basic[Eff, Res, _]): Eff[Res] =
     remote.runGetCall((), request, commandMap).map(_.getConst)
 
-  def runGet[Eff[_]: Functor, Res](
+  /** Simplified get call, doesn't require any extra call configuration parameter
+    * and will make a single rpc call to the provided command url (or subpath, actually).
+    * Since no input id is provided, the response cannot depend on it, hence the return type
+    * will be a `cats.data.Const` of some type, ignoring the input.
+    */
+    def runGet[Eff[_]: Functor, Res](
     command: String,
   )(implicit remote: Basic[Eff,Res, _]): Eff[Res] =
     remote.runGetCall((), (), (_: Any) => command).map(_.getConst)
 
+  /** A static call that uses the implicit `RemoteRpc` instance available for the expected paramter types */
   def runPost[Eff[_], CallId, Req[_], Res[_], CallConfig, Payload](
     callConfig: CallConfig,
     request: Req[CallId],
@@ -64,6 +103,7 @@ object RemoteRpc {
   )(implicit remote: Aux[Eff, Req, Res, CallConfig, Payload]): Eff[Res[CallId]] =
     remote.runPostCall(callConfig, request, commandMap, payload)
 
+  /** Simplified post call, doesn't require any extra call configuration parameter */
   def runPost[Eff[_], CallId, Req[_], Res[_], Payload](
     request: Req[CallId],
     commandMap: CallId => String,
@@ -71,6 +111,9 @@ object RemoteRpc {
   )(implicit remote: Aux[Eff, Req, Res, Any, Payload]): Eff[Res[CallId]] =
     remote.runPostCall((), request, commandMap, payload)
 
+  /** Simplified post call, doesn't require any extra call configuration parameter
+    * and will make a single rpc call on the input `CallId` value
+    */
   def runPost[Eff[_]: Functor, CallId, Res, Payload](
     request: CallId,
     commandMap: CallId => String,
@@ -78,6 +121,11 @@ object RemoteRpc {
   )(implicit remote: Aux[Eff, Id, Const[Res, ?], Any, Payload]): Eff[Res] =
     remote.runPostCall((), request, commandMap, payload).map(_.getConst)
 
+  /** Simplified post call, doesn't require any extra call configuration parameter
+    * and will make a single rpc call to the provided command url (or subpath, actually).
+    * Since no input id is provided, the response cannot depend on it, hence the return type
+    * will be a `cats.data.Const` of some type, ignoring the input.
+    */
   def runPost[Eff[_]: Functor, Res, Payload](
     command: String,
     payload: Option[Payload]

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/BlockchainOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/BlockchainOperator.scala
@@ -1,0 +1,377 @@
+package tech.cryptonomic.conseil.tezos
+
+import tech.cryptonomic.conseil.generic.chain.{DataFetcher, RemoteRpc}
+import tech.cryptonomic.conseil.generic.chain.DataFetcher.{fetch, fetchMerge}
+import tech.cryptonomic.conseil.tezos.TezosTypes._
+import tech.cryptonomic.conseil.tezos.michelson.JsonToMichelson
+import tech.cryptonomic.conseil.tezos.michelson.dto.{MichelsonCode, MichelsonElement, MichelsonExpression, MichelsonSchema}
+import tech.cryptonomic.conseil.tezos.michelson.parser.JsonParser
+import tech.cryptonomic.conseil.util.JsonUtil.{fromJson, JsonString => JS}
+import com.typesafe.scalalogging.Logger
+import cats.{Functor, MonadError, Monoid}
+import cats.data.Reader
+import cats.syntax.applicative._
+import cats.syntax.applicativeError._
+import cats.syntax.apply._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import scala.math.max
+import scala.reflect.ClassTag
+import scala.util.Try
+
+/** Operations run against Tezos nodes, mainly used for collecting chain data for later entry into a database. */
+trait BlockchainOperator {
+
+  /** which tezos network to go against */
+  def network: String
+  /** assumes some capability to log */
+  def logger: Logger
+
+  //use this aliases to make signatures easier to read and kept in-sync
+
+  /** the whole results of reading latest info from the chain */
+  type BlockFetchingResults = List[(Block, List[AccountId])]
+  /** describes capability to run a single remote call returning strings*/
+  type RpcGet[F[_]] = RemoteRpc.Basic[F, String, _]
+  /** describes capability to run a single remote call returning strings, passing a payload*/
+  type RpcPost[F[_], Payload] = RemoteRpc.Basic[F, String, Payload]
+  /** complex fetching of multiple data, collected in Lists (both input and corresponding outputs), with internal string encoding */
+  type ListFetcher[F[_], In, Out] = DataFetcher.Aux[F, List, Throwable, In, Out, String]
+  /** a monad that can raise and handle Throwables */
+  type MonadThrow[F[_]] = MonadError[F, Throwable]
+  /** generic pair of multiple Ts with their associated block reference */
+  type BlockRelated[T] = (Block, List[T])
+
+  /**
+    * Fetches a specific account for a given block.
+    * @param blockHash  Hash of given block
+    * @param accountId  Account ID
+    * @return           The account
+    */
+  def getAccountForBlock[F[_] : RpcGet : Functor](blockHash: BlockHash, accountId: AccountId): F[Account] =
+    RemoteRpc.runGet(s"blocks/${blockHash.value}/context/contracts/${accountId.id}")
+      .map(fromJson[Account])
+
+  /**
+    * Fetches the manager of a specific account for a given block.
+    * @param blockHash  Hash of given block
+    * @param accountId  Account ID
+    * @return           The account's manager key
+    */
+  def getAccountManagerForBlock[F[_] : RpcGet : Functor](blockHash: BlockHash, accountId: AccountId): F[ManagerKey] =
+    RemoteRpc.runGet(s"blocks/${blockHash.value}/context/contracts/${accountId.id}/manager_key")
+      .map(fromJson[ManagerKey])
+
+  /**
+    * Fetches all accounts for a given block.
+    * @param blockHash  Hash of given block.
+    * @return           Accounts
+    */
+  def getAllAccountsForBlock[F[_] : MonadThrow : RpcGet](blockHash: BlockHash)
+    (implicit fetchProvider: Reader[BlockHash, ListFetcher[F, AccountId, Option[Account]]]): F[Map[AccountId, Account]] = {
+
+    for {
+      jsonEncodedAccounts <- RemoteRpc.runGet(s"blocks/${blockHash.value}/context/contracts")
+      accountIds = fromJson[List[String]](jsonEncodedAccounts).map(AccountId)
+      accounts <- getAccountsForBlock(accountIds, blockHash)
+    } yield accounts
+  }
+
+  /**
+    * Fetches the accounts identified by id
+    *
+    * @param accountIds the ids
+    * @param blockHash  the block storing the accounts, the head block if not specified
+    * @return           the list of accounts, indexed by AccountId
+    */
+  def getAccountsForBlock[F[_] : MonadThrow](accountIds: List[AccountId], blockHash: BlockHash = blockHeadHash)
+    (implicit fetchProvider: Reader[BlockHash, ListFetcher[F, AccountId, Option[Account]]]): F[Map[AccountId, Account]] = {
+      import TezosOptics.Accounts.optionalScriptCode
+      import cats.instances.list._
+
+      implicit val fetcher = fetchProvider(blockHash)
+
+      /*tries decoding but simply returns the input unchanged on failure*/
+      def parseScript(code: String): String = Try(toMichelsonScript[MichelsonCode](code)).getOrElse(code)
+
+      val fetchedAccounts: F[List[(AccountId, Option[Account])]] =
+        fetch[AccountId, Option[Account], F, List, Throwable].run(accountIds)
+
+      fetchedAccounts.map(
+        indexedAccounts =>
+          indexedAccounts.collect {
+            case (accountId, Some(account)) => accountId -> optionalScriptCode.modify(parseScript)(account)
+          }.toMap
+      )
+    }
+
+  /**
+    * Get accounts for all the identifiers passed-in with the corresponding block
+    * @param accountsBlocksIndex a map from unique id to the [latest] block reference
+    * @return         Accounts with their corresponding block data
+    *
+    */
+  @deprecated(message = "This might not be needed anymore", since = "April 2019")
+  def getAccountsForBlocks[F[_] : MonadThrow](accountsBlocksIndex: Map[AccountId, BlockReference])
+    (implicit fetchProvider: Reader[BlockHash, ListFetcher[F, AccountId, Option[Account]]]): F[List[BlockAccounts]] = {
+
+    def notifyAnyLostIds(missing: Set[AccountId]) =
+      if (missing.nonEmpty) {
+        logger.warn(
+          "The following account keys were not found querying the {} node: {}",
+          network,
+          missing.map(_.id).mkString("\n", ",", "\n")
+        )
+      }
+
+    //uses the index to collect together BlockAccounts matching the same block
+    def groupByLatestBlock(data: Map[AccountId, Account]): List[BlockAccounts] =
+      data.groupBy {
+        case (id, _) => accountsBlocksIndex(id)
+      }.map {
+        case ((hash, level), accounts) => BlockAccounts(hash, level, accounts)
+      }.toList
+
+    //fetch accounts by requested ids and group them together with corresponding blocks
+    getAccountsForBlock(accountsBlocksIndex.keys.toList)
+      .onError{
+        case err =>
+          val showSomeIds = accountsBlocksIndex.keys.take(30).map(_.id).mkString("", ",", if (accountsBlocksIndex.size > 30) "..." else "")
+          logger.error(s"Could not get accounts' data for ids ${showSomeIds}", err).pure[F]
+      }
+      .map {
+        accountsMap =>
+          notifyAnyLostIds(accountsBlocksIndex.keySet -- accountsMap.keySet)
+          groupByLatestBlock(accountsMap)
+      }
+
+  }
+
+  /**
+    * Fetches operations for a block, without waiting for the result
+    * @param blockHash Hash of the block
+    * @return          The list of operations
+    */
+  def getAllOperationsForBlock[F[_] : RpcGet : MonadThrow](block: BlockData): F[List[OperationsGroup]] = {
+    import JsonDecoders.Circe.decodeLiftingTo
+    import JsonDecoders.Circe.Operations._
+    import tech.cryptonomic.conseil.util.JsonUtil.adaptManagerPubkeyField
+
+    //parse json, and try to convert to objects, converting failures to a failed F monad
+    //we could later improve by "accumulating" all errors in a single failed monad, with `decodeAccumulating`
+    def decodeOperations(json: String) =
+      decodeLiftingTo[F, List[List[OperationsGroup]]](adaptManagerPubkeyField(JS.sanitize(json)))
+        .map(_.flatten)
+
+    if (isGenesis(block))
+      List.empty.pure //This is a workaround for the Tezos node returning a 404 error when asked for the operations or accounts of the genesis blog, which seems like a bug.
+    else
+      RemoteRpc.runGet(s"blocks/${block.hash.value}/operations")
+        .flatMap(decodeOperations)
+  }
+
+  /** Fetches current votes information at the specific block */
+  def getCurrentVotesForBlock[F[_] : RpcGet : MonadThrow](block: BlockData, offset: Option[Offset] = None): F[CurrentVotes] =
+    if (isGenesis(block))
+      CurrentVotes.empty.pure
+    else {
+      import JsonDecoders.Circe._
+
+      val offsetString = offset.map(_.toString).getOrElse("")
+      val hashString = block.hash.value
+
+      val fetchCurrentQuorum =
+        RemoteRpc.runGet(s"blocks/$hashString~$offsetString/votes/current_quorum") flatMap { json =>
+          decodeLiftingTo[F, Option[Int]](json)
+        }
+
+      val fetchCurrentProposal =
+        RemoteRpc.runGet(s"blocks/$hashString~$offsetString/votes/current_proposal") flatMap { json =>
+          decodeLiftingTo[F, Option[ProtocolId]](json)
+        }
+
+      (fetchCurrentQuorum, fetchCurrentProposal).mapN(CurrentVotes.apply)
+    }
+
+  /** Fetches detailed data for voting associated to the passed-in blocks */
+  def getVotingDetails[F[_] : MonadThrow](blocks: List[Block])
+    (implicit
+      proposalFetcher: ListFetcher[F, Block, List[ProtocolId]],
+      bakersFetch: ListFetcher[F, Block, List[Voting.BakerRolls]],
+      ballotsFetcher: ListFetcher[F, Block, List[Voting.Ballot]]
+    ): F[(List[Voting.Proposal], List[BlockRelated[Voting.BakerRolls]], List[BlockRelated[Voting.Ballot]])] = {
+    import cats.instances.list._
+
+    //adapt the proposal protocols result to include the block
+    val fetchProposals =
+      fetch[Block, List[ProtocolId], F, List, Throwable]
+        .map {
+          proposalsList => proposalsList.map {
+            case (block, protocols) => Voting.Proposal(protocols, block)
+          }
+        }
+
+    val fetchBakers =
+      fetch[Block, List[Voting.BakerRolls], F, List, Throwable]
+
+    val fetchBallots =
+      fetch[Block, List[Voting.Ballot], F, List, Throwable]
+
+
+    /* combine the three kleisli operations to return a tuple of the results
+     * and then run the composition on the input blocks
+     */
+    (fetchProposals, fetchBakers, fetchBallots).tupled.run(blocks.filterNot(b => isGenesis(b.data)))
+  }
+
+  /** Fetches a single block from the chain, without waiting for the result
+    * @param hash Hash of the block
+    * @param offset an offset level to use from the passed hash, optionally
+    * @return the block data
+    */
+  def getBlock[F[_] : RpcGet : MonadThrow](hash: BlockHash, offset: Option[Offset] = None): F[Block] = {
+    import JsonDecoders.Circe.decodeLiftingTo
+    import JsonDecoders.Circe.Blocks._
+
+    val offsetString = offset.fold("")(_.toString)
+
+    val fetchBlock =
+      RemoteRpc.runGet(s"blocks/${hash.value}~$offsetString") flatMap { json =>
+        decodeLiftingTo[F, BlockData](JS.sanitize(json))
+      }
+
+    for {
+      block <- fetchBlock
+      ops <- getAllOperationsForBlock(block)
+      votes <- getCurrentVotesForBlock(block)
+    } yield Block(block, ops, votes)
+
+  }
+
+  /** Gets the block head.
+    * @return Block head
+    */
+  def getBlockHead[F[_] : RpcGet : MonadThrow](): F[Block] =
+    getBlock(blockHeadHash)
+
+  /** Gets all blocks from the head down to the oldest block not already in the database.
+   *  @param fetchLocalMaxLevel should read the current top-level available for the chain, as stored in conseil
+    * @return Blocks and Account hashes involved
+    */
+  def getBlocksNotInDatabase[F[_] : RpcGet : MonadThrow](fetchLocalMaxLevel: () => F[Int])
+  (implicit
+    blockDataFetchProvider: Reader[BlockHash, ListFetcher[F, Offset, BlockData]],
+    additionalDataFetcher: ListFetcher[F, BlockHash, (List[OperationsGroup], List[AccountId])],
+    quorumFetcher: ListFetcher[F, BlockHash, Option[Int]],
+    proposalFetcher: ListFetcher[F, BlockHash, Option[ProtocolId]],
+    resultMonoid: Monoid[BlockFetchingResults]
+  ): F[BlockFetchingResults] =
+    for {
+      maxLevel <- fetchLocalMaxLevel()
+      blockHead <- getBlockHead()
+      headLevel = blockHead.data.header.level
+      headHash = blockHead.data.hash
+      bootstrapping = maxLevel == -1
+      results <-
+        if (maxLevel < headLevel) {
+          //got something to load
+          if (bootstrapping) logger.warn("There were apparently no blocks in the database. Downloading the whole chain..")
+          else logger.info("I found the new block head at level {}, the currently stored max is {}. I'll fetch the missing {} blocks.", headLevel, maxLevel, headLevel - maxLevel)
+          getBlocks((headHash, headLevel), maxLevel + 1 to headLevel)
+        } else {
+          logger.info("No new blocks to fetch from the network")
+          resultMonoid.empty.pure
+        }
+    } yield results
+
+  /** Gets last `depth` blocks.
+    * @param depth      Number of latest block to fetch, `None` to get all
+    * @param headHash   Hash of a block from which to start, None to start from a real head
+    * @return           Blocks and Account hashes involved
+    */
+  def getLatestBlocks[F[_] : RpcGet : MonadThrow](depth: Option[Int] = None, headHash: Option[BlockHash] = None)
+  (implicit
+    blockDataFetchProvider: Reader[BlockHash, ListFetcher[F, Offset, BlockData]],
+    additionalDataFetcher: ListFetcher[F, BlockHash, (List[OperationsGroup], List[AccountId])],
+    quorumFetcher: ListFetcher[F, BlockHash, Option[Int]],
+    proposalFetcher: ListFetcher[F, BlockHash, Option[ProtocolId]]
+  ): F[BlockFetchingResults] =
+    headHash.fold(getBlockHead())(getBlock(_))
+      .flatMap {
+        maxHead =>
+          val headLevel = maxHead.data.header.level
+          val headHash = maxHead.data.hash
+          val minLevel = depth.fold(1)(d => max(1, headLevel - d + 1))
+          getBlocks((headHash, headLevel), minLevel to headLevel)
+      }
+
+  /** Gets block from Tezos Blockchains, as well as their associated operation, from minLevel to maxLevel.
+    * @param reference Hash and level of a known block
+    * @param levelRange a range of levels to load
+    * @return the list of blocks with relative account ids touched in the operations
+    */
+  private def getBlocks[F[_] : MonadThrow](reference: (BlockHash, Int), levelRange: Range.Inclusive)
+    (implicit
+      blockDataFetchProvider: Reader[BlockHash, ListFetcher[F, Offset, BlockData]],
+      additionalDataFetcher: ListFetcher[F, BlockHash, (List[OperationsGroup], List[AccountId])],
+      quorumFetcher: ListFetcher[F, BlockHash, Option[Int]],
+      proposalFetcher: ListFetcher[F, BlockHash, Option[ProtocolId]]
+    ): F[BlockFetchingResults] = {
+      import cats.instances.list._
+      import TezosTypes.Lenses._
+
+      val (hashRef, levelRef) = reference
+      require(levelRange.start >= 0 && levelRange.end <= levelRef)
+      val offsets = levelRange.map(lvl => levelRef - lvl).toList
+
+      implicit val blockDataFetcher = blockDataFetchProvider(hashRef)
+      val proposalsStateFetch = fetchMerge(quorumFetcher, proposalFetcher)(CurrentVotes.apply)
+
+      val parseMichelsonScripts: Block => Block = {
+        val codeAlter = codeLens.modify(toMichelsonScript[MichelsonSchema])
+        val storageAlter = storageLens.modify(toMichelsonScript[MichelsonExpression])
+        val parametersAlter = parametersLens.modify(toMichelsonScript[MichelsonExpression])
+
+        codeAlter compose storageAlter compose parametersAlter
+      }
+
+      //Gets blocks data for the requested offsets and associates the operations and account hashes available involved in said operations
+      //Special care is taken for the genesis block (level = 0) that doesn't have operations defined, we use empty data for it
+      for {
+        fetchedBlocksData <- fetch[Offset, BlockData, F, List, Throwable].run(offsets)
+        blockHashes = fetchedBlocksData.collect{ case (offset, block) if !isGenesis(block) => block.hash }
+        fetchedOperationsWithAccounts <- fetch[BlockHash, (List[OperationsGroup], List[AccountId]), F, List, Throwable].run(blockHashes)
+        proposalsState <- proposalsStateFetch.run(blockHashes)
+      } yield {
+        val operationalDataMap = fetchedOperationsWithAccounts.map{ case (hash, (ops, accounts)) => (hash, (ops, accounts))}.toMap
+        val proposalsMap = proposalsState.toMap
+        fetchedBlocksData.map {
+          case (offset, md) =>
+            val (ops, accs) = if (isGenesis(md)) (List.empty, List.empty) else operationalDataMap(md.hash)
+            val votes = proposalsMap.getOrElse(md.hash, CurrentVotes.empty)
+            (parseMichelsonScripts(Block(md, ops, votes)), accs)
+        }
+      }
+
+    }
+
+  private def toMichelsonScript[T <: MichelsonElement : JsonParser.Parser](json: Any)(implicit tag: ClassTag[T]): String = {
+    val UNPARSABLE_CODE_PLACEMENT = "Unparsable code: "
+    import JsonToMichelson._
+    import tech.cryptonomic.conseil.util.Conversion.Syntax._
+
+    Some(json).collect {
+      case t: String => t.convertToA[Either[Throwable, ?], String]
+      case t: Micheline => t.expression.convertToA[Either[Throwable, ?], String]
+    } match {
+      case Some(Right(value)) => value
+      case Some(Left(t)) =>
+        logger.error(s"${tag.runtimeClass}: Error during conversion of $json", t)
+        UNPARSABLE_CODE_PLACEMENT + json
+      case _ =>
+        logger.error(s"${tag.runtimeClass}: Error during conversion of $json")
+        UNPARSABLE_CODE_PLACEMENT + json
+    }
+  }
+
+}

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/NodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/NodeOperator.scala
@@ -20,7 +20,7 @@ import scala.reflect.ClassTag
 import scala.util.Try
 
 /** Operations run against Tezos nodes, mainly used for collecting chain data for later entry into a database. */
-trait BlockchainOperator {
+trait NodeOperator {
 
   /** which tezos network to go against */
   def network: String
@@ -323,6 +323,8 @@ trait BlockchainOperator {
       val (hashRef, levelRef) = reference
       require(levelRange.start >= 0 && levelRange.end <= levelRef)
       val offsets = levelRange.map(lvl => levelRef - lvl).toList
+
+      logger.debug(s"Request to fetch blocks offsets up to ${offsets.max} starting from $levelRef, hash: ${hashRef.value}")
 
       implicit val blockDataFetcher = blockDataFetchProvider(hashRef)
       val proposalsStateFetch = fetchMerge(quorumFetcher, proposalFetcher)(CurrentVotes.apply)

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -48,8 +48,6 @@ object TezosNodeOperator {
         .filterNot(_.isEmpty)
         .map(subRange => subRange.head to subRange.last)
 
-    val isGenesis = (data: BlockData) => data.header.level == 0
-
 }
 
 /**
@@ -68,7 +66,6 @@ class TezosNodeOperator(val network: String, batchConf: BatchFetchConfiguration)
   with TezosRemoteInstances.Akka.Streams
   with BlocksDataFetchers
   with AccountsDataFetchers {
-  import TezosNodeOperator.isGenesis
   import batchConf.blockPageSize
 
   override implicit val actorMaterializer = ActorMaterializer()
@@ -140,7 +137,7 @@ class TezosNodeOperator(val network: String, batchConf: BatchFetchConfiguration)
     import TezosOptics.Accounts.optionalScriptCode
     import tech.cryptonomic.conseil.generic.chain.DataFetcher.fetch
 
-    implicit val fetcherInstance = accountFetcher(blockHash)
+    implicit val fetcherInstance = accountsFetcherProvider(blockHash)
 
     /*tries decoding but simply returns the input unchanged on failure*/
     def parseScript(code: String): String = Try(toMichelsonScript[MichelsonCode](code)).getOrElse(code)
@@ -386,7 +383,7 @@ class TezosNodeOperator(val network: String, batchConf: BatchFetchConfiguration)
     require(levelRange.start >= 0 && levelRange.end <= levelRef)
     val offsets = levelRange.map(lvl => levelRef - lvl).toList
 
-    implicit val blockFetcher = blocksFetcher(hashRef)
+    implicit val blockFetcher = blocksFetcherProvider(hashRef)
 
     //read the separate parts of voting and merge the results
     val proposalsStateFetch =

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosRemotes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosRemotes.scala
@@ -42,6 +42,8 @@ object TezosRemoteInstances {
 
     }
 
+    object Futures extends Futures
+
     trait Futures {
       import cats.Id
       import cats.data.Const
@@ -116,7 +118,7 @@ object TezosRemoteInstances {
         }
     }
 
-    object Streams {
+    object Streams extends Streams {
 
       type ConcurrencyLevel = Int
       type StreamSource[A] = Source[A, akka.NotUsed]

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -49,8 +49,14 @@ object TezosTypes {
     pattern.matcher(s).matches
   }
 
+  /** is the block the genesis? */
+  val isGenesis = (data: BlockData) => data.header.level == 0
+
   /** convenience alias to simplify declarations of block hash+level tuples */
   type BlockReference = (BlockHash, Int)
+
+  /** a block offset from the head */
+  type Offset = Int
 
   final case class PublicKey(value: String) extends AnyVal
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/JsonToMichelson.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/JsonToMichelson.scala
@@ -4,6 +4,7 @@ import tech.cryptonomic.conseil.tezos.michelson.dto.MichelsonElement
 import tech.cryptonomic.conseil.tezos.michelson.parser.JsonParser
 import tech.cryptonomic.conseil.tezos.michelson.parser.JsonParser.Parser
 import tech.cryptonomic.conseil.tezos.michelson.renderer.MichelsonRenderer._
+import tech.cryptonomic.conseil.util.Conversion
 
 /* Converts Michelson schema from JSON to its native format */
 object JsonToMichelson {
@@ -12,5 +13,9 @@ object JsonToMichelson {
 
   def convert[T <: MichelsonElement:Parser](json: String): Result[String] = {
     JsonParser.parse[T](json).map(_.render())
+  }
+
+  implicit def michelsonConversions[T] = new Conversion[Either[Throwable, ?], String, String] {
+    override def convert(from: String): Either[Throwable, String] = convert(from)
   }
 }

--- a/src/main/scala/tech/cryptonomic/conseil/util/ConfigUtil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/util/ConfigUtil.scala
@@ -6,7 +6,7 @@ import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.{Network, P
 
 import scala.util.Try
 import tech.cryptonomic.conseil.config.Platforms._
-import tech.cryptonomic.conseil.config.{HttpStreamingConfiguration, Newest}
+import tech.cryptonomic.conseil.config.HttpStreamingConfiguration
 
 object ConfigUtil {
 

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTest.scala
@@ -2,198 +2,176 @@ package tech.cryptonomic.conseil.tezos
 
 import com.typesafe.scalalogging.LazyLogging
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FlatSpec, Matchers}
-import tech.cryptonomic.conseil.config.BatchFetchConfiguration
-import tech.cryptonomic.conseil.tezos.TezosTypes.BlockHash
+import tech.cryptonomic.conseil.tezos.TezosTypes._
+import tech.cryptonomic.conseil.generic.chain.RemoteRpc
 
-import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration._
+import cats.Id
+import cats.data.{Const, Reader}
 
-class TezosNodeOperatorTest extends FlatSpec with MockFactory with Matchers with LazyLogging with ScalaFutures with IntegrationPatience {
-  import ExecutionContext.Implicits.global
+class TezosNodeOperatorTest
+  extends FlatSpec
+  with MockFactory
+  with Matchers
+  with LazyLogging
+  with TezosNodeOperatorTestImplicits {
+  //used to log within the test node using the testsuite's own logger
+  val outerLogger = logger
 
-  val config = BatchFetchConfiguration(1, 1, 500, 10 seconds, 10 seconds)
+  // create a test instance
+  val sut: NodeOperator = new NodeOperator {
+    override val logger = outerLogger
+    override val network: String = "network"
+  }
 
   "getBlock" should "correctly fetch the genesis block" in {
     //given
-    val tezosRPCInterface = stub[TezosRPCInterface]
-    val blockResponse = Future.successful(TezosResponseBuilder.genesisBlockResponse)
-    (tezosRPCInterface.runAsyncGetQuery _).when("zeronet", "blocks/BLockGenesisGenesisGenesisGenesisGenesisb83baZgbyZe~").returns(blockResponse)
+    //test remote caller, with no special effect on input or output, returning a String
+    implicit val testRpc = new RemoteRpc[Id, Id, Const[String, ?]] {
+      type CallConfig = Any
+      type PostPayload = Nothing
 
-    val nodeOp: TezosNodeOperator = new TezosNodeOperator(tezosRPCInterface, "zeronet", config)
+      override def runGetCall[CallId](callConfig: Any, request: CallId, commandMap: CallId => String): Const[String,CallId] =
+        Const(TezosResponseBuilder.genesisBlockResponse)
+
+      override def runPostCall[CallId](callConfig: Any, request: CallId, commandMap: CallId => String, payload: Option[Nothing]): Const[String,CallId] = ???
+    }
 
     //when
-    val block: Future[TezosTypes.Block] = nodeOp.getBlock(BlockHash("BLockGenesisGenesisGenesisGenesisGenesisb83baZgbyZe"))
+    val block: TezosTypes.Block = sut.getBlock[Id](BlockHash("BLockGenesisGenesisGenesisGenesisGenesisb83baZgbyZe"))
 
     //then
-    block.futureValue.data.hash shouldBe BlockHash("BLockGenesisGenesisGenesisGenesisGenesisb83baZgbyZe")
+    block.data.hash shouldBe BlockHash("BLockGenesisGenesisGenesisGenesisGenesisb83baZgbyZe")
   }
 
-  "getLatestBlocks" should "correctly fetch all the blocks if no depth is passed-in" in {
-    //given
-    val tezosRPCInterface = stub[TezosRPCInterface]
-    val blockResponse = Future.successful(TezosResponseBuilder.blockResponse)
-    val operationsResponse = Future.successful(TezosResponseBuilder.operationsResponse)
-    val votesQuorum = Future.successful(TezosResponseBuilder.votesQuorum)
-    val votesProposal = Future.successful(TezosResponseBuilder.votesProposal)
+  "getLatestBlocks" should "correctly fetch all the blocks if no depth is passed-in" in withInstances {
+    implicit extraBlockFetcher => implicit quorumFetcher => implicit proposalFetcher =>
+      //given
+      //test remote caller, with no special effect on input or output, returning a String, based on expected calls
+      implicit val testRpc = new RemoteRpc[Id, Id, Const[String, ?]] {
+        type CallConfig = Any
+        type PostPayload = Nothing
+        val Quorum = "blocks/.+/votes/current_quorum".r
+        val Proposal = "blocks/.+/votes/current_proposal".r
 
-    (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/head~")
-      .returns(blockResponse)
-    (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c/operations")
-      .returns(operationsResponse)
-    (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c~/votes/current_quorum")
-      .returns(votesQuorum)
-    (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c~/votes/current_proposal")
-      .returns(votesProposal)
+        override def runGetCall[CallId](callConfig: Any, request: CallId, commandMap: CallId => String): Const[String,CallId] =
+          Const(commandMap(request) match {
+              case "blocks/head~" => TezosResponseBuilder.blockResponse
+              case "blocks/head~/operations" => TezosResponseBuilder.operationsResponse
+              case "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c/operations" => TezosResponseBuilder.operationsResponse
+              case Quorum() => TezosResponseBuilder.votesQuorum
+              case Proposal() => TezosResponseBuilder.votesProposal
+            }
+          )
 
-    (tezosRPCInterface.runBatchedGetQuery[Any] _)
-      .when("zeronet", *, *, *, *)
-      .onCall((_, input, command, _, _) =>
-        Future.successful(List(
-          //dirty trick to find the type of input content and provide the appropriate response
-          input match {
-            case (_: Int) :: tail => (0, TezosResponseBuilder.batchedGetBlockQueryResponse)
-            case (hash: BlockHash) :: tail if command(hash) endsWith "operations" =>
-              (hash, TezosResponseBuilder.batchedGetOperationsQueryResponse)
-            case (hash: BlockHash) :: tail if command(hash) endsWith "votes/current_quorum" =>
-              (hash, TezosResponseBuilder.votesQuorum)
-            case (hash: BlockHash) :: tail if command(hash) endsWith "votes/current_proposal" =>
-              (hash, TezosResponseBuilder.votesProposal)
-          }
-        ))
+        override def runPostCall[CallId](callConfig: Any, request: CallId, commandMap: CallId => String, payload: Option[Nothing]): Const[String,CallId] = ???
+      }
+
+      //test dataFetcher for blocks
+      implicit val blockFetchProvider = Reader(
+        (_: BlockHash) => testBlockFetcher(TezosResponseBuilder.batchedGetBlockQueryResponse)
       )
 
-    val nodeOp: TezosNodeOperator = new TezosNodeOperator(tezosRPCInterface, "zeronet", config)
+      //when
+      val blocksResults: sut.BlockFetchingResults = sut.getLatestBlocks[Id]()
 
-    //when
-    val blockPages: Future[nodeOp.PaginatedBlocksResults] = nodeOp.getLatestBlocks()
+      //then
+      blocksResults should have size 1
+      val (Block(data, ops, votes), accounts) = blocksResults.head
+      data.hash.value shouldBe "BMKoXSqeytk6NU3pdL7q8GLN8TT7kcodU1T6AUxeiGqz2gffmEF"
+      data.header.level shouldBe 162385
 
-    //then
-    val (pages, total) = blockPages.futureValue
-    total shouldBe 3
-    val results = pages.toList
-    results should have length 1
-    results.head.futureValue should have length 1
+      ops shouldBe empty
+      votes shouldEqual CurrentVotes.empty
+      accounts shouldBe empty
 
   }
 
-  "getLatestBlocks" should "correctly fetch latest blocks" in {
-    //given
-    val tezosRPCInterface = stub[TezosRPCInterface]
-    val blockResponse = Future.successful(TezosResponseBuilder.blockResponse)
-    val operationsResponse = Future.successful(TezosResponseBuilder.operationsResponse)
-    val votesPeriodKind = Future.successful(TezosResponseBuilder.votesPeriodKind)
-    val votesQuorum = Future.successful(TezosResponseBuilder.votesQuorum)
-    val votesProposal = Future.successful(TezosResponseBuilder.votesProposal)
+  "getLatestBlocks" should "correctly fetch latest blocks" in withInstances {
+    implicit extraBlockFetcher => implicit quorumFetcher => implicit proposalFetcher =>
+      //given
+      //test remote caller, with no special effect on input or output, returning a String, based on expected calls
+      implicit val testRpc = new RemoteRpc[Id, Id, Const[String, ?]] {
+        type CallConfig = Any
+        type PostPayload = Nothing
+        val Quorum = "blocks/.+/votes/current_quorum".r
+        val Proposal = "blocks/.+/votes/current_proposal".r
 
-    (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/head~")
-      .returns(blockResponse)
-    (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c/operations")
-      .returns(operationsResponse)
-    (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c~/votes/current_period_kind")
-      .returns(votesPeriodKind)
-    (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c~/votes/current_quorum")
-      .returns(votesQuorum)
-    (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c~/votes/current_proposal")
-      .returns(votesProposal)
+        override def runGetCall[CallId](callConfig: Any, request: CallId, commandMap: CallId => String): Const[String,CallId] =
+          Const(commandMap(request) match {
+              case "blocks/head~" => TezosResponseBuilder.blockResponse
+              case "blocks/head~/operations" => TezosResponseBuilder.operationsResponse
+              case "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c/operations" => TezosResponseBuilder.operationsResponse
+              case Quorum() => TezosResponseBuilder.votesQuorum
+              case Proposal() => TezosResponseBuilder.votesProposal
+            }
+          )
 
-    (tezosRPCInterface.runBatchedGetQuery[Any] _)
-      .when("zeronet", *, *, *, *)
-      .onCall((_, input, command, _, _) =>
-        Future.successful(List(
-          //dirty trick to find the type of input content and provide the appropriate response
-          input match {
-            case (_: Int) :: tail => (0, TezosResponseBuilder.batchedGetBlockQueryResponse)
-            case (hash: BlockHash) :: tail if command(hash) endsWith "operations" =>
-              (hash, TezosResponseBuilder.batchedGetOperationsQueryResponse)
-            case (hash: BlockHash) :: tail if command(hash) endsWith "votes/current_period_kind" =>
-              (hash, TezosResponseBuilder.votesPeriodKind)
-            case (hash: BlockHash) :: tail if command(hash) endsWith "votes/current_quorum" =>
-              (hash, TezosResponseBuilder.votesQuorum)
-            case (hash: BlockHash) :: tail if command(hash) endsWith "votes/current_proposal" =>
-              (hash, TezosResponseBuilder.votesProposal)
-          }
-        ))
+        override def runPostCall[CallId](callConfig: Any, request: CallId, commandMap: CallId => String, payload: Option[Nothing]): Const[String,CallId] = ???
+      }
+
+      //test dataFetcher for blocks
+      implicit val blockFetchProvider = Reader(
+        (_: BlockHash) => testBlockFetcher(TezosResponseBuilder.batchedGetBlockQueryResponse)
       )
 
-    val nodeOp: TezosNodeOperator = new TezosNodeOperator(tezosRPCInterface, "zeronet", config)
+      //when
+      val blocksResults: sut.BlockFetchingResults = sut.getLatestBlocks[Id](depth = Some(1))
 
-    //when
-    val blockPages: Future[nodeOp.PaginatedBlocksResults] = nodeOp.getLatestBlocks(Some(1))
+      //then
+      blocksResults should have size 1
 
-    //then
-    val (pages, total) = blockPages.futureValue
-    total shouldBe 1
-    val results = pages.toList
-    results should have length 1
-    results.head.futureValue should have length 1
+      val (Block(data, ops, votes), accounts) = blocksResults.head
+      data.hash.value shouldBe "BMKoXSqeytk6NU3pdL7q8GLN8TT7kcodU1T6AUxeiGqz2gffmEF"
+      data.header.level shouldBe 162385
+
+      ops shouldBe empty
+      votes shouldEqual CurrentVotes.empty
+      accounts shouldBe empty
+
   }
 
-  "getLatestBlocks" should "correctly fetch blocks starting from a given head" in {
-    //given
-    val tezosRPCInterface = stub[TezosRPCInterface]
-    val blockResponse = Future.successful(TezosResponseBuilder.blockResponse)
-    val operationsResponse = Future.successful(TezosResponseBuilder.operationsResponse)
-    val votesPeriodKind = Future.successful(TezosResponseBuilder.votesPeriodKind)
-    val votesQuorum = Future.successful(TezosResponseBuilder.votesQuorum)
-    val votesProposal = Future.successful(TezosResponseBuilder.votesProposal)
+  "getLatestBlocks" should "correctly fetch blocks starting from a given head" in withInstances {
+    implicit extraBlockFetcher => implicit quorumFetcher => implicit proposalFetcher =>
+      //given
+      //test remote caller, with no special effect on input or output, returning a String, based on expected calls
+      implicit val testRpc = new RemoteRpc[Id, Id, Const[String, ?]] {
+        type CallConfig = Any
+        type PostPayload = Nothing
+        val Quorum = "blocks/.+/votes/current_quorum".r
+        val Proposal = "blocks/.+/votes/current_proposal".r
 
-    (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c~")
-      .returns(blockResponse)
-    (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c/operations")
-      .returns(operationsResponse)
-    (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c~/votes/current_period_kind")
-      .returns(votesPeriodKind)
-    (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c~/votes/current_quorum")
-      .returns(votesQuorum)
-    (tezosRPCInterface.runAsyncGetQuery _)
-      .when("zeronet", "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c~/votes/current_proposal")
-      .returns(votesProposal)
+        override def runGetCall[CallId](callConfig: Any, request: CallId, commandMap: CallId => String): Const[String,CallId] =
+          Const(commandMap(request) match {
+              case "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c~" => TezosResponseBuilder.blockResponse
+              case "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c~/operations" => TezosResponseBuilder.operationsResponse
+              case "blocks/BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c/operations" => TezosResponseBuilder.operationsResponse
+              case Quorum() => TezosResponseBuilder.votesQuorum
+              case Proposal() => TezosResponseBuilder.votesProposal
+            }
+          )
 
-    (tezosRPCInterface.runBatchedGetQuery[Any] _)
-      .when("zeronet", *, *, *, *)
-      .onCall((_, input, command, _, _) =>
-        Future.successful(List(
-          //dirty trick to find the type of input content and provide the appropriate response
-          input match {
-            case (_: Int) :: tail => (0, TezosResponseBuilder.batchedGetBlockQueryResponse)
-            case (hash: BlockHash) :: tail if command(hash) endsWith "operations" =>
-              (hash, TezosResponseBuilder.batchedGetOperationsQueryResponse)
-            case (hash: BlockHash) :: tail if command(hash) endsWith "votes/current_period_kind" =>
-              (hash, TezosResponseBuilder.votesPeriodKind)
-            case (hash: BlockHash) :: tail if command(hash) endsWith "votes/current_quorum" =>
-              (hash, TezosResponseBuilder.votesQuorum)
-            case (hash: BlockHash) :: tail if command(hash) endsWith "votes/current_proposal" =>
-              (hash, TezosResponseBuilder.votesProposal)
-          }
-        ))
+        override def runPostCall[CallId](callConfig: Any, request: CallId, commandMap: CallId => String, payload: Option[Nothing]): Const[String,CallId] = ???
+      }
+
+      //test dataFetcher for blocks
+      implicit val blockFetchProvider = Reader(
+        (_: BlockHash) => testBlockFetcher(TezosResponseBuilder.batchedGetBlockQueryResponse)
       )
 
-    val nodeOp: TezosNodeOperator = new TezosNodeOperator(tezosRPCInterface, "zeronet", config)
+      //when
+      val blocksResults: sut.BlockFetchingResults = sut.getLatestBlocks[Id](depth = Some(1), headHash = Some(BlockHash("BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c")))
 
-    //when
-    val blockPages: Future[nodeOp.PaginatedBlocksResults] = nodeOp.getLatestBlocks(Some(1), Some(BlockHash("BLJKK4VRwZk7qzw64NfErGv69X4iWngdzfBABULks3Nd33grU6c")))
+      //then
+      blocksResults should have size 1
 
-    //then
-    val (pages, total) = blockPages.futureValue
-    total shouldBe 1
-    val results = pages.toList
-    results should have length 1
-    results.head.futureValue should have length 1
+      val (Block(data, ops, votes), accounts) = blocksResults.head
+      data.hash.value shouldBe "BMKoXSqeytk6NU3pdL7q8GLN8TT7kcodU1T6AUxeiGqz2gffmEF"
+      data.header.level shouldBe 162385
+
+      ops shouldBe empty
+      votes shouldEqual CurrentVotes.empty
+      accounts shouldBe empty
   }
 
 }

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTestFixtures.scala
@@ -5,6 +5,7 @@ import cats.data.Kleisli
 import tech.cryptonomic.conseil.generic.chain.DataFetcher
 import TezosTypes._
 
+/** provides implicit instances useful to call methods for testing the `NodeOperator`*/
 trait TezosNodeOperatorTestImplicits {
 
   //we need this to run the node's methods with an Id effect, though this instance is not lawful
@@ -19,7 +20,7 @@ trait TezosNodeOperatorTestImplicits {
     override def handleErrorWith[A](fa: cats.Id[A])(f: Throwable => cats.Id[A]): cats.Id[A] = fa
   }
 
-
+  //type alias, makes things more readable
   type TestFetcher[In, Out] = DataFetcher.Aux[Id, List, Throwable, In, Out, String]
 
   /** Use it to get dummy instances of fetchers needed by complex node operations

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTestFixtures.scala
@@ -1,0 +1,79 @@
+package tech.cryptonomic.conseil.tezos
+
+import cats.{Id, MonadError}
+import cats.data.Kleisli
+import tech.cryptonomic.conseil.generic.chain.DataFetcher
+import TezosTypes._
+
+trait TezosNodeOperatorTestImplicits {
+
+  //we need this to run the node's methods with an Id effect, though this instance is not lawful
+  implicit val idErrorInstance = new MonadError[Id, Throwable] {
+    override def raiseError[A](e: Throwable): cats.Id[A] = throw e
+    override def flatMap[A, B](fa: cats.Id[A])(f: A => cats.Id[B]): cats.Id[B] = f(fa)
+    override def tailRecM[A, B](a: A)(f: A => cats.Id[Either[A,B]]): cats.Id[B] = f(a) match {
+      case Left(value) => raiseError(new RuntimeException("didn't expect"))
+      case Right(value) => value
+    }
+    override def pure[A](x: A): cats.Id[A] = x
+    override def handleErrorWith[A](fa: cats.Id[A])(f: Throwable => cats.Id[A]): cats.Id[A] = fa
+  }
+
+
+  type TestFetcher[In, Out] = DataFetcher.Aux[Id, List, Throwable, In, Out, String]
+
+  /** Use it to get dummy instances of fetchers needed by complex node operations
+    * and make them available implicitly
+    */
+  protected def withInstances (
+    testCode:
+      TestFetcher[BlockHash, (List[OperationsGroup], List[AccountId])] =>
+      TestFetcher[BlockHash, Option[Int]] =>
+      TestFetcher[BlockHash, Option[TezosTypes.ProtocolId]] =>
+      Any
+  ) = {
+    val extraBlockFetcher = dummyFetcher[BlockHash, (List[OperationsGroup], List[AccountId])](out = (Nil, Nil))
+    val quorumFetcher = dummyFetcher[BlockHash, Option[Int]](out = None)
+    val proposalFetcher = dummyFetcher[BlockHash, Option[ProtocolId]](out = None)
+    testCode(extraBlockFetcher)(quorumFetcher)(proposalFetcher)
+  }
+
+  /** A semi-realistic fetcher of blocks that will return a single json response, passed-in
+    * as an argument, and will try to decode it as json to a `BlockData` instance
+    */
+  protected def testBlockFetcher(jsonResponse: String) = new DataFetcher[Id, List, Throwable] {
+    type Encoded = String
+    type In = Offset
+    type Out = BlockData
+
+    import JsonDecoders.Circe.Blocks._
+    import JsonDecoders.Circe.decodeLiftingTo
+
+    override def fetchData = Kleisli[Id, List[In], List[(In, Encoded)]](
+      _ => (0, jsonResponse) :: Nil
+    )
+
+    override def decodeData = Kleisli(
+      json => decodeLiftingTo[Id, BlockData](json)
+    )
+  }
+
+  /* Provides a fetcher that
+   * - encodes internally to an empty string
+   * - returns always `out` as the final decoded result for any input
+   */
+  private def dummyFetcher[I, O](out: O) = new DataFetcher[Id, List, Throwable] {
+    type Encoded = String
+    type In = I
+    type Out = O
+
+    override def fetchData = Kleisli[Id, List[In], List[(In, Encoded)]]{
+      _.map(_ -> "")
+    }
+
+    override def decodeData = Kleisli[Id, String, Out]{
+      Function.const(out)
+    }
+  }
+
+}


### PR DESCRIPTION
## This is a multi-step rewrite to finally create a more flexible design of the node operator, allowing for different "backends" to implement the rpc calls and tezos fetch logic

### It is not meant to be merged as-is but to provide material for progressive review of the whole refactor

The "pluggable-backend" approach will make it easier to try streaming designs, based on different implementations than akka-stream and plain scala futures
The long-term plan is to open a discussion to evaluate the switch to cats-effects/monix/fs2

---
The current step defines an alternative interface for the `NodeOperator` that is parametric on effects.
The parametric methods use implicit constraints (type classes) to decide what kind of actual effect can be used concretely, .e.g Monad, Functor, Appicative, ...
In addition the NodeOperator calls now will require available instances of data-fetchers and remote-rpc callers tailored to the specific effect.

We also rewrite Lorre to use the new NodeOperator, and provide the implicit instances before each call.
The resulting code replaces the exisiting future-based one, but doesn't currently implement the "batching logic", thus being unfitted yet for production deployment.
The plan for next step is to re-introduce the batching logic, in a design that decouples it from the NodeOperator itself.
We also introduce here a finer control on error logging for each requested rpc call.

Finally, the node test is no more based on an async model. The required fetchers and remote-rpc are provided as dummy/stubs, and only the actual node logic should be tested, arguably for best and more fine-grained checks.

The current version doesn't provide yet a substitute implementation for the "write-side" of the node, which was actually never used yet (but will be provided in the following PRs)