### PR TITLE
Adding configurable query result size limit

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -5,6 +5,7 @@ conseil: {
   hostname: "0.0.0.0"
   port: 1337
   cache-ttl: 15 minutes
+  max-query-result-size: 100000
 }
 
 # Runtime settings for Lorre process

--- a/src/main/scala/tech/cryptonomic/conseil/Conseil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Conseil.scala
@@ -55,7 +55,7 @@ object Conseil extends App with LazyLogging with EnableCORSDirectives with Conse
       lazy val transformation = new UnitTransformation(metadataOverrides)
       lazy val metadataService = new MetadataService(platforms, transformation, tezosPlatformDiscoveryOperations)
       lazy val platformDiscovery = PlatformDiscovery(metadataService)(tezosDispatcher)
-      lazy val data = Data(platforms, tezosPlatformDiscoveryOperations)(tezosDispatcher)
+      lazy val data = Data(platforms, tezosPlatformDiscoveryOperations, server)(tezosDispatcher)
 
       val route = cors() {
         enableCORS {

--- a/src/main/scala/tech/cryptonomic/conseil/config/Shared.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/config/Shared.scala
@@ -4,7 +4,7 @@ import tech.cryptonomic.conseil.tezos.TezosTypes.BlockHash
 
 import scala.concurrent.duration.FiniteDuration
 
-final case class ServerConfiguration(hostname: String, port: Int, cacheTTL: FiniteDuration)
+final case class ServerConfiguration(hostname: String, port: Int, cacheTTL: FiniteDuration, maxQueryResultSize: Int)
 
 final case class LorreConfiguration(
   sleepInterval: FiniteDuration,

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataPlatform.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataPlatform.scala
@@ -7,7 +7,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 /** Companion object providing default apply implementation */
 object DataPlatform {
-  def apply(): DataPlatform = new DataPlatform(Map("tezos" -> ApiOperations))
+  def apply(maxQueryResultSize: Int): DataPlatform = new DataPlatform(Map("tezos" -> ApiOperations), maxQueryResultSize)
 }
 
 /** Class for validating if query protocol exists for the given platform
@@ -15,7 +15,7 @@ object DataPlatform {
   * @param operationsMap map of platformName -> QueryProtocolOperations
   * */
 
-class DataPlatform(operationsMap: Map[String, DataOperations]) {
+class DataPlatform(operationsMap: Map[String, DataOperations], maxQueryResultSize: Int) {
   import cats.instances.future._
   import cats.instances.option._
   import cats.syntax.traverse._
@@ -28,6 +28,6 @@ class DataPlatform(operationsMap: Map[String, DataOperations]) {
     * */
   def queryWithPredicates(platform: String, tableName: String, query: Query)
     (implicit ec: ExecutionContext): Future[Option[List[QueryResponse]]] = {
-    operationsMap.get(platform).map(_.queryWithPredicates(tableName, query)).sequence
+    operationsMap.get(platform).map(_.queryWithPredicates(tableName, query.copy(limit = Math.min(query.limit, maxQueryResultSize)))).sequence
   }
 }

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
@@ -34,8 +34,6 @@ object DataTypes {
   }
   /** Default value of limit parameter */
   val defaultLimitValue: Int = 10000
-  /** Max value of limit parameter */
-  val maxLimitValue: Int = 100000
 
   /** Replaces timestamp represented as Long in predicates with one understood by the SQL */
   private def replaceTimestampInPredicates(entity: String, query: Query, tezosPlatformDiscoveryOperations: TezosPlatformDiscoveryOperations)

--- a/src/main/scala/tech/cryptonomic/conseil/routes/Data.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/Data.scala
@@ -4,6 +4,7 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import com.typesafe.scalalogging.LazyLogging
 import tech.cryptonomic.conseil.config.Platforms.PlatformsConfiguration
+import tech.cryptonomic.conseil.config.ServerConfiguration
 import tech.cryptonomic.conseil.db.DatabaseApiFiltering
 import tech.cryptonomic.conseil.generic.chain.DataPlatform
 import tech.cryptonomic.conseil.tezos.TezosPlatformDiscoveryOperations
@@ -16,8 +17,8 @@ import scala.concurrent.{ExecutionContext, Future}
 
 /** Companion object providing apply implementation */
 object Data {
-  def apply(config: PlatformsConfiguration, tezosPlatformDiscoveryOperations: TezosPlatformDiscoveryOperations)(implicit ec: ExecutionContext): Data =
-    new Data(config, DataPlatform(), tezosPlatformDiscoveryOperations)
+  def apply(config: PlatformsConfiguration, tezosPlatformDiscoveryOperations: TezosPlatformDiscoveryOperations, server: ServerConfiguration)(implicit ec: ExecutionContext): Data =
+    new Data(config, DataPlatform(server.maxQueryResultSize), tezosPlatformDiscoveryOperations)
 }
 
 /**

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
@@ -407,7 +407,7 @@ object ApiOperations extends DataOperations with MetadataOperations {
         sanitizePredicates(query.predicates),
         query.orderBy,
         query.aggregation,
-        Math.min(query.limit, DataTypes.maxLimitValue)
+        query.limit
       )
     )
   }

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DataTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DataTest.scala
@@ -82,7 +82,7 @@ class DataTest extends WordSpec with Matchers with ScalatestRouteTest with Scala
       Future.successful(responseAsMap)
   }
 
-  val fakeQPP: DataPlatform = new DataPlatform(Map("tezos" -> fakeQPO))
+  val fakeQPP: DataPlatform = new DataPlatform(Map("tezos" -> fakeQPO), 1000)
   val cfg = PlatformsConfiguration(
     platforms = Map(
       Tezos -> List(TezosConfiguration("alphanet", TezosNodeConfiguration(protocol = "http", hostname = "localhost", port = 8732)))


### PR DESCRIPTION
As @anonymoussprocket requested, I've removed hardcoded value which represented maximum size of the query result and replaced it with value from the config.

## Required changes to DB schema
 new value in configuration added:
```
  conseil: {
    hostname: "0.0.0.0"
    port: 1337
    cache-ttl: 15 minutes
+  max-query-result-size: 100000
  }
```

