### PR TITLE
Conseil 323 - default values for the predicates

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
@@ -206,7 +206,7 @@ object DataTypes {
     def validate(entity: String, tezosPlatformDiscovery: TezosPlatformDiscoveryOperations)(implicit ec: ExecutionContext):
     Future[Either[List[QueryValidationError], Query]] = {
 
-      val patchedPredicates = this.predicates.toList.flatten.map(_.toPredicate)
+      val patchedPredicates = predicates.getOrElse(List.empty).map(_.toPredicate)
       val query = this.into[Query]
         .withFieldConst(_.fields, fields.getOrElse(List.empty))
         .withFieldConst(_.predicates, patchedPredicates)

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
@@ -171,12 +171,15 @@ object DataTypes {
     inverse: Option[Boolean] = Some(false),
     precision: Option[Int] = None
   ) {
+    /** Transforms Aggregation predicate received form API into AggregationPredicate */
     def toAggregationPredicate: AggregationPredicate = {
       AggregationPredicate(operation = OperationType.in).patchWith(this)
     }
   }
 
+  /** Aggregation that is received by the API */
   case class ApiAggregation(field: String, function: AggregationType = AggregationType.sum, predicate: Option[ApiAggregationPredicate] = None) {
+    /** Transforms Aggregation received form API into Aggregation */
     def toAggregation: Aggregation = {
       Aggregation(field, function, predicate.map(_.toAggregationPredicate))
     }

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataJsonSchemas.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataJsonSchemas.scala
@@ -21,6 +21,18 @@ trait DataJsonSchemas extends generic.JsonSchemas {
   implicit lazy val queryOrderingOperationSchema: JsonSchema[OperationType.Value] =
     enumeration(OperationType.values.toSeq)(_.toString)
 
+  /** API predicate schema */
+  implicit lazy val apiPredicateSchema: JsonSchema[ApiPredicate] =
+    genericJsonSchema[ApiPredicate]
+
+  /** API aggregation schema */
+  implicit lazy val apiAggregationSchema: JsonSchema[ApiAggregation] =
+    genericJsonSchema[ApiAggregation]
+
+  /** API aggregation predicate schema */
+  implicit lazy val apiAggregationPredicateSchema: JsonSchema[ApiAggregationPredicate] =
+    genericJsonSchema[ApiAggregationPredicate]
+
   /** Query ordering schema */
   implicit lazy val queryOrderingSchema: JsonSchema[QueryOrdering] =
     genericJsonSchema[QueryOrdering]

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
@@ -63,7 +63,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
       val query = ApiQuery(
         fields = None,
-        predicates = Some(List(Predicate("valid", OperationType.in))),
+        predicates = Some(List(ApiPredicate("valid", OperationType.in))),
         orderBy = None,
         limit = None,
         output = None,
@@ -89,7 +89,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
       val query = ApiQuery(
         fields = None,
-        predicates = Some(List(Predicate("invalid", OperationType.in))),
+        predicates = Some(List(ApiPredicate("invalid", OperationType.in))),
         orderBy = None,
         limit = None,
         output = None,
@@ -154,7 +154,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
         orderBy = None,
         limit = None,
         output = None,
-        aggregation = Some(Aggregation(field = "valid"))
+        aggregation = Some(ApiAggregation(field = "valid"))
       )
 
       val result = query.validate("test", tpdo)
@@ -181,7 +181,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
         orderBy = None,
         limit = None,
         output = None,
-        aggregation = Some(Aggregation(field = "invalid"))
+        aggregation = Some(ApiAggregation(field = "invalid"))
       )
 
       val result = query.validate("test", tpdo)
@@ -208,7 +208,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
         orderBy = None,
         limit = None,
         output = None,
-        aggregation = Some(Aggregation(field = "invalid"))
+        aggregation = Some(ApiAggregation(field = "invalid"))
       )
 
       val result = query.validate("test", tpdo)
@@ -235,7 +235,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
         orderBy = None,
         limit = None,
         output = None,
-        aggregation = Some(Aggregation(field = "valid", function = AggregationType.count))
+        aggregation = Some(ApiAggregation(field = "valid", function = AggregationType.count))
       )
 
       val result = query.validate("test", tpdo)
@@ -258,7 +258,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
       val query = ApiQuery(
         fields = None,
-        predicates = Some(List(Predicate(field = "valid", operation = OperationType.in, set = List(123456789000L)))),
+        predicates = Some(List(ApiPredicate(field = "valid", operation = OperationType.in, set = Some(List(123456789000L))))),
         orderBy = None,
         limit = None,
         output = None,


### PR DESCRIPTION
Because of lack of handling of default parameters in `endpoints` library I had to write a bit more boilerplate code to make default parameters work as expected. If anyone has any suggestions how to make it less complicated I'm open to any suggestions.