### PR TITLE
357-2 - Store delegates and delegated contract information based on checkpoint

### DIFF
--- a/doc/conseil.sql
+++ b/doc/conseil.sql
@@ -189,7 +189,31 @@ CREATE TABLE public.balance_updates (
     category character varying
 );
 
+CREATE TABLE public.delegates (
+    pkh character varying PRIMARY KEY,
+    block_id character varying NOT NULL,
+    balance numeric,
+    frozen_balance numeric,
+    staking_balance numeric,
+    delegated_balance numeric,
+    deactivated boolean NOT NULL,
+    grace_period integer NOT NULL,
+    block_level numeric DEFAULT '-1'::integer NOT NULL
+);
 
+CREATE TABLE public.delegated_contracts (
+    account_id character varying NOT NULL,
+    block_id character varying NOT NULL,
+    manager character varying NOT NULL,
+    spendable boolean NOT NULL,
+    delegate_setable boolean NOT NULL,
+    delegate_value character varying,
+    counter integer NOT NULL,
+    script character varying,
+    storage character varying,
+    balance numeric NOT NULL,
+    block_level numeric DEFAULT '-1'::integer NOT NULL
+);
 --
 -- Name: accounts_checkpoint; Type: TABLE; Schema: public; Owner: -
 --
@@ -408,6 +432,15 @@ CREATE INDEX ix_proposals_protocol ON public.proposals USING btree (protocol_has
 
 ALTER TABLE ONLY public.accounts
     ADD CONSTRAINT accounts_block_id_fkey FOREIGN KEY (block_id) REFERENCES public.blocks(hash);
+
+ALTER TABLE ONLY public.delegated_contracts
+    ADD CONSTRAINT contracts_delegate_pkh_fkey FOREIGN KEY (delegate_value) REFERENCES public.delegates(pkh);
+
+ALTER TABLE ONLY public.delegated_contracts
+    ADD CONSTRAINT contracts_block_id_fkey FOREIGN KEY (block_id) REFERENCES public.blocks(hash);
+
+ALTER TABLE ONLY public.delegates
+    ADD CONSTRAINT delegates_block_id_fkey FOREIGN KEY (block_id) REFERENCES public.blocks(hash);
 
 --
 -- Name: accounts_checkpoint checkpoint_block_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -

--- a/doc/conseil.sql
+++ b/doc/conseil.sql
@@ -203,16 +203,7 @@ CREATE TABLE public.delegates (
 
 CREATE TABLE public.delegated_contracts (
     account_id character varying NOT NULL,
-    block_id character varying NOT NULL,
-    manager character varying NOT NULL,
-    spendable boolean NOT NULL,
-    delegate_setable boolean NOT NULL,
-    delegate_value character varying,
-    counter integer NOT NULL,
-    script character varying,
-    storage character varying,
-    balance numeric NOT NULL,
-    block_level numeric DEFAULT '-1'::integer NOT NULL
+    delegate_value character varying
 );
 --
 -- Name: accounts_checkpoint; Type: TABLE; Schema: public; Owner: -
@@ -437,7 +428,7 @@ ALTER TABLE ONLY public.delegated_contracts
     ADD CONSTRAINT contracts_delegate_pkh_fkey FOREIGN KEY (delegate_value) REFERENCES public.delegates(pkh);
 
 ALTER TABLE ONLY public.delegated_contracts
-    ADD CONSTRAINT contracts_block_id_fkey FOREIGN KEY (block_id) REFERENCES public.blocks(hash);
+    ADD CONSTRAINT contracts_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.accounts(account_id);
 
 ALTER TABLE ONLY public.delegates
     ADD CONSTRAINT delegates_block_id_fkey FOREIGN KEY (block_id) REFERENCES public.blocks(hash);

--- a/doc/conseil.sql
+++ b/doc/conseil.sql
@@ -198,7 +198,7 @@ CREATE TABLE public.delegates (
     delegated_balance numeric,
     deactivated boolean NOT NULL,
     grace_period integer NOT NULL,
-    block_level numeric DEFAULT '-1'::integer NOT NULL
+    block_level integer DEFAULT '-1'::integer NOT NULL
 );
 
 CREATE TABLE public.delegated_contracts (

--- a/doc/conseil.sql
+++ b/doc/conseil.sql
@@ -247,10 +247,10 @@ CREATE TABLE public.proposals (
 
 
 --
--- Name: bakers; Type: TABLE; Schema: public; Owner: -
+-- Name: rolls; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.bakers (
+CREATE TABLE public.rolls (
     pkh character varying NOT NULL,
     rolls integer NOT NULL,
     block_id character varying NOT NULL,
@@ -467,11 +467,11 @@ ALTER TABLE ONLY public.proposals
 
 
 --
--- Name: bakers baker_block_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: rolls rolls_block_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.bakers
-    ADD CONSTRAINT baker_block_id_fkey FOREIGN KEY (block_id) REFERENCES public.blocks(hash);
+ALTER TABLE ONLY public.rolls
+    ADD CONSTRAINT rolls_block_id_fkey FOREIGN KEY (block_id) REFERENCES public.blocks(hash);
 
 
 

--- a/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
@@ -5,7 +5,7 @@ import akka.Done
 import mouse.any._
 import com.typesafe.scalalogging.LazyLogging
 import tech.cryptonomic.conseil.tezos.{TezosTypes, FeeOperations, ShutdownComplete, TezosErrors, TezosNodeInterface, TezosNodeOperator, TezosDatabaseOperations => TezosDb}
-import tech.cryptonomic.conseil.tezos.TezosTypes.{BlockTagged, Account, AccountId}
+import tech.cryptonomic.conseil.tezos.TezosTypes.{BlockTagged, Account, AccountId, Delegate, PublicKeyHash}
 import tech.cryptonomic.conseil.io.MainOutputs.LorreOutput
 import tech.cryptonomic.conseil.util.DatabaseUtil
 import tech.cryptonomic.conseil.config.{Custom, Everything, LorreAppConfig, Newest}
@@ -23,6 +23,7 @@ import scala.util.{Failure, Success, Try}
 object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig with LorreOutput {
 
   //reads all configuration upstart, will only complete if all values are found
+
   val config = loadApplicationConfiguration(args)
 
   //stop if conf is not available
@@ -177,7 +178,9 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
           (processed, nextPage) =>
             //wait for each page to load, before looking at the next, thus  starting the new computation
             val justDone = Await.result(
-              processBlocksPage(nextPage) <* processTezosAccounts(),
+              processBlocksPage(nextPage) <*
+                processTezosAccounts() <*
+                processTezosDelegates(),
               atMost = batchingConf.blockPageProcessingTimeout)
             processed + justDone <| logProgress
         }
@@ -231,12 +234,8 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
     }
   }
 
-  /**
-    * Fetches and stores all accounts from the latest blocks stored in the database.
-    *
-    * NOTE: as the call is now async, it won't stop the application on error as before, so
-    * we should evaluate how to handle failed processing
-    */
+
+  /** Fetches and stores all accounts from the latest blocks stored in the database. */
   private[this] def processTezosAccounts(): Future[Done] = {
     import cats.instances.list._
     import cats.syntax.functorFilter._
@@ -274,16 +273,16 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
         //custom progress tracking for accounts
         val logProgress = logProcessingProgress(entityName = "account", totalToProcess = total, processStartNanos = System.nanoTime()) _
 
-          /* Process in a strictly sequential way, to avoid opening an unbounded number of requests on the http-client.
-          * The size and partition of results is driven by the NodeOperator itself, were each page contains a
-          * "thunked" future of the result.
-          * Such future will be actually started only as the page iterator is scanned, one element at the time
-          */
-          pages.foldLeft(0) {
-            (processed, nextPage) =>
-              //wait for each page to load, before looking at the next, thus  starting the new computation
-              val justDone = Await.result(processAccountsPage(nextPage), atMost = batchingConf.accountPageProcessingTimeout)
-              processed + justDone <| logProgress
+        /* Process in a strictly sequential way, to avoid opening an unbounded number of requests on the http-client.
+        * The size and partition of results is driven by the NodeOperator itself, were each page contains a
+        * "thunked" future of the result.
+        * Such future will be actually started only as the page iterator is scanned, one element at the time
+        */
+        pages.foldLeft(0) {
+          (processed, nextPage) =>
+            //wait for each page to load, before looking at the next, thus  starting the new computation
+            val justDone = Await.result(processAccountsPage(nextPage), atMost = batchingConf.accountPageProcessingTimeout)
+            processed + justDone <| logProgress
         }
 
         checkpoints
@@ -306,6 +305,66 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
         Failure(AccountsProcessingFailed(message = error, e))
       case success => Success(Done)
     }
+  }
+
+  /** Fetches and stores all delegates from the latest blocks stored in the database. */
+  private[this] def processTezosDelegates(): Future[Done] = {
+
+    logger.info("Processing latest Tezos data for account delegates...")
+
+    def logOutcome: PartialFunction[Try[Int], Unit] = {
+      case Success(delegateRows) =>
+        logger.info("{} delegates were touched on the database.", delegateRows)
+      case Failure(e) =>
+        logger.error("Could not write delegates to the database")
+    }
+
+    def processDelegatesPage(delegatesInfo: Future[List[BlockTagged[Map[PublicKeyHash, Delegate]]]]): Future[Int] =
+      delegatesInfo.flatMap{
+        taggedDelegates =>
+          db.run(TezosDb.writeDelegatesAndCopyContracts(taggedDelegates))
+            .andThen(logOutcome)
+      }
+
+    val saveDelegates = db.run(TezosDb.getLatestDelegatesFromCheckpoint) map {
+      checkpoints =>
+        logger.debug("I loaded all stored delegate references and will proceed to fetch updated information from the chain")
+        val (pages, total) = tezosNodeOperator.getDelegatesForBlocks(checkpoints)
+        //custom progress tracking for accounts
+        val logProgress = logProcessingProgress(entityName = "delegate", totalToProcess = total, processStartNanos = System.nanoTime()) _
+
+        /* Process in a strictly sequential way, to avoid opening an unbounded number of requests on the http-client.
+        * The size and partition of results is driven by the NodeOperator itself, were each page contains a
+        * "thunked" future of the result.
+        * Such future will be actually started only as the page iterator is scanned, one element at the time
+        */
+        pages.foldLeft(0) {
+          (processed, nextPage) =>
+            //wait for each page to load, before looking at the next, thus  starting the new computation
+            val justDone = Await.result(processDelegatesPage(nextPage), atMost = batchingConf.accountPageProcessingTimeout)
+            processed + justDone <| logProgress
+        }
+
+        checkpoints
+    }
+
+    saveDelegates.andThen {
+      //additional cleanup, that can fail with no downsides
+      case Success(checkpoints) =>
+        val processed = Some(checkpoints.keySet)
+        logger.debug("Cleaning checkpointed delegates..")
+        Await.result(db.run(TezosDb.cleanDelegatesCheckpoint(processed)), atMost = batchingConf.accountPageProcessingTimeout)
+        logger.debug("Done cleaning checkpointed delegates.")
+      case _ =>
+        ()
+    }.transform {
+      case Failure(e) =>
+        val error = "I failed to fetch delegates from client and update them"
+        logger.error(error, e)
+        Failure(DelegatesProcessingFailed(message = error, e))
+      case success => Success(Done)
+    }
+
   }
 
   /** Keeps track of time passed between different partial checkpoints of some entity processing

--- a/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
@@ -215,7 +215,7 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
         val writeProposal = TezosDb.writeVotingProposals(proposals)
         //this is a nested list, each block with many baker rolls
         val writeBakers = bakersBlocks.traverse {
-          case (block, bakers) => TezosDb.writeVotingBakers(bakers, block)
+          case (block, bakersRolls) => TezosDb.writeVotingRolls(bakersRolls, block)
         }
         //this is a nested list, each block with many ballot votes
         val writeBallots = ballotsBlocks.traverse {

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/CsvConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/CsvConversions.scala
@@ -2,7 +2,7 @@ package tech.cryptonomic.conseil.routes.openapi
 
 import tech.cryptonomic.conseil.generic.chain.DataTypes.QueryResponse
 import tech.cryptonomic.conseil.util.Conversion
-import tech.cryptonomic.conseil.util.Conversion.Id
+import cats.Id
 
 /** Object containing implicit conversions to CSV format */
 object CsvConversions {

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
@@ -320,7 +320,7 @@ object ApiOperations extends DataOperations with MetadataOperations {
     * Fetches an account by account id from the db.
     * @param account_id The account's id number
     * @param ec ExecutionContext needed to invoke the data fetching using async results
-    * @return The account with its associated operation groups
+    * @return The account
     */
   def fetchAccount(account_id: AccountId)(implicit ec: ExecutionContext): Future[Option[AccountResult]] = {
     val fetchOperation =

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
@@ -442,14 +442,14 @@ object DatabaseConversions {
     }
   }
 
-  implicit val bakersToRows = new Conversion[List, (Block, List[Voting.BakerRolls]), Tables.BakersRow] {
+  implicit val rollsToRows = new Conversion[List, (Block, List[Voting.BakerRolls]), Tables.RollsRow] {
     override def convert(from: (Block, List[Voting.BakerRolls])) = {
       val (block, bakers) = from
       val blockHash = block.data.hash.value
       val blockLevel = block.data.header.level
       bakers.map {
         case Voting.BakerRolls(PublicKeyHash(hash), rolls) =>
-          Tables.BakersRow(
+          Tables.RollsRow(
             pkh = hash,
             rolls = rolls,
             blockId = blockHash,

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
@@ -288,53 +288,26 @@ trait Tables {
 
   /** Entity class storing rows of table DelegatedContracts
    *  @param accountId Database column account_id SqlType(varchar)
-   *  @param blockId Database column block_id SqlType(varchar)
-   *  @param manager Database column manager SqlType(varchar)
-   *  @param spendable Database column spendable SqlType(bool)
-   *  @param delegateSetable Database column delegate_setable SqlType(bool)
-   *  @param delegateValue Database column delegate_value SqlType(varchar), Default(None)
-   *  @param counter Database column counter SqlType(int4)
-   *  @param script Database column script SqlType(varchar), Default(None)
-   *  @param storage Database column storage SqlType(varchar), Default(None)
-   *  @param balance Database column balance SqlType(numeric)
-   *  @param blockLevel Database column block_level SqlType(numeric), Default(-1) */
-  case class DelegatedContractsRow(accountId: String, blockId: String, manager: String, spendable: Boolean, delegateSetable: Boolean, delegateValue: Option[String] = None, counter: Int, script: Option[String] = None, storage: Option[String] = None, balance: scala.math.BigDecimal, blockLevel: scala.math.BigDecimal = scala.math.BigDecimal("-1"))
+   *  @param delegateValue Database column delegate_value SqlType(varchar), Default(None) */
+  case class DelegatedContractsRow(accountId: String, delegateValue: Option[String] = None)
   /** GetResult implicit for fetching DelegatedContractsRow objects using plain SQL queries */
-  implicit def GetResultDelegatedContractsRow(implicit e0: GR[String], e1: GR[Boolean], e2: GR[Option[String]], e3: GR[Int], e4: GR[scala.math.BigDecimal]): GR[DelegatedContractsRow] = GR{
+  implicit def GetResultDelegatedContractsRow(implicit e0: GR[String], e1: GR[Option[String]]): GR[DelegatedContractsRow] = GR{
     prs => import prs._
-    DelegatedContractsRow.tupled((<<[String], <<[String], <<[String], <<[Boolean], <<[Boolean], <<?[String], <<[Int], <<?[String], <<?[String], <<[scala.math.BigDecimal], <<[scala.math.BigDecimal]))
+    DelegatedContractsRow.tupled((<<[String], <<?[String]))
   }
   /** Table description of table delegated_contracts. Objects of this class serve as prototypes for rows in queries. */
   class DelegatedContracts(_tableTag: Tag) extends profile.api.Table[DelegatedContractsRow](_tableTag, "delegated_contracts") {
-    def * = (accountId, blockId, manager, spendable, delegateSetable, delegateValue, counter, script, storage, balance, blockLevel) <> (DelegatedContractsRow.tupled, DelegatedContractsRow.unapply)
+    def * = (accountId, delegateValue) <> (DelegatedContractsRow.tupled, DelegatedContractsRow.unapply)
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? = ((Rep.Some(accountId), Rep.Some(blockId), Rep.Some(manager), Rep.Some(spendable), Rep.Some(delegateSetable), delegateValue, Rep.Some(counter), script, storage, Rep.Some(balance), Rep.Some(blockLevel))).shaped.<>({r=>import r._; _1.map(_=> DelegatedContractsRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get, _6, _7.get, _8, _9, _10.get, _11.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+    def ? = ((Rep.Some(accountId), delegateValue)).shaped.<>({r=>import r._; _1.map(_=> DelegatedContractsRow.tupled((_1.get, _2)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
 
     /** Database column account_id SqlType(varchar) */
     val accountId: Rep[String] = column[String]("account_id")
-    /** Database column block_id SqlType(varchar) */
-    val blockId: Rep[String] = column[String]("block_id")
-    /** Database column manager SqlType(varchar) */
-    val manager: Rep[String] = column[String]("manager")
-    /** Database column spendable SqlType(bool) */
-    val spendable: Rep[Boolean] = column[Boolean]("spendable")
-    /** Database column delegate_setable SqlType(bool) */
-    val delegateSetable: Rep[Boolean] = column[Boolean]("delegate_setable")
     /** Database column delegate_value SqlType(varchar), Default(None) */
     val delegateValue: Rep[Option[String]] = column[Option[String]]("delegate_value", O.Default(None))
-    /** Database column counter SqlType(int4) */
-    val counter: Rep[Int] = column[Int]("counter")
-    /** Database column script SqlType(varchar), Default(None) */
-    val script: Rep[Option[String]] = column[Option[String]]("script", O.Default(None))
-    /** Database column storage SqlType(varchar), Default(None) */
-    val storage: Rep[Option[String]] = column[Option[String]]("storage", O.Default(None))
-    /** Database column balance SqlType(numeric) */
-    val balance: Rep[scala.math.BigDecimal] = column[scala.math.BigDecimal]("balance")
-    /** Database column block_level SqlType(numeric), Default(-1) */
-    val blockLevel: Rep[scala.math.BigDecimal] = column[scala.math.BigDecimal]("block_level", O.Default(scala.math.BigDecimal("-1")))
 
-    /** Foreign key referencing Blocks (database name contracts_block_id_fkey) */
-    lazy val blocksFk = foreignKey("contracts_block_id_fkey", blockId, Blocks)(r => r.hash, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
+    /** Foreign key referencing Accounts (database name contracts_account_id_fkey) */
+    lazy val accountsFk = foreignKey("contracts_account_id_fkey", accountId, Accounts)(r => r.accountId, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
     /** Foreign key referencing Delegates (database name contracts_delegate_pkh_fkey) */
     lazy val delegatesFk = foreignKey("contracts_delegate_pkh_fkey", delegateValue, Delegates)(r => Rep.Some(r.pkh), onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
   }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
@@ -16,7 +16,7 @@ trait Tables {
   import slick.jdbc.{GetResult => GR}
 
   /** DDL for all tables. Call .create to execute. */
-  lazy val schema: profile.SchemaDescription = Array(Accounts.schema, AccountsCheckpoint.schema, Bakers.schema, BalanceUpdates.schema, Ballots.schema, Blocks.schema, DelegatesCheckpoint.schema, Fees.schema, OperationGroups.schema, Operations.schema, Proposals.schema).reduceLeft(_ ++ _)
+  lazy val schema: profile.SchemaDescription = Array(Accounts.schema, AccountsCheckpoint.schema, Bakers.schema, BalanceUpdates.schema, Ballots.schema, Blocks.schema, DelegatedContracts.schema, Delegates.schema, DelegatesCheckpoint.schema, Fees.schema, OperationGroups.schema, Operations.schema, Proposals.schema).reduceLeft(_ ++ _)
   @deprecated("Use .schema instead of .ddl", "3.0")
   def ddl = schema
 
@@ -317,6 +317,108 @@ trait Tables {
   }
   /** Collection-like TableQuery object for table Blocks */
   lazy val Blocks = new TableQuery(tag => new Blocks(tag))
+
+  /** Entity class storing rows of table DelegatedContracts
+   *  @param accountId Database column account_id SqlType(varchar)
+   *  @param blockId Database column block_id SqlType(varchar)
+   *  @param manager Database column manager SqlType(varchar)
+   *  @param spendable Database column spendable SqlType(bool)
+   *  @param delegateSetable Database column delegate_setable SqlType(bool)
+   *  @param delegateValue Database column delegate_value SqlType(varchar), Default(None)
+   *  @param counter Database column counter SqlType(int4)
+   *  @param script Database column script SqlType(varchar), Default(None)
+   *  @param storage Database column storage SqlType(varchar), Default(None)
+   *  @param balance Database column balance SqlType(numeric)
+   *  @param blockLevel Database column block_level SqlType(numeric), Default(-1) */
+  case class DelegatedContractsRow(accountId: String, blockId: String, manager: String, spendable: Boolean, delegateSetable: Boolean, delegateValue: Option[String] = None, counter: Int, script: Option[String] = None, storage: Option[String] = None, balance: scala.math.BigDecimal, blockLevel: scala.math.BigDecimal = scala.math.BigDecimal("-1"))
+  /** GetResult implicit for fetching DelegatedContractsRow objects using plain SQL queries */
+  implicit def GetResultDelegatedContractsRow(implicit e0: GR[String], e1: GR[Boolean], e2: GR[Option[String]], e3: GR[Int], e4: GR[scala.math.BigDecimal]): GR[DelegatedContractsRow] = GR{
+    prs => import prs._
+    DelegatedContractsRow.tupled((<<[String], <<[String], <<[String], <<[Boolean], <<[Boolean], <<?[String], <<[Int], <<?[String], <<?[String], <<[scala.math.BigDecimal], <<[scala.math.BigDecimal]))
+  }
+  /** Table description of table delegated_contracts. Objects of this class serve as prototypes for rows in queries. */
+  class DelegatedContracts(_tableTag: Tag) extends profile.api.Table[DelegatedContractsRow](_tableTag, "delegated_contracts") {
+    def * = (accountId, blockId, manager, spendable, delegateSetable, delegateValue, counter, script, storage, balance, blockLevel) <> (DelegatedContractsRow.tupled, DelegatedContractsRow.unapply)
+    /** Maps whole row to an option. Useful for outer joins. */
+    def ? = ((Rep.Some(accountId), Rep.Some(blockId), Rep.Some(manager), Rep.Some(spendable), Rep.Some(delegateSetable), delegateValue, Rep.Some(counter), script, storage, Rep.Some(balance), Rep.Some(blockLevel))).shaped.<>({r=>import r._; _1.map(_=> DelegatedContractsRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get, _6, _7.get, _8, _9, _10.get, _11.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+
+    /** Database column account_id SqlType(varchar) */
+    val accountId: Rep[String] = column[String]("account_id")
+    /** Database column block_id SqlType(varchar) */
+    val blockId: Rep[String] = column[String]("block_id")
+    /** Database column manager SqlType(varchar) */
+    val manager: Rep[String] = column[String]("manager")
+    /** Database column spendable SqlType(bool) */
+    val spendable: Rep[Boolean] = column[Boolean]("spendable")
+    /** Database column delegate_setable SqlType(bool) */
+    val delegateSetable: Rep[Boolean] = column[Boolean]("delegate_setable")
+    /** Database column delegate_value SqlType(varchar), Default(None) */
+    val delegateValue: Rep[Option[String]] = column[Option[String]]("delegate_value", O.Default(None))
+    /** Database column counter SqlType(int4) */
+    val counter: Rep[Int] = column[Int]("counter")
+    /** Database column script SqlType(varchar), Default(None) */
+    val script: Rep[Option[String]] = column[Option[String]]("script", O.Default(None))
+    /** Database column storage SqlType(varchar), Default(None) */
+    val storage: Rep[Option[String]] = column[Option[String]]("storage", O.Default(None))
+    /** Database column balance SqlType(numeric) */
+    val balance: Rep[scala.math.BigDecimal] = column[scala.math.BigDecimal]("balance")
+    /** Database column block_level SqlType(numeric), Default(-1) */
+    val blockLevel: Rep[scala.math.BigDecimal] = column[scala.math.BigDecimal]("block_level", O.Default(scala.math.BigDecimal("-1")))
+
+    /** Foreign key referencing Blocks (database name contracts_block_id_fkey) */
+    lazy val blocksFk = foreignKey("contracts_block_id_fkey", blockId, Blocks)(r => r.hash, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
+    /** Foreign key referencing Delegates (database name contracts_delegate_pkh_fkey) */
+    lazy val delegatesFk = foreignKey("contracts_delegate_pkh_fkey", delegateValue, Delegates)(r => Rep.Some(r.pkh), onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
+  }
+  /** Collection-like TableQuery object for table DelegatedContracts */
+  lazy val DelegatedContracts = new TableQuery(tag => new DelegatedContracts(tag))
+
+  /** Entity class storing rows of table Delegates
+   *  @param pkh Database column pkh SqlType(varchar), PrimaryKey
+   *  @param blockId Database column block_id SqlType(varchar)
+   *  @param balance Database column balance SqlType(numeric), Default(None)
+   *  @param frozenBalance Database column frozen_balance SqlType(numeric), Default(None)
+   *  @param stakingBalance Database column staking_balance SqlType(numeric), Default(None)
+   *  @param delegatedBalance Database column delegated_balance SqlType(numeric), Default(None)
+   *  @param deactivated Database column deactivated SqlType(bool)
+   *  @param gracePeriod Database column grace_period SqlType(int4)
+   *  @param blockLevel Database column block_level SqlType(numeric), Default(-1) */
+  case class DelegatesRow(pkh: String, blockId: String, balance: Option[scala.math.BigDecimal] = None, frozenBalance: Option[scala.math.BigDecimal] = None, stakingBalance: Option[scala.math.BigDecimal] = None, delegatedBalance: Option[scala.math.BigDecimal] = None, deactivated: Boolean, gracePeriod: Int, blockLevel: scala.math.BigDecimal = scala.math.BigDecimal("-1"))
+  /** GetResult implicit for fetching DelegatesRow objects using plain SQL queries */
+  implicit def GetResultDelegatesRow(implicit e0: GR[String], e1: GR[Option[scala.math.BigDecimal]], e2: GR[Boolean], e3: GR[Int], e4: GR[scala.math.BigDecimal]): GR[DelegatesRow] = GR{
+    prs => import prs._
+    DelegatesRow.tupled((<<[String], <<[String], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<[Boolean], <<[Int], <<[scala.math.BigDecimal]))
+  }
+  /** Table description of table delegates. Objects of this class serve as prototypes for rows in queries. */
+  class Delegates(_tableTag: Tag) extends profile.api.Table[DelegatesRow](_tableTag, "delegates") {
+    def * = (pkh, blockId, balance, frozenBalance, stakingBalance, delegatedBalance, deactivated, gracePeriod, blockLevel) <> (DelegatesRow.tupled, DelegatesRow.unapply)
+    /** Maps whole row to an option. Useful for outer joins. */
+    def ? = ((Rep.Some(pkh), Rep.Some(blockId), balance, frozenBalance, stakingBalance, delegatedBalance, Rep.Some(deactivated), Rep.Some(gracePeriod), Rep.Some(blockLevel))).shaped.<>({r=>import r._; _1.map(_=> DelegatesRow.tupled((_1.get, _2.get, _3, _4, _5, _6, _7.get, _8.get, _9.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+
+    /** Database column pkh SqlType(varchar), PrimaryKey */
+    val pkh: Rep[String] = column[String]("pkh", O.PrimaryKey)
+    /** Database column block_id SqlType(varchar) */
+    val blockId: Rep[String] = column[String]("block_id")
+    /** Database column balance SqlType(numeric), Default(None) */
+    val balance: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("balance", O.Default(None))
+    /** Database column frozen_balance SqlType(numeric), Default(None) */
+    val frozenBalance: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("frozen_balance", O.Default(None))
+    /** Database column staking_balance SqlType(numeric), Default(None) */
+    val stakingBalance: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("staking_balance", O.Default(None))
+    /** Database column delegated_balance SqlType(numeric), Default(None) */
+    val delegatedBalance: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("delegated_balance", O.Default(None))
+    /** Database column deactivated SqlType(bool) */
+    val deactivated: Rep[Boolean] = column[Boolean]("deactivated")
+    /** Database column grace_period SqlType(int4) */
+    val gracePeriod: Rep[Int] = column[Int]("grace_period")
+    /** Database column block_level SqlType(numeric), Default(-1) */
+    val blockLevel: Rep[scala.math.BigDecimal] = column[scala.math.BigDecimal]("block_level", O.Default(scala.math.BigDecimal("-1")))
+
+    /** Foreign key referencing Blocks (database name delegates_block_id_fkey) */
+    lazy val blocksFk = foreignKey("delegates_block_id_fkey", blockId, Blocks)(r => r.hash, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
+  }
+  /** Collection-like TableQuery object for table Delegates */
+  lazy val Delegates = new TableQuery(tag => new Delegates(tag))
 
   /** Entity class storing rows of table DelegatesCheckpoint
    *  @param delegatePkh Database column delegate_pkh SqlType(varchar)

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
@@ -16,7 +16,7 @@ trait Tables {
   import slick.jdbc.{GetResult => GR}
 
   /** DDL for all tables. Call .create to execute. */
-  lazy val schema: profile.SchemaDescription = Array(Accounts.schema, AccountsCheckpoint.schema, Bakers.schema, BalanceUpdates.schema, Ballots.schema, Blocks.schema, DelegatedContracts.schema, Delegates.schema, DelegatesCheckpoint.schema, Fees.schema, OperationGroups.schema, Operations.schema, Proposals.schema).reduceLeft(_ ++ _)
+  lazy val schema: profile.SchemaDescription = Array(Accounts.schema, AccountsCheckpoint.schema, BalanceUpdates.schema, Ballots.schema, Blocks.schema, DelegatedContracts.schema, Delegates.schema, DelegatesCheckpoint.schema, Fees.schema, OperationGroups.schema, Operations.schema, Proposals.schema, Rolls.schema).reduceLeft(_ ++ _)
   @deprecated("Use .schema instead of .ddl", "3.0")
   def ddl = schema
 
@@ -109,38 +109,6 @@ trait Tables {
   }
   /** Collection-like TableQuery object for table AccountsCheckpoint */
   lazy val AccountsCheckpoint = new TableQuery(tag => new AccountsCheckpoint(tag))
-
-  /** Entity class storing rows of table Bakers
-   *  @param pkh Database column pkh SqlType(varchar)
-   *  @param rolls Database column rolls SqlType(int4)
-   *  @param blockId Database column block_id SqlType(varchar)
-   *  @param blockLevel Database column block_level SqlType(int4) */
-  case class BakersRow(pkh: String, rolls: Int, blockId: String, blockLevel: Int)
-  /** GetResult implicit for fetching BakersRow objects using plain SQL queries */
-  implicit def GetResultBakersRow(implicit e0: GR[String], e1: GR[Int]): GR[BakersRow] = GR{
-    prs => import prs._
-    BakersRow.tupled((<<[String], <<[Int], <<[String], <<[Int]))
-  }
-  /** Table description of table bakers. Objects of this class serve as prototypes for rows in queries. */
-  class Bakers(_tableTag: Tag) extends profile.api.Table[BakersRow](_tableTag, "bakers") {
-    def * = (pkh, rolls, blockId, blockLevel) <> (BakersRow.tupled, BakersRow.unapply)
-    /** Maps whole row to an option. Useful for outer joins. */
-    def ? = ((Rep.Some(pkh), Rep.Some(rolls), Rep.Some(blockId), Rep.Some(blockLevel))).shaped.<>({r=>import r._; _1.map(_=> BakersRow.tupled((_1.get, _2.get, _3.get, _4.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
-
-    /** Database column pkh SqlType(varchar) */
-    val pkh: Rep[String] = column[String]("pkh")
-    /** Database column rolls SqlType(int4) */
-    val rolls: Rep[Int] = column[Int]("rolls")
-    /** Database column block_id SqlType(varchar) */
-    val blockId: Rep[String] = column[String]("block_id")
-    /** Database column block_level SqlType(int4) */
-    val blockLevel: Rep[Int] = column[Int]("block_level")
-
-    /** Foreign key referencing Blocks (database name baker_block_id_fkey) */
-    lazy val blocksFk = foreignKey("baker_block_id_fkey", blockId, Blocks)(r => r.hash, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
-  }
-  /** Collection-like TableQuery object for table Bakers */
-  lazy val Bakers = new TableQuery(tag => new Bakers(tag))
 
   /** Entity class storing rows of table BalanceUpdates
    *  @param id Database column id SqlType(serial), AutoInc, PrimaryKey
@@ -673,4 +641,36 @@ trait Tables {
   }
   /** Collection-like TableQuery object for table Proposals */
   lazy val Proposals = new TableQuery(tag => new Proposals(tag))
+
+  /** Entity class storing rows of table Rolls
+   *  @param pkh Database column pkh SqlType(varchar)
+   *  @param rolls Database column rolls SqlType(int4)
+   *  @param blockId Database column block_id SqlType(varchar)
+   *  @param blockLevel Database column block_level SqlType(int4) */
+  case class RollsRow(pkh: String, rolls: Int, blockId: String, blockLevel: Int)
+  /** GetResult implicit for fetching RollsRow objects using plain SQL queries */
+  implicit def GetResultRollsRow(implicit e0: GR[String], e1: GR[Int]): GR[RollsRow] = GR{
+    prs => import prs._
+    RollsRow.tupled((<<[String], <<[Int], <<[String], <<[Int]))
+  }
+  /** Table description of table rolls. Objects of this class serve as prototypes for rows in queries. */
+  class Rolls(_tableTag: Tag) extends profile.api.Table[RollsRow](_tableTag, "rolls") {
+    def * = (pkh, rolls, blockId, blockLevel) <> (RollsRow.tupled, RollsRow.unapply)
+    /** Maps whole row to an option. Useful for outer joins. */
+    def ? = ((Rep.Some(pkh), Rep.Some(rolls), Rep.Some(blockId), Rep.Some(blockLevel))).shaped.<>({r=>import r._; _1.map(_=> RollsRow.tupled((_1.get, _2.get, _3.get, _4.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+
+    /** Database column pkh SqlType(varchar) */
+    val pkh: Rep[String] = column[String]("pkh")
+    /** Database column rolls SqlType(int4) */
+    val rolls: Rep[Int] = column[Int]("rolls")
+    /** Database column block_id SqlType(varchar) */
+    val blockId: Rep[String] = column[String]("block_id")
+    /** Database column block_level SqlType(int4) */
+    val blockLevel: Rep[Int] = column[Int]("block_level")
+
+    /** Foreign key referencing Blocks (database name rolls_block_id_fkey) */
+    lazy val blocksFk = foreignKey("rolls_block_id_fkey", blockId, Blocks)(r => r.hash, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
+  }
+  /** Collection-like TableQuery object for table Rolls */
+  lazy val Rolls = new TableQuery(tag => new Rolls(tag))
 }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
@@ -382,12 +382,12 @@ trait Tables {
    *  @param delegatedBalance Database column delegated_balance SqlType(numeric), Default(None)
    *  @param deactivated Database column deactivated SqlType(bool)
    *  @param gracePeriod Database column grace_period SqlType(int4)
-   *  @param blockLevel Database column block_level SqlType(numeric), Default(-1) */
-  case class DelegatesRow(pkh: String, blockId: String, balance: Option[scala.math.BigDecimal] = None, frozenBalance: Option[scala.math.BigDecimal] = None, stakingBalance: Option[scala.math.BigDecimal] = None, delegatedBalance: Option[scala.math.BigDecimal] = None, deactivated: Boolean, gracePeriod: Int, blockLevel: scala.math.BigDecimal = scala.math.BigDecimal("-1"))
+   *  @param blockLevel Database column block_level SqlType(int4), Default(-1) */
+  case class DelegatesRow(pkh: String, blockId: String, balance: Option[scala.math.BigDecimal] = None, frozenBalance: Option[scala.math.BigDecimal] = None, stakingBalance: Option[scala.math.BigDecimal] = None, delegatedBalance: Option[scala.math.BigDecimal] = None, deactivated: Boolean, gracePeriod: Int, blockLevel: Int = -1)
   /** GetResult implicit for fetching DelegatesRow objects using plain SQL queries */
-  implicit def GetResultDelegatesRow(implicit e0: GR[String], e1: GR[Option[scala.math.BigDecimal]], e2: GR[Boolean], e3: GR[Int], e4: GR[scala.math.BigDecimal]): GR[DelegatesRow] = GR{
+  implicit def GetResultDelegatesRow(implicit e0: GR[String], e1: GR[Option[scala.math.BigDecimal]], e2: GR[Boolean], e3: GR[Int]): GR[DelegatesRow] = GR{
     prs => import prs._
-    DelegatesRow.tupled((<<[String], <<[String], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<[Boolean], <<[Int], <<[scala.math.BigDecimal]))
+    DelegatesRow.tupled((<<[String], <<[String], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<[Boolean], <<[Int], <<[Int]))
   }
   /** Table description of table delegates. Objects of this class serve as prototypes for rows in queries. */
   class Delegates(_tableTag: Tag) extends profile.api.Table[DelegatesRow](_tableTag, "delegates") {
@@ -411,8 +411,8 @@ trait Tables {
     val deactivated: Rep[Boolean] = column[Boolean]("deactivated")
     /** Database column grace_period SqlType(int4) */
     val gracePeriod: Rep[Int] = column[Int]("grace_period")
-    /** Database column block_level SqlType(numeric), Default(-1) */
-    val blockLevel: Rep[scala.math.BigDecimal] = column[scala.math.BigDecimal]("block_level", O.Default(scala.math.BigDecimal("-1")))
+    /** Database column block_level SqlType(int4), Default(-1) */
+    val blockLevel: Rep[Int] = column[Int]("block_level", O.Default(-1))
 
     /** Foreign key referencing Blocks (database name delegates_block_id_fkey) */
     lazy val blocksFk = foreignKey("delegates_block_id_fkey", blockId, Blocks)(r => r.hash, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
@@ -298,8 +298,8 @@ object TezosDatabaseOperations extends LazyLogging {
   }
 
   /** Writes bakers to the database */
-  def writeVotingBakers(bakers: List[Voting.BakerRolls], block: Block): DBIO[Option[Int]] = {
-    Tables.Bakers ++= (block, bakers).convertToA[List, Tables.BakersRow]
+  def writeVotingRolls(bakers: List[Voting.BakerRolls], block: Block): DBIO[Option[Int]] = {
+    Tables.Rolls ++= (block, bakers).convertToA[List, Tables.RollsRow]
   }
 
   /** Writes ballots to the database */

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosErrors.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosErrors.scala
@@ -9,4 +9,7 @@ trait TezosErrors {
   /** Something went wrong during handling of Accounts */
   case class AccountsProcessingFailed(message: String, cause: Throwable) extends java.lang.RuntimeException
 
+  /** Something went wrong during handling of Delegates */
+  case class DelegatesProcessingFailed(message: String, cause: Throwable) extends java.lang.RuntimeException
+
 }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -4,7 +4,6 @@ import monocle.Traversal
 import monocle.function.all._
 import monocle.macros.{GenLens, GenPrism}
 import monocle.std.option._
-import tech.cryptonomic.conseil.tezos.TezosTypes.Scripted.Contracts
 
 /**
   * Classes used for deserializing Tezos node RPC results.
@@ -22,12 +21,12 @@ object TezosTypes {
     private val script = GenLens[Origination](_.script)
     private val parameters = GenLens[Transaction](_.parameters)
 
-    private val storage = GenLens[Contracts](_.storage)
-    private val code = GenLens[Contracts](_.code)
+    private val storage = GenLens[Scripted.Contracts](_.storage)
+    private val code = GenLens[Scripted.Contracts](_.code)
 
     private val expression = GenLens[Micheline](_.expression)
 
-    private val scriptLens: Traversal[Block, Contracts] =
+    private val scriptLens: Traversal[Block, Scripted.Contracts] =
       operationGroups composeTraversal each composeLens
         operations composeTraversal each composePrism
         origination composeLens
@@ -347,10 +346,13 @@ object TezosTypes {
     balance: scala.math.BigDecimal,
     spendable: Boolean,
     delegate: AccountDelegate,
-    script: Option[Contracts],
+    script: Option[Scripted.Contracts],
     counter: Int
   )
 
+  /** Keeps track of association between some domain type and a block reference
+    * Synthetic class, no domain correspondence, it's used to simplify signatures
+    */
   final case class BlockTagged[T](
     blockHash: BlockHash,
     blockLevel: Int,

--- a/src/main/scala/tech/cryptonomic/conseil/util/Conversion.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/util/Conversion.scala
@@ -1,6 +1,7 @@
 package tech.cryptonomic.conseil.util
 
 import scala.annotation.implicitNotFound
+import cats.Id
 
 /**
   * A type class that enables to convert an object to another
@@ -17,12 +18,6 @@ trait Conversion[F[_], FROM, TO] {
 
 /** type class companion */
 object Conversion {
-
-  /** This alias allows to return converted objects with no actual wrapping effect
-    * This is a type constructor that corresponds to his type parameter, while
-    * conforming to the required "shape" `F[_]` for the conversion to be defined.
-    */
-  type Id[T] = T
 
   /** Implicitly summons a `Conversion` instance for the given types,
     * if available in scope.
@@ -42,7 +37,7 @@ object Conversion {
         conv.convert(from)
 
       /** converts the object to a `TO` instance, with no effect wrapping the result */
-      def convertTo[TO](implicit conv: Conversion[Conversion.Id, FROM, TO]): TO =
+      def convertTo[TO](implicit conv: Conversion[Id, FROM, TO]): TO =
         conv.convert(from)
     }
 

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DatabaseConversionsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DatabaseConversionsTest.scala
@@ -878,15 +878,15 @@ class DatabaseConversionsTest
     "convert a Voting Baker to a database row" in {
       import tech.cryptonomic.conseil.tezos.TezosTypes.Voting.BakerRolls
 
-      val sampleBakers = BakerRolls(pkh = PublicKeyHash("key"), rolls = 500)
+      val sampleRolls = BakerRolls(pkh = PublicKeyHash("key"), rolls = 500)
 
-      val converted = (block, List(sampleBakers)).convertToA[List, Tables.BakersRow]
+      val converted = (block, List(sampleRolls)).convertToA[List, Tables.RollsRow]
       converted should have size 1
 
       converted should contain only (
-        Tables.BakersRow(
-          pkh = sampleBakers.pkh.value,
-          rolls = sampleBakers.rolls,
+        Tables.RollsRow(
+          pkh = sampleRolls.pkh.value,
+          rolls = sampleRolls.rolls,
           blockId = block.data.hash.value,
           blockLevel = block.data.header.level)
       )

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/InMemoryDatabase.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/InMemoryDatabase.scala
@@ -56,6 +56,8 @@ trait InMemoryDatabase extends BeforeAndAfterAll with BeforeAndAfterEach {
     Tables.Operations,
     Tables.BalanceUpdates,
     Tables.Accounts,
+    Tables.Delegates,
+    Tables.DelegatedContracts,
     Tables.Fees,
     Tables.AccountsCheckpoint,
     Tables.DelegatesCheckpoint,

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/InMemoryDatabase.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/InMemoryDatabase.scala
@@ -63,7 +63,7 @@ trait InMemoryDatabase extends BeforeAndAfterAll with BeforeAndAfterEach {
     Tables.DelegatesCheckpoint,
     Tables.Proposals,
     Tables.Ballots,
-    Tables.Bakers
+    Tables.Rolls
   )
 
   protected val dbSchema =

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
@@ -594,7 +594,7 @@ class TezosDatabaseOperationsTest
           Tables.Delegates += delegate
         )
 
-      dbHandler.run(populate)
+      dbHandler.run(populate).isReadyWithin(5 seconds) shouldBe true
 
       //prepare new delegates
       val changes = 2

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
@@ -1053,7 +1053,7 @@ class TezosDatabaseOperationsTest
 
     }
 
-    "write voting bakers" in {
+    "write voting bakers rolls" in {
       import DatabaseConversions._
       import tech.cryptonomic.conseil.util.Conversion.Syntax._
 
@@ -1061,29 +1061,29 @@ class TezosDatabaseOperationsTest
       implicit val randomSeed = RandomSeed(testReferenceTimestamp.getTime)
 
       val block = generateSingleBlock(atLevel = 1, atTime = testReferenceDateTime)
-      val bakers = Voting.generateBakers(howMany = 3)
+      val rolls = Voting.generateBakersRolls(howMany = 3)
 
       //write
       val writeAndGetRows = for {
         _ <- Tables.Blocks += block.convertTo[Tables.BlocksRow]
-        written <- sut.writeVotingBakers(bakers, block)
-        rows <- Tables.Bakers.result
+        written <- sut.writeVotingRolls(rolls, block)
+        rows <- Tables.Rolls.result
       } yield (written, rows)
 
-      val (stored, dbBakers) = dbHandler.run(writeAndGetRows.transactionally).futureValue
+      val (stored, dbRolls) = dbHandler.run(writeAndGetRows.transactionally).futureValue
 
       //expectations
-      stored.value shouldEqual bakers.size
-      dbBakers should have size bakers.size
+      stored.value shouldEqual rolls.size
+      dbRolls should have size rolls.size
 
       import org.scalatest.Inspectors._
 
-      forAll(dbBakers) {
-        bakerRow =>
-          val generated = bakers.find(_.pkh.value == bakerRow.pkh).value
-          bakerRow.rolls shouldEqual generated.rolls
-          bakerRow.blockId shouldBe block.data.hash.value
-          bakerRow.blockLevel shouldBe block.data.header.level
+      forAll(dbRolls) {
+        rollsRow =>
+          val generated = rolls.find(_.pkh.value == rollsRow.pkh).value
+          rollsRow.rolls shouldEqual generated.rolls
+          rollsRow.blockId shouldBe block.data.hash.value
+          rollsRow.blockLevel shouldBe block.data.header.level
       }
 
     }

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
@@ -560,16 +560,7 @@ class TezosDatabaseOperationsTest
       forAll(dbContracts zip delegatedAccounts) {
         case (contract, account) =>
           contract.accountId shouldEqual account.accountId
-          contract.balance shouldEqual account.balance
-          contract.blockId shouldEqual account.blockId
-          contract.blockLevel shouldEqual account.blockLevel
-          contract.counter shouldEqual account.counter
-          contract.delegateSetable shouldEqual account.delegateSetable
           contract.delegateValue shouldEqual account.delegateValue
-          contract.manager shouldEqual account.manager
-          contract.script shouldEqual account.script
-          contract.spendable shouldEqual account.spendable
-          contract.storage shouldEqual account.storage
       }
 
     }

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
@@ -65,6 +65,23 @@ class TezosDatabaseOperationsTest
       }
     }
 
+    "tell if there are any stored blocks" in {
+      implicit val randomSeed = RandomSeed(testReferenceTimestamp.getTime)
+
+      //generate data
+      val blocks = generateBlockRows(toLevel = 5, testReferenceTimestamp)
+
+      //check initial condition
+      dbHandler.run(sut.doBlocksExist()).futureValue shouldBe false
+
+      //store some blocks
+      dbHandler.run(Tables.Blocks ++= blocks).futureValue shouldBe Some(blocks.size)
+
+      //check final condition
+      dbHandler.run(sut.doBlocksExist()).futureValue shouldBe true
+
+    }
+
     "write blocks" in {
       implicit val randomSeed = RandomSeed(testReferenceTimestamp.getTime)
 
@@ -408,7 +425,7 @@ class TezosDatabaseOperationsTest
 
     }
 
-    "clean the checkpoints with no selection" in {
+    "clean the accounts checkpoints with no selection" in {
       implicit val randomSeed = RandomSeed(testReferenceTimestamp.getTime)
 
       //generate data
@@ -445,7 +462,7 @@ class TezosDatabaseOperationsTest
         survivors shouldBe empty
       }
 
-      "clean the checkpoints with a partial id selection" in {
+      "clean the accounts checkpoints with a partial id selection" in {
       implicit val randomSeed = RandomSeed(testReferenceTimestamp.getTime)
 
       //generate data
@@ -485,6 +502,281 @@ class TezosDatabaseOperationsTest
       val (initialCount, deletes, survivors) = dbHandler.run(populateAndTest.transactionally).futureValue
       initialCount.value shouldBe checkpointRows.size
       deletes shouldEqual checkpointRows.filter(row => inSelection(row.accountId)).size
+      survivors should contain theSameElementsAs expected
+
+    }
+
+    "write delegates for a single block" in {
+      implicit val randomSeed = RandomSeed(testReferenceTimestamp.getTime)
+
+      val expectedCount = 3
+
+      val block = generateBlockRows(1, testReferenceTimestamp).head
+      val delegatedAccounts = generateAccountRows(howMany = expectedCount, block)
+      val delegatesInfo = generateDelegates(delegatedHashes = delegatedAccounts.map(_.accountId), BlockHash(block.hash), block.level)
+
+      val writeAndGetRows = for {
+        _ <- Tables.Blocks += block
+        _ <- Tables.Accounts ++= delegatedAccounts
+        written <- sut.writeDelegatesAndCopyContracts(List(delegatesInfo))
+        delegatesRows <- Tables.Delegates.result
+        contractsRows <- Tables.DelegatedContracts.result
+      } yield (written, delegatesRows, contractsRows)
+
+      val (stored, dbDelegates, dbContracts) = dbHandler.run(writeAndGetRows.transactionally).futureValue
+
+      stored shouldBe expectedCount
+
+      dbDelegates should have size expectedCount
+      dbContracts should have size expectedCount
+
+      import org.scalatest.Inspectors._
+
+      forAll(dbDelegates zip delegatesInfo.content) {
+        case (row, (pkh, delegate)) =>
+          row.pkh shouldEqual pkh.value
+          row.balance shouldEqual (delegate.balance match {
+            case PositiveDecimal(value) => Some(value)
+            case _ => None
+          })
+          row.delegatedBalance shouldEqual (delegate.delegated_balance match{
+            case PositiveDecimal(value) => Some(value)
+            case _ => None
+          })
+          row.frozenBalance shouldEqual (delegate.frozen_balance match{
+            case PositiveDecimal(value) => Some(value)
+            case _ => None
+          })
+          row.stakingBalance shouldEqual (delegate.staking_balance match{
+            case PositiveDecimal(value) => Some(value)
+            case _ => None
+          })
+          row.gracePeriod shouldEqual delegate.grace_period
+          row.deactivated shouldBe delegate.deactivated
+          row.blockId shouldEqual block.hash
+          row.blockLevel shouldEqual block.level
+      }
+
+      forAll(dbContracts zip delegatedAccounts) {
+        case (contract, account) =>
+          contract.accountId shouldEqual account.accountId
+          contract.balance shouldEqual account.balance
+          contract.blockId shouldEqual account.blockId
+          contract.blockLevel shouldEqual account.blockLevel
+          contract.counter shouldEqual account.counter
+          contract.delegateSetable shouldEqual account.delegateSetable
+          contract.delegateValue shouldEqual account.delegateValue
+          contract.manager shouldEqual account.manager
+          contract.script shouldEqual account.script
+          contract.spendable shouldEqual account.spendable
+          contract.storage shouldEqual account.storage
+      }
+
+    }
+
+    "fail to write delegates if the reference block is not stored" in {
+      implicit val randomSeed = RandomSeed(testReferenceTimestamp.getTime)
+
+      val block = generateBlockRows(1, testReferenceTimestamp).head
+      val delegatedAccounts = generateAccountRows(howMany = 1, block)
+      val delegatesInfo = generateDelegates(delegatedHashes = delegatedAccounts.map(_.accountId), blockHash = BlockHash("no-block-hash"), blockLevel = 1)
+
+      val resultFuture = dbHandler.run(sut.writeDelegatesAndCopyContracts(List(delegatesInfo)))
+
+      whenReady(resultFuture.failed) {
+          _ shouldBe a [java.sql.SQLException]
+      }
+    }
+
+    "update delegates if they exists already" in {
+      implicit val randomSeed = RandomSeed(testReferenceTimestamp.getTime)
+
+      //generate data
+      val blocks @ (second :: first :: genesis :: Nil) = generateBlockRows(toLevel = 2, startAt = testReferenceTimestamp)
+      val account = generateAccountRows(1, first).head
+      val delegate = generateDelegateRows(1, first).head
+
+      val populate =
+        DBIO.seq(
+          Tables.Blocks ++= blocks,
+          Tables.Accounts += account,
+          Tables.Delegates += delegate
+        )
+
+      dbHandler.run(populate)
+
+      //prepare new delegates
+      val changes = 2
+      val (hashUpdate, levelUpdate) = (second.hash, second.level)
+      val delegatedKeys = generateAccounts(howMany = changes, BlockHash(hashUpdate), levelUpdate).content.keySet.map(_.id)
+      val delegatesInfo = generateDelegates(delegatedHashes = delegatedKeys.toList, blockHash = BlockHash(hashUpdate), blockLevel = levelUpdate)
+
+      //rewrite one of the keys to make it update the previously stored delegate row
+      val delegateMap = delegatesInfo.content
+      val pkh = delegateMap.keySet.head
+      val updatedMap = (delegateMap - pkh) + (PublicKeyHash(delegate.pkh) -> delegateMap(pkh))
+      val updatedDelegates = delegatesInfo.copy(content = updatedMap)
+
+      //do the updates
+      val writeUpdatedAndGetRows = for {
+        written <- sut.writeDelegatesAndCopyContracts(List(updatedDelegates))
+        rows <- Tables.Delegates.result
+      } yield (written, rows)
+
+      val (updates, dbDelegates) = dbHandler.run(writeUpdatedAndGetRows.transactionally).futureValue
+
+      //number of db changes
+      updates shouldBe changes
+
+      //total number of rows on db (1 update and 1 insert expected)
+      dbDelegates should have size changes
+
+      import org.scalatest.Inspectors._
+
+      //both rows on db should refer to updated data
+      forAll(dbDelegates zip updatedDelegates.content) {
+        case (row, (pkh, delegate)) =>
+          row.pkh shouldEqual pkh.value
+          row.balance shouldEqual (delegate.balance match {
+            case PositiveDecimal(value) => Some(value)
+            case _ => None
+          })
+          row.delegatedBalance shouldEqual (delegate.delegated_balance match{
+            case PositiveDecimal(value) => Some(value)
+            case _ => None
+          })
+          row.frozenBalance shouldEqual (delegate.frozen_balance match{
+            case PositiveDecimal(value) => Some(value)
+            case _ => None
+          })
+          row.stakingBalance shouldEqual (delegate.staking_balance match{
+            case PositiveDecimal(value) => Some(value)
+            case _ => None
+          })
+          row.gracePeriod shouldEqual delegate.grace_period
+          row.deactivated shouldBe delegate.deactivated
+          row.blockId should (equal(first.hash) or equal(second.hash))
+          row.blockLevel should (equal(first.level) or equal(second.level))
+      }
+
+    }
+
+    "store checkpoint delegate key hashes with block reference" in {
+      implicit val randomSeed = RandomSeed(testReferenceTimestamp.getTime)
+      //custom hash generator with predictable seed
+      val generateHash: Int => String = alphaNumericGenerator(new Random(randomSeed.seed))
+
+      val maxLevel = 1
+      val pkPerBlock = 3
+      val expectedCount = (maxLevel + 1) * pkPerBlock
+
+      //generate data
+      val blocks = generateBlockRows(toLevel = maxLevel, testReferenceTimestamp)
+      val keys = blocks.map(block => (BlockHash(block.hash), block.level, List.fill(pkPerBlock)(PublicKeyHash(generateHash(5)))))
+
+      //store and write
+      val populateAndFetch = for {
+        _ <- Tables.Blocks ++= blocks
+        written <- sut.writeDelegatesCheckpoint(keys)
+        rows <- Tables.DelegatesCheckpoint.result
+      } yield (written, rows)
+
+      val (stored, checkpointRows) = dbHandler.run(populateAndFetch).futureValue
+
+      //number of changes
+      stored.value shouldBe expectedCount
+      checkpointRows should have size expectedCount
+
+      import org.scalatest.Inspectors._
+
+      val flattenedKeysData = keys.flatMap{ case (hash, level, keys) => keys.map((hash, level, _))}
+
+      forAll(checkpointRows.zip(flattenedKeysData)) {
+        case (row, (hash, level, keyHash)) =>
+          row.blockId shouldEqual hash.value
+          row.blockLevel shouldBe level
+          row.delegatePkh shouldEqual keyHash.value
+      }
+
+    }
+
+    "clean the delegates checkpoints with no selection" in {
+      implicit val randomSeed = RandomSeed(testReferenceTimestamp.getTime)
+
+      //generate data
+      val blocks = generateBlockRows(toLevel = 5, testReferenceTimestamp)
+
+      //store required blocks for FK
+      dbHandler.run(Tables.Blocks ++= blocks).futureValue shouldBe Some(blocks.size)
+
+      val delegateKeyHashes = Array("pkh0", "pkh1", "pkh2", "pkh3", "pkh4", "pkh5", "pkh6")
+      val blockIds = blocks.map(_.hash)
+
+      //create test data:
+      val checkpointRows = Array(
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(1), blockIds(1), blockLevel = 1),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(2), blockIds(1), blockLevel = 1),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(3), blockIds(1), blockLevel = 1),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(4), blockIds(2), blockLevel = 2),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(5), blockIds(2), blockLevel = 2),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(2), blockIds(3), blockLevel = 3),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(3), blockIds(4), blockLevel = 4),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(5), blockIds(4), blockLevel = 4),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(6), blockIds(5), blockLevel = 5)
+        )
+
+        val populateAndTest = for {
+          stored <- Tables.DelegatesCheckpoint ++= checkpointRows
+          cleaned <- sut.cleanDelegatesCheckpoint()
+          rows <- Tables.DelegatesCheckpoint.result
+        } yield (stored, cleaned, rows)
+
+        val (initialCount, deletes, survivors) = dbHandler.run(populateAndTest.transactionally).futureValue
+        initialCount.value shouldBe checkpointRows.size
+        deletes shouldBe checkpointRows.size
+        survivors shouldBe empty
+      }
+
+      "clean the delegates checkpoints with a partial key hash selection" in {
+      implicit val randomSeed = RandomSeed(testReferenceTimestamp.getTime)
+
+      //generate data
+      val blocks = generateBlockRows(toLevel = 5, testReferenceTimestamp)
+
+      //store required blocks for FK
+      dbHandler.run(Tables.Blocks ++= blocks).futureValue shouldBe Some(blocks.size)
+
+      val delegateKeyHashes = Array("pkh0", "pkh1", "pkh2", "pkh3", "pkh4", "pkh5", "pkh6")
+      val blockIds = blocks.map(_.hash)
+
+      //create test data:
+      val checkpointRows = Array(
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(1), blockIds(1), blockLevel = 1),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(2), blockIds(1), blockLevel = 1),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(3), blockIds(1), blockLevel = 1),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(4), blockIds(2), blockLevel = 2),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(5), blockIds(2), blockLevel = 2),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(2), blockIds(3), blockLevel = 3),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(3), blockIds(4), blockLevel = 4),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(5), blockIds(4), blockLevel = 4),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(6), blockIds(5), blockLevel = 5)
+      )
+
+      val inSelection = Set(delegateKeyHashes(1), delegateKeyHashes(2), delegateKeyHashes(3), delegateKeyHashes(4))
+
+      val selection = inSelection.map(PublicKeyHash)
+
+      val expected = checkpointRows.filterNot(row => inSelection(row.delegatePkh))
+
+      val populateAndTest = for {
+        stored <- Tables.DelegatesCheckpoint ++= checkpointRows
+        cleaned <- sut.cleanDelegatesCheckpoint(Some(selection))
+        rows <- Tables.DelegatesCheckpoint.result
+      } yield (stored, cleaned, rows)
+
+      val (initialCount, deletes, survivors) = dbHandler.run(populateAndTest.transactionally).futureValue
+      initialCount.value shouldBe checkpointRows.size
+      deletes shouldEqual checkpointRows.filter(row => inSelection(row.delegatePkh)).size
       survivors should contain theSameElementsAs expected
 
     }
@@ -539,45 +831,55 @@ class TezosDatabaseOperationsTest
 
     }
 
-    "store checkpoint delegate key hashes with block reference" in {
+    "read latest delegate key hashes from checkpoint" in {
       implicit val randomSeed = RandomSeed(testReferenceTimestamp.getTime)
-      //custom hash generator with predictable seed
-      val generateHash: Int => String = alphaNumericGenerator(new Random(randomSeed.seed))
-
-      val maxLevel = 1
-      val pkPerBlock = 3
-      val expectedCount = (maxLevel + 1) * pkPerBlock
 
       //generate data
-      val blocks = generateBlockRows(toLevel = maxLevel, testReferenceTimestamp)
-      val keys = blocks.map(block => (BlockHash(block.hash), block.level, List.fill(pkPerBlock)(PublicKeyHash(generateHash(5)))))
+      val blocks = generateBlockRows(toLevel = 5, testReferenceTimestamp)
 
-      //store and write
+      //store required blocks for FK
+      dbHandler.run(Tables.Blocks ++= blocks).futureValue shouldBe Some(blocks.size)
+      val delegateKeyHashes = Array("pkh0", "pkh1", "pkh2", "pkh3", "pkh4", "pkh5", "pkh6")
+      val blockIds = blocks.map(_.hash)
+
+      //create test data:
+      val checkpointRows = Array(
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(1), blockIds(1), blockLevel = 1),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(2), blockIds(1), blockLevel = 1),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(3), blockIds(1), blockLevel = 1),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(4), blockIds(2), blockLevel = 2),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(5), blockIds(2), blockLevel = 2),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(2), blockIds(3), blockLevel = 3),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(3), blockIds(4), blockLevel = 4),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(5), blockIds(4), blockLevel = 4),
+        Tables.DelegatesCheckpointRow(delegateKeyHashes(6), blockIds(5), blockLevel = 5)
+      )
+
+      def entry(delegateAtIndex: Int, atLevel: Int) =
+        PublicKeyHash(delegateKeyHashes(delegateAtIndex)) -> (BlockHash(blockIds(atLevel)), atLevel)
+
+        //expecting only the following to remain
+      val expected =
+        Map(
+          entry(delegateAtIndex = 1, atLevel = 1),
+          entry(delegateAtIndex = 2, atLevel = 3),
+          entry(delegateAtIndex = 3, atLevel = 4),
+          entry(delegateAtIndex = 4, atLevel = 2),
+          entry(delegateAtIndex = 5, atLevel = 4),
+          entry(delegateAtIndex = 6, atLevel = 5)
+      )
+
       val populateAndFetch = for {
-        _ <- Tables.Blocks ++= blocks
-        written <- sut.writeDelegatesCheckpoint(keys)
-        rows <- Tables.DelegatesCheckpoint.result
-      } yield (written, rows)
+        stored <- Tables.DelegatesCheckpoint ++= checkpointRows
+        rows <- sut.getLatestDelegatesFromCheckpoint
+      } yield (stored, rows)
 
-      val (stored, checkpointRows) = dbHandler.run(populateAndFetch).futureValue
+      val (initialCount, latest) = dbHandler.run(populateAndFetch.transactionally).futureValue
+      initialCount.value shouldBe checkpointRows.size
 
-      //number of changes
-      stored.value shouldBe expectedCount
-      checkpointRows should have size expectedCount
-
-      import org.scalatest.Inspectors._
-
-      val flattenedKeysData = keys.flatMap{ case (hash, level, keys) => keys.map((hash, level, _))}
-
-      forAll(checkpointRows.zip(flattenedKeysData)) {
-        case (row, (hash, level, keyHash)) =>
-          row.blockId shouldEqual hash.value
-          row.blockLevel shouldBe level
-          row.delegatePkh shouldEqual keyHash.value
-      }
+      latest.toSeq should contain theSameElementsAs expected.toSeq
 
     }
-
 
     "fetch nothing if looking up a non-existent operation group by hash" in {
       dbHandler.run(sut.operationsForGroup("no-group-here")).futureValue shouldBe None

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
@@ -370,7 +370,7 @@ trait TezosDataGeneration extends RandomGenerationKit {
 
     }
 
-    def generateBakers(howMany: Int)(implicit randomSeed: RandomSeed) = {
+    def generateBakersRolls(howMany: Int)(implicit randomSeed: RandomSeed) = {
       require(howMany > 0, "the test can only generate a positive number of bakers, you asked for a non positive value")
 
       //custom hash generator with predictable seed

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
@@ -5,12 +5,13 @@ import java.time.ZonedDateTime
 
 import scala.util.Random
 import tech.cryptonomic.conseil.util.{RandomGenerationKit, RandomSeed}
-import tech.cryptonomic.conseil.tezos.Tables.{AccountsRow, BlocksRow, OperationGroupsRow}
+import tech.cryptonomic.conseil.tezos.Tables.{AccountsRow, BlocksRow, DelegatesRow, OperationGroupsRow}
 import tech.cryptonomic.conseil.tezos.TezosTypes._
 import tech.cryptonomic.conseil.tezos.FeeOperations.AverageFees
 import tech.cryptonomic.conseil.tezos.TezosTypes.Scripted.Contracts
 
 trait TezosDataGeneration extends RandomGenerationKit {
+  import TezosTypes.Syntax._
 
   /* randomly populate a number of fees */
   def generateFees(howMany: Int, startAt: Timestamp)(implicit randomSeed: RandomSeed): List[AverageFees] = {
@@ -41,7 +42,7 @@ trait TezosDataGeneration extends RandomGenerationKit {
 
     val accounts = (1 to howMany).map {
       currentId =>
-        (AccountId(String valueOf currentId),
+        AccountId(String valueOf currentId) ->
           Account(
             manager = PublicKeyHash("manager"),
             balance = rnd.nextInt,
@@ -50,10 +51,36 @@ trait TezosDataGeneration extends RandomGenerationKit {
             script = Some(Contracts(Micheline("storage"), Micheline("script"))),
             counter = currentId
           )
-        )
     }.toMap
 
-    BlockTagged(blockHash, blockLevel, accounts)
+    accounts.taggedWithBlock(blockHash, blockLevel)
+  }
+
+  /* randomly generates a number of delegates with associated block data */
+  def generateDelegates(delegatedHashes: List[String], blockHash: BlockHash, blockLevel: Int)(implicit randomSeed: RandomSeed): BlockTagged[Map[PublicKeyHash, Delegate]] = {
+    require(delegatedHashes.nonEmpty, "the test can generates a positive number of delegates, you can't pass an empty list of account key hashes")
+
+    val rnd = new Random(randomSeed.seed)
+
+    //custom hash generator with predictable seed
+    val generateHash: Int => String = alphaNumericGenerator(rnd)
+
+    val delegates = delegatedHashes.zipWithIndex.map {
+      case (accountPkh, counter) =>
+        PublicKeyHash(generateHash(10)) ->
+          Delegate(
+            balance = PositiveDecimal(rnd.nextInt()),
+            frozen_balance = PositiveDecimal(rnd.nextInt()),
+            frozen_balance_by_cycle = List.empty,
+            staking_balance = PositiveDecimal(rnd.nextInt()),
+            delegated_contracts = List(ContractId(accountPkh)),
+            delegated_balance = PositiveDecimal(rnd.nextInt()),
+            deactivated = false,
+            grace_period = rnd.nextInt()
+          )
+    }.toMap
+
+    delegates.taggedWithBlock(blockHash, blockLevel)
   }
 
   /* randomly populate a number of blocks based on a level range */
@@ -293,6 +320,28 @@ trait TezosDataGeneration extends RandomGenerationKit {
           balance = 0
         )
     }.toList
+
+  }
+
+  /* randomly generates a number of delegate rows for some block */
+  def generateDelegateRows(howMany: Int, block: BlocksRow)(implicit randomSeed: RandomSeed): List[DelegatesRow] = {
+    require(howMany > 0, "the test can only generate a positive number of delegates, you asked for a non positive value")
+
+    //custom hash generator with predictable seed
+    val generateHash: Int => String = alphaNumericGenerator(new Random(randomSeed.seed))
+
+    List.fill(howMany) {
+      DelegatesRow(
+        blockId = block.hash,
+        pkh = generateHash(10),
+        balance = Some(0),
+        frozenBalance = Some(0),
+        stakingBalance = Some(0),
+        delegatedBalance = Some(0),
+        deactivated = true,
+        gracePeriod = 0
+      )
+    }
 
   }
 

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
@@ -201,6 +201,62 @@ class TezosPlatformDiscoveryOperationsTest
         )
     }
 
+    "return list of attributes of delegates" in {
+
+      sut.getTableAttributes("delegates").futureValue shouldBe
+        Some(
+          List(
+            Attribute("pkh", "Pkh", DataType.String, Some(0), KeyType.UniqueKey, "delegates"),
+            Attribute("block_id", "Block id", DataType.String, Some(0), KeyType.NonKey, "delegates"),
+            Attribute("balance", "Balance", DataType.Decimal, None, KeyType.NonKey, "delegates"),
+            Attribute("frozen_balance", "Frozen balance", DataType.Decimal, None, KeyType.NonKey, "delegates"),
+            Attribute("staking_balance", "Staking balance", DataType.Decimal, None, KeyType.NonKey, "delegates"),
+            Attribute("delegated_balance", "Delegated balance", DataType.Decimal, None, KeyType.NonKey, "delegates"),
+            Attribute("deactivated", "Deactivated", DataType.Boolean, Some(0), KeyType.NonKey, "delegates"),
+            Attribute("grace_period", "Grace period", DataType.Int, None, KeyType.NonKey, "delegates"),
+            Attribute("block_level", "Block level", DataType.Int, None, KeyType.NonKey, "delegates")
+          )
+        )
+    }
+
+    "return list of attributes of proposals" in {
+
+      sut.getTableAttributes("proposals").futureValue shouldBe
+        Some(
+          List(
+            Attribute("protocol_hash", "Protocol hash", DataType.String, Some(0), KeyType.UniqueKey, "proposals"),
+            Attribute("block_id", "Block id", DataType.String, Some(0), KeyType.NonKey, "proposals"),
+            Attribute("block_level", "Block level", DataType.Int, None, KeyType.NonKey, "proposals")
+          )
+        )
+    }
+
+    "return list of attributes of bakers" in {
+
+      sut.getTableAttributes("bakers").futureValue shouldBe
+        Some(
+          List(
+            Attribute("pkh", "Pkh", DataType.String, Some(0), KeyType.NonKey, "bakers"),
+            Attribute("rolls", "Rolls", DataType.Int, None, KeyType.NonKey, "bakers"),
+            Attribute("block_id", "Block id", DataType.String, Some(0), KeyType.NonKey, "bakers"),
+            Attribute("block_level", "Block level", DataType.Int, None, KeyType.NonKey, "bakers")
+          )
+        )
+    }
+
+    "return list of attributes of ballots" in {
+
+      sut.getTableAttributes("ballots").futureValue shouldBe
+        Some(
+          List(
+            Attribute("pkh", "Pkh", DataType.String, Some(0), KeyType.NonKey, "ballots"),
+            Attribute("ballot", "Ballot", DataType.String, Some(0), KeyType.NonKey, "ballots"),
+            Attribute("block_id", "Block id", DataType.String, Some(0), KeyType.NonKey, "ballots"),
+            Attribute("block_level", "Block level", DataType.Int, None, KeyType.NonKey, "ballots")
+          )
+        )
+    }
+
     "return empty list for non existing table" in {
       sut.getTableAttributes("nonExisting").futureValue shouldBe None
     }

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
@@ -47,6 +47,7 @@ class TezosPlatformDiscoveryOperationsTest
   override def beforeAll(): Unit = {
     super.beforeAll()
     sut.init()
+    ()
   }
 
   "getNetworks" should {
@@ -231,15 +232,15 @@ class TezosPlatformDiscoveryOperationsTest
         )
     }
 
-    "return list of attributes of bakers" in {
+    "return list of attributes of rolls" in {
 
-      sut.getTableAttributes("bakers").futureValue shouldBe
+      sut.getTableAttributes("rolls").futureValue shouldBe
         Some(
           List(
-            Attribute("pkh", "Pkh", DataType.String, Some(0), KeyType.NonKey, "bakers"),
-            Attribute("rolls", "Rolls", DataType.Int, None, KeyType.NonKey, "bakers"),
-            Attribute("block_id", "Block id", DataType.String, Some(0), KeyType.NonKey, "bakers"),
-            Attribute("block_level", "Block level", DataType.Int, None, KeyType.NonKey, "bakers")
+            Attribute("pkh", "Pkh", DataType.String, Some(0), KeyType.NonKey, "rolls"),
+            Attribute("rolls", "Rolls", DataType.Int, None, KeyType.NonKey, "rolls"),
+            Attribute("block_id", "Block id", DataType.String, Some(0), KeyType.NonKey, "rolls"),
+            Attribute("block_level", "Block level", DataType.Int, None, KeyType.NonKey, "rolls")
           )
         )
     }


### PR DESCRIPTION
closes #357 
At each cycle the delegates pkh from a block operations' are saved in a checkpoint table, transactionally.
Right after that we now read the key hashes and fetch complete delegates data and store that on a table, with the addition of copying any account data for the delegated contracts to a separate table.

The delegated_contracts data is a duplicate of the more general accounts.

## Required changes to DB schema
We need to setup 2 new tables with associated indexes and FKs

```sql
CREATE TABLE public.delegates (
    pkh character varying PRIMARY KEY,
    block_id character varying NOT NULL,
    balance numeric,
    frozen_balance numeric,
    staking_balance numeric,
    delegated_balance numeric,
    deactivated boolean NOT NULL,
    grace_period integer NOT NULL,
    block_level integer DEFAULT '-1'::integer NOT NULL
);

CREATE TABLE public.delegated_contracts (
    account_id character varying NOT NULL,
    delegate_value character varying
);

ALTER TABLE ONLY public.delegated_contracts
    ADD CONSTRAINT contracts_delegate_pkh_fkey FOREIGN KEY (delegate_value) REFERENCES public.delegates(pkh);

ALTER TABLE ONLY public.delegated_contracts
    ADD CONSTRAINT contracts_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.accounts(account_id);

ALTER TABLE ONLY public.delegates
    ADD CONSTRAINT delegates_block_id_fkey FOREIGN KEY (block_id) REFERENCES public.blocks(hash);

ALTER TABLE IF EXISTS bakers
    RENAME TO rolls;
-- we won't rename the FK constraint
```