### PR TITLE
Conseil 357-1: delegates checkpoint table

### DIFF
--- a/doc/conseil.sql
+++ b/doc/conseil.sql
@@ -200,6 +200,16 @@ CREATE TABLE public.accounts_checkpoint (
     block_level integer DEFAULT '-1'::integer NOT NULL
 );
 
+--
+-- Name: delegates_checkpoint; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.delegates_checkpoint (
+    delegate_pkh character varying NOT NULL,
+    block_id character varying NOT NULL,
+    block_level integer DEFAULT '-1'::integer NOT NULL
+);
+
 
 --
 -- Name: proposals; Type: TABLE; Schema: public; Owner: -
@@ -380,6 +390,12 @@ CREATE INDEX ix_operations_source ON public.operations USING btree (source);
 CREATE INDEX ix_accounts_checkpoint_block_level ON public.accounts_checkpoint USING btree (block_level);
 
 --
+-- Name: ix_delegates_checkpoint_block_level; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_delegates_checkpoint_block_level ON public.delegates_checkpoint USING btree (block_level);
+
+--
 -- Name: ix_proposals_protocol; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -399,6 +415,13 @@ ALTER TABLE ONLY public.accounts
 
 ALTER TABLE ONLY public.accounts_checkpoint
     ADD CONSTRAINT checkpoint_block_id_fkey FOREIGN KEY (block_id) REFERENCES public.blocks(hash);
+
+--
+-- Name: delegates_checkpoint delegate_checkpoint_block_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.delegates_checkpoint
+    ADD CONSTRAINT delegate_checkpoint_block_id_fkey FOREIGN KEY (block_id) REFERENCES public.blocks(hash);
 
 
 --

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
@@ -39,9 +39,9 @@ object DatabaseConversions {
       )
   }
 
