### PR TITLE
#343 - rename dataformat -> dataFormat

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -153,7 +153,7 @@ akka {
 #
 # Additionally, on attributes level you can provide two parameters:
 # * placeholder: String
-# * dataformat: String
+# * dataFormat: String
 
 metadata-overrides {
   tezos {
@@ -654,7 +654,7 @@ metadata-overrides {
                 visible: true
               }
               timestamp {
-                dataformat: "yyyy MMM dd HH:mm Z",
+                dataFormat: "yyyy MMM dd HH:mm Z",
                 visible: true
               }
               validation_pass {

--- a/src/main/scala/tech/cryptonomic/conseil/config/MetadataOverridesConfiguration.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/config/MetadataOverridesConfiguration.scala
@@ -45,4 +45,4 @@ case class NetworkConfiguration(displayName: Option[String], visible: Option[Boo
 case class EntityConfiguration(displayName: Option[String], visible: Option[Boolean], description: Option[String] = None, attributes: Map[AttributeName, AttributeConfiguration] = Map.empty)
 
 // configuration for attribute
-case class AttributeConfiguration(displayName: Option[String], visible: Option[Boolean], description: Option[String] = None, placeholder: Option[String] = None, dataformat: Option[String] = None)
+case class AttributeConfiguration(displayName: Option[String], visible: Option[Boolean], description: Option[String] = None, placeholder: Option[String] = None, dataFormat: Option[String] = None)

--- a/src/main/scala/tech/cryptonomic/conseil/config/MetadataOverridesConfiguration.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/config/MetadataOverridesConfiguration.scala
@@ -35,4 +35,4 @@ case class NetworkConfiguration(displayName: Option[String], visible: Option[Boo
 
 case class EntityConfiguration(displayName: Option[String], visible: Option[Boolean], description: Option[String] = None, attributes: Map[AttributeName, AttributeConfiguration] = Map.empty)
 
-case class AttributeConfiguration(displayName: Option[String], visible: Option[Boolean], description: Option[String] = None, placeholder: Option[String] = None, dataformat: Option[String] = None)
+case class AttributeConfiguration(displayName: Option[String], visible: Option[Boolean], description: Option[String] = None, placeholder: Option[String] = None, dataFormat: Option[String] = None)

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/PlatformDiscoveryTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/PlatformDiscoveryTypes.scala
@@ -27,7 +27,7 @@ object PlatformDiscoveryTypes {
     entity: String,
     description: Option[String] = None,
     placeholder: Option[String] = None,
-    dataformat: Option[String] = None
+    dataFormat: Option[String] = None
   )
 
   /** Enumeration of data types */

--- a/src/main/scala/tech/cryptonomic/conseil/metadata/UnitTransformation.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/metadata/UnitTransformation.scala
@@ -50,7 +50,7 @@ class UnitTransformation(overrides: MetadataOverridesConfiguration) {
         .flatMap(_.description),
       placeholder = overrideAttribute
         .flatMap(_.placeholder),
-      dataformat = overrideAttribute
-        .flatMap(_.dataformat))
+      dataFormat = overrideAttribute
+        .flatMap(_.dataFormat))
   }
 }

--- a/src/test/scala/tech/cryptonomic/conseil/metadata/MetadataServiceTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/metadata/MetadataServiceTest.scala
@@ -273,13 +273,13 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
         PlatformConfiguration(None, Some(true), None, Map("mainnet" ->
           NetworkConfiguration(None, Some(true), None, Map("entity" ->
             EntityConfiguration(None, Some(true), None, Map("attribute" ->
-              AttributeConfiguration(Some("overwritten-name"), Some(true), Some("description"), Some("placeholder"), Some("dataformat")))))))))
+              AttributeConfiguration(Some("overwritten-name"), Some(true), Some("description"), Some("placeholder"), Some("dataFormat")))))))))
 
       // when
       val result = sut(overwrittenConfiguration).getTableAttributes(EntityPath("entity", NetworkPath("mainnet", PlatformPath("tezos")))).futureValue
 
       // then
-      result shouldBe Some(List(Attribute("attribute", "overwritten-name", Int, None, NonKey, "entity", Some("description"), Some("placeholder"), Some("dataformat"))))
+      result shouldBe Some(List(Attribute("attribute", "overwritten-name", Int, None, NonKey, "entity", Some("description"), Some("placeholder"), Some("dataFormat"))))
     }
 
     "filter out a hidden attribute" in {

--- a/src/test/scala/tech/cryptonomic/conseil/routes/PlatformDiscoveryTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/routes/PlatformDiscoveryTest.scala
@@ -148,7 +148,7 @@ class PlatformDiscoveryTest extends WordSpec with Matchers with ScalatestRouteTe
         PlatformConfiguration(None, Some(true), None, Map("mainnet" ->
           NetworkConfiguration(None, Some(true), None, Map("entity" ->
             EntityConfiguration(None, Some(true), None, Map("attribute" ->
-              AttributeConfiguration(None, Some(true), Some("description"), Some("placeholder"), Some("dataformat")))))))))
+              AttributeConfiguration(None, Some(true), Some("description"), Some("placeholder"), Some("dataFormat")))))))))
 
       // when
       Get("/v2/metadata/tezos/mainnet/entity/attributes") ~> addHeader("apiKey", "hooman") ~> sut(overridesConfiguration) ~> check {
@@ -161,7 +161,7 @@ class PlatformDiscoveryTest extends WordSpec with Matchers with ScalatestRouteTe
         result.head("displayName") shouldBe "attribute-name"
         result.head("description") shouldBe "description"
         result.head("placeholder") shouldBe "placeholder"
-        result.head("dataformat") shouldBe "dataformat"
+        result.head("dataFormat") shouldBe "dataFormat"
       }
     }
 


### PR DESCRIPTION
**BEFORE MERGE DESTINATION SHOULD BE CHANGED TO MASTER AND PR https://github.com/Cryptonomic/Conseil/pull/336 FOR BRANCH [feature/316-supplementary-metadata](https://github.com/Cryptonomic/Conseil/tree/feature/316-supplementary-metadata) SHOULD BE MERGED**

Rename ``dataformat`` to ``dataFormat`` in the sake of consistency.