-  implicit val blockAccountsToAccountRows = new Conversion[List, BlockAccounts, Tables.AccountsRow] {
-    override def convert(from: BlockAccounts) = {
-      val BlockAccounts(hash, level, accounts) = from
+  implicit val blockAccountsToAccountRows = new Conversion[List, BlockTagged[Map[AccountId, Account]], Tables.AccountsRow] {
+    override def convert(from: BlockTagged[Map[AccountId, Account]]) = {
+      val BlockTagged(hash, level, accounts) = from
       accounts.map {
         case (id, Account(manager, balance, spendable, delegate, script, counter)) =>
         Tables.AccountsRow(
@@ -365,6 +365,21 @@ object DatabaseConversions {
         accountId =>
           Tables.AccountsCheckpointRow(
             accountId = accountId.id,
+            blockId = blockHash.value,
+            blockLevel = blockLevel
+          )
+      )
+    }
+
+  }
+
+  implicit val blockDelegatesAssociationToCheckpointRow = new Conversion[List, (BlockHash, Int, List[PublicKeyHash]), Tables.DelegatesCheckpointRow] {
+    override def convert(from: (BlockHash, Int, List[PublicKeyHash])) = {
+      val (blockHash, blockLevel, pkhs) = from
+      pkhs.map(
+        keyHash =>
+          Tables.DelegatesCheckpointRow(
+            delegatePkh = keyHash.value,
             blockId = blockHash.value,
             blockLevel = blockLevel
           )

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeFetchers.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeFetchers.scala
@@ -58,7 +58,7 @@ trait BlocksDataFetchers {
     type In = Offset
     type Out = BlockData
 
-    def makeUrl = (offset: Offset) => s"blocks/${hashRef.value}~${String.valueOf(offset)}"
+    private def makeUrl = (offset: Offset) => s"blocks/${hashRef.value}~${String.valueOf(offset)}"
 
     //fetch a future stream of values
     override val fetchData =
@@ -100,7 +100,7 @@ trait BlocksDataFetchers {
     type In = BlockHash
     type Out = List[OperationsGroup]
 
-    val makeUrl = (hash: BlockHash) => s"blocks/${hash.value}/operations"
+    private val makeUrl = (hash: BlockHash) => s"blocks/${hash.value}/operations"
 
     override val fetchData =
       Kleisli(hashes =>
@@ -135,7 +135,7 @@ trait BlocksDataFetchers {
     type In = BlockHash
     type Out = Option[Int]
 
-    val makeUrl = (hash: BlockHash) => s"blocks/${hash.value}/votes/current_quorum"
+    private val makeUrl = (hash: BlockHash) => s"blocks/${hash.value}/votes/current_quorum"
 
     override val fetchData =
       Kleisli(hashes =>
@@ -168,7 +168,7 @@ trait BlocksDataFetchers {
     type In = BlockHash
     type Out = Option[ProtocolId]
 
-    val makeUrl = (hash: BlockHash) => s"blocks/${hash.value}/votes/current_proposal"
+    private val makeUrl = (hash: BlockHash) => s"blocks/${hash.value}/votes/current_proposal"
 
     override val fetchData =
       Kleisli(hashes =>
@@ -202,7 +202,7 @@ trait BlocksDataFetchers {
     type In = Block
     type Out = List[ProtocolId]
 
-    val makeUrl = (block: Block) => s"blocks/${block.data.hash.value}/votes/proposals"
+    private val makeUrl = (block: Block) => s"blocks/${block.data.hash.value}/votes/proposals"
 
     override val fetchData =
       Kleisli(blocks =>
@@ -237,7 +237,7 @@ trait BlocksDataFetchers {
     type In = Block
     type Out = List[Voting.BakerRolls]
 
-    val makeUrl = (block: Block) => s"blocks/${block.data.hash.value}/votes/listings"
+    private val makeUrl = (block: Block) => s"blocks/${block.data.hash.value}/votes/listings"
 
     override val fetchData =
       Kleisli(blocks =>
@@ -272,7 +272,7 @@ trait BlocksDataFetchers {
     type In = Block
     type Out = List[Voting.Ballot]
 
-    val makeUrl = (block: Block) => s"blocks/${block.data.hash.value}/votes/ballot_list"
+    private val makeUrl = (block: Block) => s"blocks/${block.data.hash.value}/votes/ballot_list"
 
     override val fetchData =
       Kleisli(blocks =>
@@ -343,7 +343,7 @@ trait AccountsDataFetchers {
     type In = AccountId
     type Out = Option[Account]
 
-    val makeUrl = (id: AccountId) => s"blocks/${referenceBlock.value}/context/contracts/${id.id}"
+    private val makeUrl = (id: AccountId) => s"blocks/${referenceBlock.value}/context/contracts/${id.id}"
 
     override val fetchData = Kleisli(
       ids =>
@@ -377,7 +377,7 @@ trait AccountsDataFetchers {
     type In = PublicKeyHash
     type Out = Delegate
 
-    val makeUrl = (pkh: PublicKeyHash) => s"blocks/${referenceBlock.value}/context/delegates/${pkh.value}"
+    private val makeUrl = (pkh: PublicKeyHash) => s"blocks/${referenceBlock.value}/context/delegates/${pkh.value}"
 
     override val fetchData = Kleisli(
       keyHashes =>

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -261,9 +261,6 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
     (fetchProposals, fetchBakers, fetchBallots).tupled.run(blocks.filterNot(b => isGenesis(b.data)))
   }
 
-  //move it to the node operator
-  def getDelegatesForBlock(keys: List[PublicKeyHash], blockHash: BlockHash): Future[Map[Delegate, Contract]] = ???
-
   /**
     * Fetches a single block from the chain, without waiting for the result
     * @param hash      Hash of the block

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -8,7 +8,7 @@ import tech.cryptonomic.conseil.util.JsonUtil.{fromJson, JsonString => JS}
 import tech.cryptonomic.conseil.config.{BatchFetchConfiguration, SodiumConfiguration}
 import tech.cryptonomic.conseil.tezos.TezosTypes.Lenses._
 import tech.cryptonomic.conseil.tezos.michelson.JsonToMichelson.convert
-import tech.cryptonomic.conseil.tezos.michelson.dto.{MichelsonElement, MichelsonExpression, MichelsonInstruction, MichelsonSchema}
+import tech.cryptonomic.conseil.tezos.michelson.dto.{MichelsonElement, MichelsonInstruction, MichelsonSchema}
 import tech.cryptonomic.conseil.tezos.michelson.parser.JsonParser.Parser
 import cats.instances.future._
 import cats.syntax.applicative._
@@ -69,7 +69,7 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
   //use this alias to make signatures easier to read and kept in-sync
   type BlockFetchingResults = List[(Block, List[AccountId])]
   type PaginatedBlocksResults = (Iterator[Future[BlockFetchingResults]], Int)
-  type PaginatedAccountResults = (Iterator[Future[List[BlockAccounts]]], Int)
+  type PaginatedAccountResults = (Iterator[Future[List[BlockTagged[Map[AccountId, Account]]]]], Int)
 
   //introduced to simplify signatures
   type BallotBlock = (Block, List[Voting.Ballot])
@@ -155,16 +155,17 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
     * @return         Accounts with their corresponding block data
     */
   def getAccountsForBlocks(accountsBlocksIndex: Map[AccountId, BlockReference]): PaginatedAccountResults = {
+    import TezosTypes.Syntax._
 
     def notifyAnyLostIds(missing: Set[AccountId]) =
       if (missing.nonEmpty) logger.warn("The following account keys were not found querying the {} node: {}", network, missing.map(_.id).mkString("\n", ",", "\n"))
 
     //uses the index to collect together BlockAccounts matching the same block
-    def groupByLatestBlock(data: Map[AccountId, Account]): List[BlockAccounts] =
+    def groupByLatestBlock(data: Map[AccountId, Account]): List[BlockTagged[Map[AccountId, Account]]] =
       data.groupBy {
         case (id, _) => accountsBlocksIndex(id)
       }.map {
-        case ((hash, level), accounts) => BlockAccounts(hash, level, accounts)
+        case ((hash, level), accounts) => accounts.taggedWithBlock(hash, level)
       }.toList
 
     //fetch accounts by requested ids and group them together with corresponding blocks
@@ -259,6 +260,9 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
      */
     (fetchProposals, fetchBakers, fetchBallots).tupled.run(blocks.filterNot(b => isGenesis(b.data)))
   }
+
+  //move it to the node operator
+  def getDelegatesForBlock(keys: List[PublicKeyHash], blockHash: BlockHash): Future[Map[Delegate, Contract]] = ???
 
   /**
     * Fetches a single block from the chain, without waiting for the result

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -319,13 +319,13 @@ object TezosTypes {
   )
 
   final case class AppliedOperationBalanceUpdates(
-                                             kind: String,
-                                             contract: Option[String],
-                                             change: Int,
-                                             category: Option[String],
-                                             delegate: Option[String],
-                                             level: Option[Int]
-                                           )
+    kind: String,
+    contract: Option[String],
+    change: Int,
+    category: Option[String],
+    delegate: Option[String],
+    level: Option[Int]
+  )
 
   final case class AppliedOperationResultStatus(
     status: String,
@@ -357,6 +357,38 @@ object TezosTypes {
       accounts: Map[AccountId, Account] = Map.empty
   )
 
+  final case class Delegate(
+    balance: PositiveBigNumber,
+    frozen_balance: PositiveBigNumber,
+    frozen_balance_by_cycle: List[CycleBalance],
+    staking_balance: PositiveBigNumber,
+    delegated_contracts: List[ContractId],
+    delegated_balance: PositiveBigNumber,
+    deactivated: Boolean,
+    grace_period: Int
+  )
+
+  final case class CycleBalance(
+    cycle: Int,
+    deposit: PositiveBigNumber,
+    fees: PositiveBigNumber,
+    rewards: PositiveBigNumber
+  )
+
+  final case class Contract(
+    manager: PublicKeyHash,
+    balance: PositiveBigNumber,
+    spendable: Boolean,
+    delegate: ContractDelegate,
+    script: Option[Scripted.Contracts],
+    counter: PositiveBigNumber
+  )
+
+  final case class ContractDelegate(
+    setable: Boolean,
+    value: Option[PublicKeyHash]
+  )
+
   object VotingPeriod extends Enumeration {
     type Kind = Value
     val proposal, promotion_vote, testing_vote, testing = Value
@@ -374,40 +406,40 @@ object TezosTypes {
   }
 
   final case class Block(
-                    data: BlockData,
-                    operationGroups: List[OperationsGroup],
-                    votes: CurrentVotes
-                  )
+    data: BlockData,
+    operationGroups: List[OperationsGroup],
+    votes: CurrentVotes
+  )
 
   final case class ManagerKey(
-                       manager: String,
-                       key: Option[String]
-                       )
+    manager: String,
+    key: Option[String]
+  )
 
   final case class ForgedOperation(operation: String)
 
   final case class AppliedOperationError(
-                                  kind: String,
-                                  id: String,
-                                  hash: String
-                                  )
+    kind: String,
+    id: String,
+    hash: String
+  )
 
   final case class AppliedOperationResult(
-                                   operation: String,
-                                   status: String,
-                                   operationKind: Option[String],
-                                   balanceUpdates: Option[List[AppliedOperationBalanceUpdates]],
-                                   originatedContracts: Option[List[String]],
-                                   errors: Option[List[AppliedOperationError]]
-                                   )
+    operation: String,
+    status: String,
+    operationKind: Option[String],
+    balanceUpdates: Option[List[AppliedOperationBalanceUpdates]],
+    originatedContracts: Option[List[String]],
+    errors: Option[List[AppliedOperationError]]
+  )
 
   final case class AppliedOperation(
-                             kind: String,
-                             balance_updates: Option[List[AppliedOperationBalanceUpdates]],
-                             operation_results: Option[List[AppliedOperationResult]],
-                             id: Option[String],
-                             contract: Option[String]
-                             )
+    kind: String,
+    balance_updates: Option[List[AppliedOperationBalanceUpdates]],
+    operation_results: Option[List[AppliedOperationResult]],
+    id: Option[String],
+    contract: Option[String]
+  )
 
   final case class InjectedOperation(injectedOperation: String)
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -351,11 +351,13 @@ object TezosTypes {
     counter: Int
   )
 
-  final case class BlockAccounts(
-      blockHash: BlockHash,
-      blockLevel: Int,
-      accounts: Map[AccountId, Account] = Map.empty
-  )
+  final case class BlockTagged[T](
+    blockHash: BlockHash,
+    blockLevel: Int,
+    content: T
+  ) {
+    val asTuple = (blockHash, blockLevel, content)
+  }
 
   final case class Delegate(
     balance: PositiveBigNumber,
@@ -453,5 +455,15 @@ object TezosTypes {
     final case class Ballot(pkh: PublicKeyHash, ballot: Vote)
   }
 
+  object Syntax {
+
+    /** provides a factory to tag any content with a reference block */
+    implicit class BlockTagger[T](val content: T) extends AnyVal {
+
+      /** creates a BlockTagged[T] instance based on any `T` value, adding the block reference */
+      def taggedWithBlock(hash: BlockHash, level: Int): BlockTagged[T] = BlockTagged(hash, level, content)
+    }
+
+  }
 
 }

--- a/src/main/scala/tech/cryptonomic/conseil/util/ConfigUtil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/util/ConfigUtil.scala
@@ -51,7 +51,7 @@ object ConfigUtil {
     /** converts multiple read failures to a single, generic, FailureReason */
     val reasonFromReadFailures = (failures: ConfigReaderFailures) =>
       new FailureReason {
-        override val description = failures.toList.map(_.description).mkString(" and ")
+        override val description = failures.toList.map(_.description).mkString(" ")
       }
 
     /** extract a custom class type from the generic lightbend-config value failing with a `FailureReason` */

--- a/src/main/scala/tech/cryptonomic/conseil/util/ConfigUtil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/util/ConfigUtil.scala
@@ -6,7 +6,7 @@ import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.{Network, P
 
 import scala.util.Try
 import tech.cryptonomic.conseil.config.Platforms._
-import tech.cryptonomic.conseil.config.{HttpStreamingConfiguration, Newest}
+import tech.cryptonomic.conseil.config.HttpStreamingConfiguration
 
 object ConfigUtil {
 
@@ -69,7 +69,7 @@ object ConfigUtil {
       */
     def foldReadResults[T, R](readResults: Traversable[Either[FailureReason, T]])(reduce: Traversable[T] => R) = {
       //elements might have failed, collect all failures
-      val failureDescription = readResults.collect { case Left(f) => f.description }.mkString(" and ")
+      val failureDescription = readResults.collect { case Left(f) => f.description }.mkString(" ")
       if (failureDescription.nonEmpty) logger.warn("Can't correctly read platform configuration, reasons are: {}", failureDescription)
       //test for failures, and if there's none, we can safely read the Right values
       Either.cond(

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/InMemoryDatabase.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/InMemoryDatabase.scala
@@ -58,6 +58,7 @@ trait InMemoryDatabase extends BeforeAndAfterAll with BeforeAndAfterEach {
     Tables.Accounts,
     Tables.Fees,
     Tables.AccountsCheckpoint,
+    Tables.DelegatesCheckpoint,
     Tables.Proposals,
     Tables.Ballots,
     Tables.Bakers

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTest.scala
@@ -11,6 +11,8 @@ class JsonDecodersTest extends WordSpec
 
   import JsonDecoders.Circe._
   import JsonDecoders.Circe.Accounts._
+  import JsonDecoders.Circe.Scripts._
+  import JsonDecoders.Circe.Numbers._
   import JsonDecoders.Circe.Operations._
   import JsonDecoders.Circe.Votes._
   import io.circe.parser.decode
@@ -29,7 +31,7 @@ class JsonDecodersTest extends WordSpec
     "allow decoding json with duplicate fields" in {
       import io.circe.Decoder
       import io.circe.generic.extras.semiauto._
-      implicit val derivationConf = tezosDerivationConfig
+      implicit val derivationConf = Derivation.tezosDerivationConfig
 
       case class JsonTest(field: String)
 
@@ -46,7 +48,7 @@ class JsonDecodersTest extends WordSpec
     "decode null fields as empty Options" in {
       import io.circe.Decoder
       import io.circe.generic.extras.semiauto._
-      implicit val derivationConf = tezosDerivationConfig
+      implicit val derivationConf = Derivation.tezosDerivationConfig
 
       case class JsonTest(field: Option[String])
 
@@ -436,6 +438,23 @@ class JsonDecodersTest extends WordSpec
 
       val account = decoded.right.value
       account.script.value shouldEqual expectedScript
+    }
+
+    import JsonDecoders.Circe.Delegates._
+    "decode a delegate baker" in new DelegatesJsonData {
+      val decoded = decode[Delegate](delegateJson)
+      decoded shouldBe 'right
+
+      val delegate = decoded.right.value
+      delegate shouldEqual expectedDelegate
+    }
+
+    "decode delegate contracts" in new DelegatesJsonData {
+      val decoded = decode[Contract](contractJson)
+      decoded shouldBe 'right
+
+      val contract = decoded.right.value
+      contract shouldEqual expectedContract
     }
   }
 

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTestFixtures.scala
@@ -3,6 +3,194 @@ package tech.cryptonomic.conseil.tezos
 import TezosTypes._
 import tech.cryptonomic.conseil.tezos.TezosTypes.Scripted.Contracts
 
+/* defines example tezos json definitions of delegates and related contracts with the typed counterparts used in the tests */
+trait DelegatesJsonData {
+
+  val scriptJson =
+    """{
+    |  "code": [
+    |      {
+    |          "prim": "parameter",
+    |          "args": [
+    |              {
+    |                  "prim": "string"
+    |              }
+    |          ]
+    |      }
+    |  ],
+    |  "storage": {
+    |      "string": "hello"
+    |  }
+    |}""".stripMargin
+
+  val expectedScript = Contracts(
+    storage = Micheline("""{"string":"hello"}"""), code = Micheline("""[{"prim":"parameter","args":[{"prim":"string"}]}]""")
+  )
+
+  val contractJson =
+    s"""{
+    |  "manager": "tz1Tzqh3CWLdPoH4kHSqcePatkBVKTwifCHY",
+    |  "balance": "1000",
+    |  "spendable": true,
+    |  "delegate": { "setable": true, "value": "tz1LdZ6S8ScNMgaCLqrekDvbBWhLqtUebk23" },
+    |  "script": $scriptJson,
+    |  "counter": "401"
+    |}""".stripMargin
+
+  val expectedContract =
+    Contract(
+      manager = PublicKeyHash("tz1Tzqh3CWLdPoH4kHSqcePatkBVKTwifCHY"),
+      balance = PositiveDecimal(1000),
+      spendable = true,
+      delegate = ContractDelegate(
+        setable = true,
+        value = Some(PublicKeyHash("tz1LdZ6S8ScNMgaCLqrekDvbBWhLqtUebk23"))
+      ),
+      script = Some(expectedScript),
+      counter = PositiveDecimal(401)
+    )
+
+  val delegateJson =
+    """{
+    |  "balance": "15255730175061",
+    |  "frozen_balance": "4579383927370",
+    |  "frozen_balance_by_cycle": [
+    |      {
+    |          "cycle": 174,
+    |          "deposit": "1321664000000",
+    |          "fees": "572501",
+    |          "rewards": "37062032929"
+    |      },
+    |      {
+    |          "cycle": 175,
+    |          "deposit": "1510400000000",
+    |          "fees": "5341649990",
+    |          "rewards": "45404449892"
+    |      },
+    |      {
+    |          "cycle": 176,
+    |          "deposit": "1550400000000",
+    |          "fees": "301772470",
+    |          "rewards": "44143066264"
+    |      },
+    |      {
+    |          "cycle": 177,
+    |          "deposit": "62848000000",
+    |          "fees": "550000",
+    |          "rewards": "1817833324"
+    |      }
+    |  ],
+    |  "staking_balance": "15141238517762",
+    |  "delegated_contracts": [
+    |      "KT1WT8u7wBAaWsVsjQSxdtqE53RjCnEhMJL6",
+    |      "KT1VHRry7UMdMcHj7RnHe8n5JXM4g6MQHxPk",
+    |      "KT1V5aSEJQdFwZYLpnGDwJ4qpFo1NbEpLnGC",
+    |      "KT1V3ri4nnNQTsG52ypMQhZsnZpJEDi6gB4J",
+    |      "KT1UAq7cAaaza2Kf48fF9zAPhkiVgVd86Neo",
+    |      "KT1UAdtncfLKewg3w34MvoTQAdMxBH2SE2yL",
+    |      "KT1SbeNFNZfpGRqpqTRCkJ5JHZ7h7T65Qoin",
+    |      "KT1SXEuU93Uu7vv3Xii8AeKCJkCcc2buUdXY",
+    |      "KT1S3aDfc5CJqSXDXnyJVarmywDBFg9SaH1M",
+    |      "KT1RN3h385ZbPx7CvyVcBzp6CFzR5uoX6Pds",
+    |      "KT1QTN1gQcriFXH66CbuGiSthTQMSn132Xea",
+    |      "KT1QDgrtfvZLaSxg5enpo7om32UVHJNYSmvJ",
+    |      "KT1QB2y7MwCS2fsGDk283Nh3HHiye1fLvDXR",
+    |      "KT1NG4zyrmWqyYDmj3rzvT5XUnzak1W3Qb1f",
+    |      "KT1MzNXxBzmw8QcPVG5ZW4Km7sSecYDfMnDV",
+    |      "KT1MUD3o2XcSVJ89Np1jXAB1iQ1AGdohUHPh",
+    |      "KT1MCDY9jmC4Z21B5A1QNkLVi5i2KQSuLt8J",
+    |      "KT1KfQCHrXMTHMPd9fbXumLfEPbzpsm6X7EJ",
+    |      "KT1KMULX2UzK5TEoYNdpG6yVadyAkSLAVQEQ",
+    |      "KT1JsyPreVdkdN8P53SDsWk4riGfzyz5cLYC",
+    |      "KT1JsJsbqJrKyuDVvqoabnp77mxhhZpVa1Kx",
+    |      "KT1HkQP7vjzz7pVUbfvpcXFRLwCaexAWZF1C",
+    |      "KT1DjgmUxRZt5evA99somusn96Sjdnj1mhkd",
+    |      "KT1DHv7zmAYF65Y4YeUfLLr4NRyQJb43pkCz",
+    |      "KT1C2ZLQyXVMuRyc7kZeoXGGmhgsdBJX7Qj1",
+    |      "KT1Bne3CrkWFYx8tD9nvqLKXQG2NkAMezT6k",
+    |      "KT1BjqLYHZodyQLyzMC6vZFs3dEsWjTmA75h",
+    |      "KT1AowcbP82HTC4qaLE7EKQPdC1J4D14he5d",
+    |      "KT1AMAP9zczBGHAiQPwjyy17Pz2cjf9dQZuR",
+    |      "KT19Rkg1gBDcUbqm4gDY3THLmMMoDx69bLwX",
+    |      "KT19RhkHK8ssqXX1VxSSpyuyMXHK6V9RHizs",
+    |      "KT18bmcAvpLZPv6BF79RqTmZLZQSjodr3f2S"
+    |  ],
+    |  "delegated_balance": "13935725110",
+    |  "deactivated": false,
+    |  "grace_period": 181
+    |}""".stripMargin
+
+  val expectedDelegate =
+    Delegate(
+      balance = PositiveDecimal(15255730175061L),
+      frozen_balance = PositiveDecimal(4579383927370L),
+      frozen_balance_by_cycle = List(
+        CycleBalance(
+          cycle = 174,
+          deposit = PositiveDecimal(1321664000000L),
+          fees = PositiveDecimal(572501),
+          rewards = PositiveDecimal(37062032929L)
+        ),
+        CycleBalance(
+          cycle = 175,
+          deposit = PositiveDecimal(1510400000000L),
+          fees = PositiveDecimal(5341649990L),
+          rewards = PositiveDecimal(45404449892L)
+        ),
+        CycleBalance(
+          cycle = 176,
+          deposit = PositiveDecimal(1550400000000L),
+          fees = PositiveDecimal(301772470L),
+          rewards = PositiveDecimal(44143066264L)
+        ),
+        CycleBalance(
+          cycle = 177,
+          deposit = PositiveDecimal(62848000000L),
+          fees = PositiveDecimal(550000L),
+          rewards = PositiveDecimal(1817833324L)
+        )
+      ),
+      staking_balance = PositiveDecimal(15141238517762L),
+      delegated_contracts = List(
+        ContractId("KT1WT8u7wBAaWsVsjQSxdtqE53RjCnEhMJL6"),
+        ContractId("KT1VHRry7UMdMcHj7RnHe8n5JXM4g6MQHxPk"),
+        ContractId("KT1V5aSEJQdFwZYLpnGDwJ4qpFo1NbEpLnGC"),
+        ContractId("KT1V3ri4nnNQTsG52ypMQhZsnZpJEDi6gB4J"),
+        ContractId("KT1UAq7cAaaza2Kf48fF9zAPhkiVgVd86Neo"),
+        ContractId("KT1UAdtncfLKewg3w34MvoTQAdMxBH2SE2yL"),
+        ContractId("KT1SbeNFNZfpGRqpqTRCkJ5JHZ7h7T65Qoin"),
+        ContractId("KT1SXEuU93Uu7vv3Xii8AeKCJkCcc2buUdXY"),
+        ContractId("KT1S3aDfc5CJqSXDXnyJVarmywDBFg9SaH1M"),
+        ContractId("KT1RN3h385ZbPx7CvyVcBzp6CFzR5uoX6Pds"),
+        ContractId("KT1QTN1gQcriFXH66CbuGiSthTQMSn132Xea"),
+        ContractId("KT1QDgrtfvZLaSxg5enpo7om32UVHJNYSmvJ"),
+        ContractId("KT1QB2y7MwCS2fsGDk283Nh3HHiye1fLvDXR"),
+        ContractId("KT1NG4zyrmWqyYDmj3rzvT5XUnzak1W3Qb1f"),
+        ContractId("KT1MzNXxBzmw8QcPVG5ZW4Km7sSecYDfMnDV"),
+        ContractId("KT1MUD3o2XcSVJ89Np1jXAB1iQ1AGdohUHPh"),
+        ContractId("KT1MCDY9jmC4Z21B5A1QNkLVi5i2KQSuLt8J"),
+        ContractId("KT1KfQCHrXMTHMPd9fbXumLfEPbzpsm6X7EJ"),
+        ContractId("KT1KMULX2UzK5TEoYNdpG6yVadyAkSLAVQEQ"),
+        ContractId("KT1JsyPreVdkdN8P53SDsWk4riGfzyz5cLYC"),
+        ContractId("KT1JsJsbqJrKyuDVvqoabnp77mxhhZpVa1Kx"),
+        ContractId("KT1HkQP7vjzz7pVUbfvpcXFRLwCaexAWZF1C"),
+        ContractId("KT1DjgmUxRZt5evA99somusn96Sjdnj1mhkd"),
+        ContractId("KT1DHv7zmAYF65Y4YeUfLLr4NRyQJb43pkCz"),
+        ContractId("KT1C2ZLQyXVMuRyc7kZeoXGGmhgsdBJX7Qj1"),
+        ContractId("KT1Bne3CrkWFYx8tD9nvqLKXQG2NkAMezT6k"),
+        ContractId("KT1BjqLYHZodyQLyzMC6vZFs3dEsWjTmA75h"),
+        ContractId("KT1AowcbP82HTC4qaLE7EKQPdC1J4D14he5d"),
+        ContractId("KT1AMAP9zczBGHAiQPwjyy17Pz2cjf9dQZuR"),
+        ContractId("KT19Rkg1gBDcUbqm4gDY3THLmMMoDx69bLwX"),
+        ContractId("KT19RhkHK8ssqXX1VxSSpyuyMXHK6V9RHizs"),
+        ContractId("KT18bmcAvpLZPv6BF79RqTmZLZQSjodr3f2S")
+      ),
+      delegated_balance = PositiveDecimal(13935725110L),
+      deactivated = false,
+      grace_period = 181
+    )
+}
+
 /* defines example tezos json definitions of accounts and typed counterparts used in the tests */
 trait AccountsJsonData {
   val accountJson =

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
@@ -15,6 +15,8 @@ import tech.cryptonomic.conseil.generic.chain.DataTypes._
 import tech.cryptonomic.conseil.util.RandomSeed
 
 import scala.util.Random
+import scala.concurrent.duration._
+import scala.language.postfixOps
 
 class TezosDatabaseOperationsTest
   extends WordSpec
@@ -323,7 +325,7 @@ class TezosDatabaseOperationsTest
           Tables.Accounts += account
         )
 
-      dbHandler.run(populate)
+      dbHandler.run(populate).isReadyWithin(5 seconds) shouldBe true
 
       //prepare new accounts
       val accountChanges = 2

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
@@ -34,7 +34,7 @@ trait TezosDataGeneration extends RandomGenerationKit {
   }
 
   /* randomly generates a number of accounts with associated block data */
-  def generateAccounts(howMany: Int, blockHash: BlockHash, blockLevel: Int)(implicit randomSeed: RandomSeed): BlockAccounts = {
+  def generateAccounts(howMany: Int, blockHash: BlockHash, blockLevel: Int)(implicit randomSeed: RandomSeed): BlockTagged[Map[AccountId, Account]] = {
     require(howMany > 0, "the test can generates a positive number of accounts, you asked for a non positive value")
 
     val rnd = new Random(randomSeed.seed)
@@ -53,7 +53,7 @@ trait TezosDataGeneration extends RandomGenerationKit {
         )
     }.toMap
 
-    BlockAccounts(blockHash, blockLevel, accounts)
+    BlockTagged(blockHash, blockLevel, accounts)
   }
 
   /* randomly populate a number of blocks based on a level range */

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
@@ -10,7 +10,6 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{Matchers, OptionValues, WordSpec}
 import slick.dbio
-import tech.cryptonomic.conseil.config.Newest
 import tech.cryptonomic.conseil.generic.chain.DataTypes.{HighCardinalityAttribute, InvalidAttributeDataType}
 import tech.cryptonomic.conseil.generic.chain.MetadataOperations
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes._
@@ -20,7 +19,7 @@ import tech.cryptonomic.conseil.util.ConfigUtil
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
-
+import scala.language.postfixOps
 
 class TezosPlatformDiscoveryOperationsTest
   extends WordSpec
@@ -211,7 +210,7 @@ class TezosPlatformDiscoveryOperationsTest
 
     "return list of values of kind attribute of Fees without filter" in {
       val avgFee = AverageFees(1, 3, 5, Timestamp.valueOf(LocalDateTime.of(2018, 11, 22, 12, 30)), "example1")
-      metadataOperations.runQuery(TezosDatabaseOperations.writeFees(List(avgFee))).isReadyWithin(5.seconds)
+      metadataOperations.runQuery(TezosDatabaseOperations.writeFees(List(avgFee))).isReadyWithin(5 seconds)
 
       sut.listAttributeValues("fees", "kind", None).futureValue.right.get shouldBe List("example1")
     }
@@ -219,7 +218,7 @@ class TezosPlatformDiscoveryOperationsTest
     "returns a list of errors when asked for medium attribute of Fees without filter - numeric attributes should not be displayed" in {
       val avgFee = AverageFees(1, 3, 5, Timestamp.valueOf(LocalDateTime.of(2018, 11, 22, 12, 30)), "example1")
 
-      dbHandler.run(TezosDatabaseOperations.writeFees(List(avgFee))).isReadyWithin(5.seconds)
+      dbHandler.run(TezosDatabaseOperations.writeFees(List(avgFee))).isReadyWithin(5 seconds)
 
 
       sut.listAttributeValues("fees", "medium", None).futureValue.left.get shouldBe List(InvalidAttributeDataType("medium"), HighCardinalityAttribute("medium"))
@@ -229,7 +228,7 @@ class TezosPlatformDiscoveryOperationsTest
     "return empty list when trying to sql inject" in {
       val avgFee = AverageFees(1, 3, 5, Timestamp.valueOf(LocalDateTime.of(2018, 11, 22, 12, 30)), "example1")
 
-      dbHandler.run(TezosDatabaseOperations.writeFees(List(avgFee))).isReadyWithin(5.seconds)
+      dbHandler.run(TezosDatabaseOperations.writeFees(List(avgFee))).isReadyWithin(5 seconds)
       // That's how the SLQ-injected string will look like:
       // SELECT DISTINCT kind FROM fees WHERE kind LIKE '%'; DELETE FROM fees WHERE kind LIKE '%'
       val maliciousFilter = Some("'; DELETE FROM fees WHERE kind LIKE '")
@@ -247,7 +246,7 @@ class TezosPlatformDiscoveryOperationsTest
       )
 
       sut.listAttributeValues("fees", "kind", Some("1")).futureValue.right.get shouldBe List.empty
-      dbHandler.run(TezosDatabaseOperations.writeFees(avgFees)).isReadyWithin(5.seconds)
+      dbHandler.run(TezosDatabaseOperations.writeFees(avgFees)).isReadyWithin(5 seconds)
 
       sut.listAttributeValues("fees", "kind", None).futureValue.right.get should contain theSameElementsAs List("example1", "example2")
       sut.listAttributeValues("fees", "kind", Some("ex")).futureValue.right.get should contain theSameElementsAs List("example1", "example2")

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosTypesTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosTypesTest.scala
@@ -34,6 +34,26 @@ class TezosTypesTest extends WordSpec with Matchers with OptionValues {
 
   }
 
+  "The Syntax import" should {
+    "allow building Block-tagged generic data" in {
+      import TezosTypes.Syntax._
+
+      val content = "A content string"
+      val (hash, level) = (BlockHash("hash"), 1)
+
+      content.taggedWithBlock(hash, level) shouldEqual BlockTagged(hash, level, content)
+    }
+  }
+
+  "The BlockTagged wrapper" should {
+    "convert to a tuple" in {
+      val content = "A content string"
+      val (hash, level) = (BlockHash("hash"), 1)
+
+      BlockTagged(hash, level, content).asTuple shouldEqual (hash, level, content)
+    }
+  }
+
   "The lenses for tezos types" should {
 
     val blockData =


### PR DESCRIPTION
Relates to #357 

In the same way that accounts for each stored block are first indexed by id in a "checkpoint" table and then fetched and stored, we add a like-wise durable checkpoint for delegates key hashes, filled when accounts are stored.
Such data will be used to download the delegates and their contracts in a separate step, guaranteeing that any failure occurring during this step will not lose information on the delegates for the blocks already stored.
In case of failure the delegates download will be re-attempted during the next Lorre cycle, eventually cleaning the checkpoints once the operation succeeds.

This PR only store the delegates to the checkpoint.
_The actual fetching of delegates and contracts and cleanup of the checkpoints will be part of the next PR._

## Required changes to DB schema

A new table and related constraints are added

```slq
CREATE TABLE public.delegates_checkpoint (
    delegate_pkh character varying NOT NULL,
    block_id character varying NOT NULL REFERENCES public.blocks(hash),
    block_level integer DEFAULT '-1'::integer NOT NULL
);

CREATE INDEX ix_delegates_checkpoint_block_level ON public.delegates_checkpoint USING btree (block_level);

```