### PR TITLE
354 - additional supplementary metadata

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -176,10 +176,11 @@ metadata-overrides {
                 display-name: "Address"
                 placeholder: "tz1..."
                 visible: true
-                data-type: "hash"
+                data-type: "AccountAddress"
               }
               block_id {
                 display-name: "Block Hash"
+                data-type: "Hash"
                 visible: true
                 reference: {
                   entity: "blocks"
@@ -188,7 +189,7 @@ metadata-overrides {
               }
               manager {
                 visible: true
-                data-type: "hash"
+                data-type: "AccountAddress"
                 reference: {
                   entity: "accounts"
                   key: "account_id"
@@ -204,7 +205,7 @@ metadata-overrides {
               delegate_value {
                 display-name: "Delegate"
                 visible: true
-                data-type: "hash"
+                data-type: "AccountAddress"
                 reference: {
                   entity: "accounts"
                   key: "account_id"
@@ -239,7 +240,7 @@ metadata-overrides {
               pkh {
                 display-name: "Address"
                 visible: true
-                data-type: "hash"
+                data-type: "AccountAddress"
                 reference: {
                   entity: "accounts"
                   key: "account_id"
@@ -250,6 +251,7 @@ metadata-overrides {
               }
               block_id {
                 display-name: "Block Hash"
+                data-type: "Hash"
                 visible: true
                 reference: {
                   entity: "blocks"
@@ -308,7 +310,7 @@ metadata-overrides {
               pkh {
                 display-name: "Address"
                 visible: true
-                data-type: "hash"
+                data-type: "AccountAddress"
                 reference: {
                   entity: "acccounts"
                   key: "account_id"
@@ -325,6 +327,7 @@ metadata-overrides {
               }
               block_id {
                 display-name: "Block Hash"
+                data-type: "Hash"
                 visible: true
                 reference: {
                   entity: "blocks"
@@ -351,6 +354,7 @@ metadata-overrides {
               }
               predecessor {
                 display-name: "Predecessor Hash"
+                data-type: "Hash"
                 visible: true
                 reference: {
                   entity: "blocks"
@@ -385,6 +389,7 @@ metadata-overrides {
               }
               operations_hash {
                 visible: true
+                data-type: "Hash"
                 reference: {
                   entity: "operations"
                   key: "operation_group_hash"
@@ -401,7 +406,7 @@ metadata-overrides {
               }
               baker {
                 visible: true
-                data-type: "hash"
+                data-type: "AccountAddress"
                 reference: {
                   entity: "acccounts"
                   key: "account_id"
@@ -469,6 +474,7 @@ metadata-overrides {
               }
               hash {
                 visible: true
+                data-type: "Hash"
               }
               branch {
                 visible: true
@@ -478,6 +484,7 @@ metadata-overrides {
               }
               block_id {
                 display-name: "Block Hash"
+                data-type: "Hash"
                 visible: true
                 reference: {
                   entity: "blocks"
@@ -493,6 +500,7 @@ metadata-overrides {
                 visible: false
               }
               operation_group_hash: {
+                data-type: "Hash"
                 visible: true
               }
               kind: {
@@ -507,7 +515,7 @@ metadata-overrides {
               }
               delegate: {
                 visible: true
-                data-type: "hash"
+                data-type: "AccountAddress"
                 reference: {
                   entity: "acccounts"
                   key: "account_id"
@@ -527,7 +535,7 @@ metadata-overrides {
               }
               source: {
                 visible: true
-                data-type: "hash"
+                data-type: "AccountAddress"
                 reference {
                   entity: "acccounts"
                   key: "account_id"
@@ -555,7 +563,7 @@ metadata-overrides {
               }
               destination: {
                 visible: true
-                data-type: "hash"
+                data-type: "AccountAddress"
                 reference: {
                   entity: "acccounts"
                   key: "account_id"
@@ -591,6 +599,7 @@ metadata-overrides {
               }
               block_hash: {
                 display-name: "Block Hash"
+                data-type: "Hash"
                 visible: true
                 reference: {
                   entity: "blocks"
@@ -638,10 +647,11 @@ metadata-overrides {
                 display-name: "Address"
                 placeholder: "tz1..."
                 visible: true
-                data-type: "hash"
+                data-type: "AccountAddress"
               }
               block_id {
                 display-name: "Block Hash"
+                data-type: "Hash"
                 visible: true
                 reference: {
                   entity: "blocks"
@@ -653,7 +663,7 @@ metadata-overrides {
                 reference: {
                   entity: "accounts"
                   key: "account_id"
-                  data-type: "hash"
+                  data-type: "AccountAddress"
                 }
               }
               spendable {
@@ -666,7 +676,7 @@ metadata-overrides {
               delegate_value {
                 display-name: "Delegate"
                 visible: true
-                data-type: "hash"
+                data-type: "AccountAddress"
                 reference: {
                   entity: "accounts"
                   key: "account_id"
@@ -700,7 +710,7 @@ metadata-overrides {
               pkh {
                 display-name: "Address"
                 visible: true
-                data-type: "hash"
+                data-type: "AccountAddress"
                 reference: {
                   entity: "accounts"
                   key: "account_id"
@@ -711,6 +721,7 @@ metadata-overrides {
               }
               block_id {
                 display-name: "Block Hash"
+                data-type: "Hash"
                 visible: true
                 reference: {
                   entity: "blocks"
@@ -784,6 +795,7 @@ metadata-overrides {
               }
               block_id {
                 display-name: "Block Hash"
+                data-type: "Hash"
                 visible: true
                 reference: {
                   entity: "blocks"
@@ -811,6 +823,7 @@ metadata-overrides {
               predecessor {
                 display-name: "Predecessor Hash"
                 visible: true
+                data-type: "Hash"
                 reference {
                   entity: "blocks"
                   key: "hash"
@@ -840,10 +853,12 @@ metadata-overrides {
               }
               hash {
                 display-name: "Block Hash"
+                data-type: "Hash"
                 visible: true
               }
               operations_hash {
                 visible: true
+                data-type: "Hash"
                 reference: {
                   entity: "operations"
                   key: "operation_group_hash"
@@ -860,7 +875,7 @@ metadata-overrides {
               }
               baker {
                 visible: true
-                data-type: "hash"
+                data-type: "AccountAddress"
                 reference: {
                   entity: "acccounts"
                   key: "account_id"
@@ -953,6 +968,7 @@ metadata-overrides {
               }
               operation_group_hash: {
                 visible: true
+                data-type: "Hash"
               }
               kind: {
                 visible: true
@@ -966,7 +982,7 @@ metadata-overrides {
               }
               delegate: {
                 visible: true
-                data-type: "hash"
+                data-type: "AccountAddress"
                 reference: {
                   entity: "acccounts"
                   key: "account_id"
@@ -986,7 +1002,7 @@ metadata-overrides {
               }
               source: {
                 visible: true
-                data-type: "hash"
+                data-type: "AccountAddress"
                 reference {
                   entity: "acccounts"
                   key: "account_id"
@@ -1014,7 +1030,7 @@ metadata-overrides {
               }
               destination: {
                 visible: true
-                data-type: "hash"
+                data-type: "AccountAddress"
                 reference: {
                   entity: "acccounts"
                   key: "account_id"
@@ -1050,6 +1066,7 @@ metadata-overrides {
               }
               block_hash: {
                 display-name: "Block Hash"
+                data-type: "Hash"
                 visible: true
                 reference: {
                   entity: "blocks"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -181,9 +181,17 @@ metadata-overrides {
               block_id {
                 display-name: "Block Hash"
                 visible: true
+                reference: {
+                  entity: "blocks"
+                  key: "hash"
+                }
               }
               manager {
                 visible: true
+                reference: {
+                  entity: "accounts"
+                  key: "account_id"
+                }
               }
               spendable {
                 visible: true
@@ -195,6 +203,10 @@ metadata-overrides {
               delegate_value {
                 display-name: "Delegate"
                 visible: true
+                reference: {
+                  entity: "accounts"
+                  key: "account_id"
+                }
               }
               counter {
                 visible: true
@@ -211,6 +223,10 @@ metadata-overrides {
               }
               block_level {
                 visible: true
+                reference: {
+                  entity: "blocks"
+                  key: "level"
+                }
               }
             }
           }
@@ -220,6 +236,10 @@ metadata-overrides {
               pkh {
                 display-name: "Address"
                 visible: true
+                reference: {
+                  entity: "accounts"
+                  key: "account_id"
+                }
               }
               rolls {
                 visible: true
@@ -227,9 +247,17 @@ metadata-overrides {
               block_id {
                 display-name: "Block Hash"
                 visible: true
+                reference: {
+                  entity: "blocks"
+                  key: "hash"
+                }
               }
               block_level {
                 visible: true
+                reference: {
+                  entity: "blocks"
+                  key: "level"
+                }
               }
             }
           }
@@ -274,9 +302,9 @@ metadata-overrides {
               pkh {
                 display-name: "Address"
                 visible: true
-                reference {
-                  "entity": "acccounts"
-                  "key": "account_id"
+                reference: {
+                  entity: "acccounts"
+                  key: "account_id"
                 }
               }
               ballot {
@@ -291,9 +319,17 @@ metadata-overrides {
               block_id {
                 display-name: "Block Hash"
                 visible: true
+                reference: {
+                  entity: "blocks"
+                  key: "hash"
+                }
               }
               block_level {
                 visible: true
+                reference: {
+                  entity: "blocks"
+                  key: "level"
+                }
               }
             }
           }
@@ -309,6 +345,10 @@ metadata-overrides {
               predecessor {
                 display-name: "Predecessor Hash"
                 visible: true
+                reference: {
+                  entity: "blocks"
+                  key: "hash"
+                }
               }
               timestamp {
                 data-format: "YYYY MMM DD, HH:mm Z"
@@ -338,6 +378,10 @@ metadata-overrides {
               }
               operations_hash {
                 visible: true
+                reference: {
+                  entity: "operations"
+                  key: "operation_group_hash"
+                }
               }
               period_kind {
                 visible: true
@@ -350,6 +394,10 @@ metadata-overrides {
               }
               baker {
                 visible: true
+                reference: {
+                  entity: "acccounts"
+                  key: "account_id"
+                }
               }
               nonce_hash {
                 visible: true
@@ -421,6 +469,10 @@ metadata-overrides {
               block_id {
                 display-name: "Block Hash"
                 visible: true
+                reference: {
+                  entity: "blocks"
+                  key: "hash"
+                }
               }
             }
           }
@@ -438,9 +490,17 @@ metadata-overrides {
               }
               level: {
                 visible: true
+                reference: {
+                  entity: "acccounts"
+                  key: "account_id"
+                }
               }
               delegate: {
                 visible: true
+                reference: {
+                  entity: "acccounts"
+                  key: "account_id"
+                }
               }
               slots: {
                 visible: true
@@ -456,9 +516,14 @@ metadata-overrides {
               }
               source: {
                 visible: true
+                reference {
+                  entity: "acccounts"
+                  key: "account_id"
+                }
               }
               fee: {
                 visible: true
+                scale: 6
               }
               counter: {
                 visible: true
@@ -474,9 +539,14 @@ metadata-overrides {
               }
               amount: {
                 visible: true
+                scale: 6
               }
               destination: {
                 visible: true
+                reference: {
+                  entity: "acccounts"
+                  key: "account_id"
+                }
               }
               parameters: {
                 visible: true
@@ -486,6 +556,7 @@ metadata-overrides {
               }
               balance: {
                 visible: true
+                scale: 6
               }
               spendable: {
                 visible: true
@@ -508,9 +579,17 @@ metadata-overrides {
               block_hash: {
                 display-name: "Block Hash"
                 visible: true
+                reference: {
+                  entity: "acccounts"
+                  key: "account_id"
+                }
               }
               block_level: {
                 visible: true
+                reference: {
+                  entity: "acccounts"
+                  key: "account_id"
+                }
               }
               timestamp: {
                 visible: true
@@ -546,13 +625,22 @@ metadata-overrides {
                 display-name: "Address"
                 placeholder: "tz1..."
                 visible: true
+                data-type: "hash"
               }
               block_id {
                 display-name: "Block Hash"
                 visible: true
+                reference: {
+                  entity: "blocks"
+                  key: "hash"
+                }
               }
               manager {
                 visible: true
+                reference: {
+                  entity: "accounts"
+                  key: "account_id"
+                }
               }
               spendable {
                 visible: true
@@ -564,6 +652,10 @@ metadata-overrides {
               delegate_value {
                 display-name: "Delegate"
                 visible: true
+                reference: {
+                  entity: "accounts"
+                  key: "account_id"
+                }
               }
               counter {
                 visible: true
@@ -576,9 +668,14 @@ metadata-overrides {
               }
               balance {
                 visible: true
+                scale: 6
               }
               block_level {
                 visible: true
+                reference: {
+                  entity: "blocks"
+                  key: "level"
+                }
               }
             }
           }
@@ -588,6 +685,10 @@ metadata-overrides {
               pkh {
                 display-name: "Address"
                 visible: true
+                reference: {
+                  entity: "accounts"
+                  key: "account_id"
+                }
               }
               rolls {
                 visible: true
@@ -595,9 +696,17 @@ metadata-overrides {
               block_id {
                 display-name: "Block Hash"
                 visible: true
+                reference: {
+                  entity: "blocks"
+                  key: "hash"
+                }
               }
               block_level {
                 visible: true
+                reference: {
+                  entity: "blocks"
+                  key: "level"
+                }
               }
             }
           }
@@ -642,17 +751,34 @@ metadata-overrides {
               pkh {
                 display-name: "Address"
                 visible: true
+                reference: {
+                  entity: "acccounts"
+                  key: "account_id"
+                }
               }
               ballot {
                 display-name: "Vote"
                 visible: true
+                value-map: {
+                  "0": "Yay",
+                  "1": "Nay",
+                  "2": "Pass"
+                }
               }
               block_id {
                 display-name: "Block Hash"
                 visible: true
+                reference: {
+                  entity: "blocks"
+                  key: "hash"
+                }
               }
               block_level {
                 visible: true
+                reference: {
+                  entity: "blocks"
+                  key: "level"
+                }
               }
             }
           }
@@ -668,6 +794,10 @@ metadata-overrides {
               predecessor {
                 display-name: "Predecessor Hash"
                 visible: true
+                reference {
+                  entity: "blocks"
+                  key: "hash"
+                }
               }
               timestamp {
                 data-format: "YYYY MMM DD, HH:mm Z"
@@ -697,6 +827,10 @@ metadata-overrides {
               }
               operations_hash {
                 visible: true
+                reference: {
+                  entity: "operations"
+                  key: "operation_group_hash"
+                }
               }
               period_kind {
                 visible: true
@@ -709,6 +843,10 @@ metadata-overrides {
               }
               baker {
                 visible: true
+                reference: {
+                  entity: "acccounts"
+                  key: "account_id"
+                }
               }
               nonce_hash {
                 visible: true
@@ -780,6 +918,10 @@ metadata-overrides {
               block_id {
                 display-name: "Block Hash"
                 visible: true
+                reference: {
+                  entity: "blocks"
+                  key: "hash"
+                }
               }
             }
           }
@@ -797,9 +939,17 @@ metadata-overrides {
               }
               level: {
                 visible: true
+                reference: {
+                  entity: "acccounts"
+                  key: "account_id"
+                }
               }
               delegate: {
                 visible: true
+                reference: {
+                  entity: "acccounts"
+                  key: "account_id"
+                }
               }
               slots: {
                 visible: true
@@ -815,9 +965,14 @@ metadata-overrides {
               }
               source: {
                 visible: true
+                reference {
+                  entity: "acccounts"
+                  key: "account_id"
+                }
               }
               fee: {
                 visible: true
+                scale: 6
               }
               counter: {
                 visible: true
@@ -833,9 +988,14 @@ metadata-overrides {
               }
               amount: {
                 visible: true
+                scale: 6
               }
               destination: {
                 visible: true
+                reference: {
+                  entity: "acccounts"
+                  key: "account_id"
+                }
               }
               parameters: {
                 visible: true
@@ -845,6 +1005,7 @@ metadata-overrides {
               }
               balance: {
                 visible: true
+                scale: 6
               }
               spendable: {
                 visible: true
@@ -867,9 +1028,17 @@ metadata-overrides {
               block_hash: {
                 display-name: "Block Hash"
                 visible: true
+                reference: {
+                  entity: "acccounts"
+                  key: "account_id"
+                }
               }
               block_level: {
                 visible: true
+                reference: {
+                  entity: "acccounts"
+                  key: "account_id"
+                }
               }
               timestamp: {
                 visible: true

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -230,7 +230,7 @@ metadata-overrides {
               }
             }
           }
-          bakers {
+          rolls {
             visible: true
             attributes {
               pkh {
@@ -681,7 +681,7 @@ metadata-overrides {
               }
             }
           }
-          bakers {
+          rolls {
             visible: true
             attributes {
               pkh {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -443,6 +443,7 @@ metadata-overrides {
               }
               timestamp {
                 visible: true
+                data-format: "YYYY MMM DD, HH:mm Z"
               }
               kind {
                 visible: true
@@ -894,6 +895,7 @@ metadata-overrides {
               }
               timestamp {
                 visible: true
+                data-format: "YYYY MMM DD, HH:mm Z"
               }
               kind {
                 visible: true

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -155,10 +155,11 @@ akka {
 # Additionally, on attributes level you can provide following parameters:
 # * placeholder: String
 # * data-format: String
-# * value-map: Map[String, String], example: {"0": "Yay", "1": "Nay", "2": "Pass"}
+# * value-map: Map[String, String], example: {"0": "Yay", "1": "Nay", "2": "Pass"},
+# * reference: Map[String, String], example: {"entity": "acccounts", "key": "account_id"}, so UI can create links between fields
 # * data-type: String, since this value is later mapped to enum, values are limited to those supported by method
 #                      tech.cryptonomic.conseil.tezos.TezosPlatformDiscoveryOperations.mapType
-# * scale: Int
+# * scale: Int, indicate to the UI how to display a value
 
 metadata-overrides {
   tezos {
@@ -273,6 +274,10 @@ metadata-overrides {
               pkh {
                 display-name: "Address"
                 visible: true
+                reference {
+                  "entity": "acccounts"
+                  "key": "account_id"
+                }
               }
               ballot {
                 display-name: "Vote"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -188,6 +188,7 @@ metadata-overrides {
               }
               manager {
                 visible: true
+                data-type: "hash"
                 reference: {
                   entity: "accounts"
                   key: "account_id"
@@ -203,6 +204,7 @@ metadata-overrides {
               delegate_value {
                 display-name: "Delegate"
                 visible: true
+                data-type: "hash"
                 reference: {
                   entity: "accounts"
                   key: "account_id"
@@ -223,6 +225,7 @@ metadata-overrides {
               }
               block_level {
                 visible: true
+                display-name: "Block Level"
                 reference: {
                   entity: "blocks"
                   key: "level"
@@ -236,6 +239,7 @@ metadata-overrides {
               pkh {
                 display-name: "Address"
                 visible: true
+                data-type: "hash"
                 reference: {
                   entity: "accounts"
                   key: "account_id"
@@ -253,6 +257,7 @@ metadata-overrides {
                 }
               }
               block_level {
+                display-name: "Block Level"
                 visible: true
                 reference: {
                   entity: "blocks"
@@ -303,6 +308,7 @@ metadata-overrides {
               pkh {
                 display-name: "Address"
                 visible: true
+                data-type: "hash"
                 reference: {
                   entity: "acccounts"
                   key: "account_id"
@@ -395,6 +401,7 @@ metadata-overrides {
               }
               baker {
                 visible: true
+                data-type: "hash"
                 reference: {
                   entity: "acccounts"
                   key: "account_id"
@@ -494,12 +501,13 @@ metadata-overrides {
               level: {
                 visible: true
                 reference: {
-                  entity: "acccounts"
-                  key: "account_id"
+                  entity: "blocks"
+                  key: "level"
                 }
               }
               delegate: {
                 visible: true
+                data-type: "hash"
                 reference: {
                   entity: "acccounts"
                   key: "account_id"
@@ -519,6 +527,7 @@ metadata-overrides {
               }
               source: {
                 visible: true
+                data-type: "hash"
                 reference {
                   entity: "acccounts"
                   key: "account_id"
@@ -546,6 +555,7 @@ metadata-overrides {
               }
               destination: {
                 visible: true
+                data-type: "hash"
                 reference: {
                   entity: "acccounts"
                   key: "account_id"
@@ -583,15 +593,15 @@ metadata-overrides {
                 display-name: "Block Hash"
                 visible: true
                 reference: {
-                  entity: "acccounts"
-                  key: "account_id"
+                  entity: "blocks"
+                  key: "hash"
                 }
               }
               block_level: {
                 visible: true
                 reference: {
-                  entity: "acccounts"
-                  key: "account_id"
+                  entity: "blocks"
+                  key: "level"
                 }
               }
               timestamp: {
@@ -643,6 +653,7 @@ metadata-overrides {
                 reference: {
                   entity: "accounts"
                   key: "account_id"
+                  data-type: "hash"
                 }
               }
               spendable {
@@ -655,6 +666,7 @@ metadata-overrides {
               delegate_value {
                 display-name: "Delegate"
                 visible: true
+                data-type: "hash"
                 reference: {
                   entity: "accounts"
                   key: "account_id"
@@ -688,6 +700,7 @@ metadata-overrides {
               pkh {
                 display-name: "Address"
                 visible: true
+                data-type: "hash"
                 reference: {
                   entity: "accounts"
                   key: "account_id"
@@ -847,6 +860,7 @@ metadata-overrides {
               }
               baker {
                 visible: true
+                data-type: "hash"
                 reference: {
                   entity: "acccounts"
                   key: "account_id"
@@ -952,6 +966,7 @@ metadata-overrides {
               }
               delegate: {
                 visible: true
+                data-type: "hash"
                 reference: {
                   entity: "acccounts"
                   key: "account_id"
@@ -971,6 +986,7 @@ metadata-overrides {
               }
               source: {
                 visible: true
+                data-type: "hash"
                 reference {
                   entity: "acccounts"
                   key: "account_id"
@@ -998,6 +1014,7 @@ metadata-overrides {
               }
               destination: {
                 visible: true
+                data-type: "hash"
                 reference: {
                   entity: "acccounts"
                   key: "account_id"
@@ -1035,15 +1052,15 @@ metadata-overrides {
                 display-name: "Block Hash"
                 visible: true
                 reference: {
-                  entity: "acccounts"
-                  key: "account_id"
+                  entity: "blocks"
+                  key: "hash"
                 }
               }
               block_level: {
                 visible: true
                 reference: {
-                  entity: "acccounts"
-                  key: "account_id"
+                  entity: "blocks"
+                  key: "level"
                 }
               }
               timestamp: {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -262,6 +262,7 @@ metadata-overrides {
             }
           }
           balance_updates {
+            display-name: "Balance Updates"
             visible: true
             attributes {
               id {
@@ -449,6 +450,7 @@ metadata-overrides {
             }
           }
           operation_groups {
+            display-name: "Operation Groups"
             visible: true
             attributes {
               protocol {
@@ -711,6 +713,7 @@ metadata-overrides {
             }
           }
           balance_updates {
+            display-name: "Balance Updates"
             visible: true
             attributes {
               id {
@@ -898,6 +901,7 @@ metadata-overrides {
             }
           }
           operation_groups {
+            display-name: "Operation Groups"
             visible: true
             attributes {
               protocol {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -152,9 +152,13 @@ akka {
 # * visible: Boolean (false by default)
 # * description: String
 #
-# Additionally, on attributes level you can provide two parameters:
+# Additionally, on attributes level you can provide following parameters:
 # * placeholder: String
 # * data-format: String
+# * value-map: Map[String, String], example: {"0": "Yay", "1": "Nay", "2": "Pass"}
+# * data-type: String, since this value is later mapped to enum, values are limited to those supported by method
+#                      tech.cryptonomic.conseil.tezos.TezosPlatformDiscoveryOperations.mapType
+# * scale: Int
 
 metadata-overrides {
   tezos {
@@ -171,6 +175,7 @@ metadata-overrides {
                 display-name: "Address"
                 placeholder: "tz1..."
                 visible: true
+                data-type: "hash"
               }
               block_id {
                 display-name: "Block Hash"
@@ -201,6 +206,7 @@ metadata-overrides {
               }
               balance {
                 visible: true
+                scale: 6
               }
               block_level {
                 visible: true
@@ -271,6 +277,11 @@ metadata-overrides {
               ballot {
                 display-name: "Vote"
                 visible: true
+                value-map: {
+                  "0": "Yay",
+                  "1": "Nay",
+                  "2": "Pass"
+                }
               }
               block_id {
                 display-name: "Block Hash"

--- a/src/main/scala/tech/cryptonomic/conseil/config/MetadataOverridesConfiguration.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/config/MetadataOverridesConfiguration.scala
@@ -61,4 +61,5 @@ case class AttributeConfiguration(displayName: Option[String],
                                   scale: Option[Int] = None,
                                   dataType: Option[String] = None,
                                   dataFormat: Option[String] = None,
-                                  valueMap: Option[Map[String, String]] = None)
+                                  valueMap: Option[Map[String, String]] = None,
+                                  reference: Option[Map[String, String]] = None)

--- a/src/main/scala/tech/cryptonomic/conseil/config/MetadataOverridesConfiguration.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/config/MetadataOverridesConfiguration.scala
@@ -36,13 +36,29 @@ case class MetadataOverridesConfiguration(metadataOverrides: Map[PlatformName, P
 }
 
 // configuration for platform
-case class PlatformConfiguration(displayName: Option[String], visible: Option[Boolean], description: Option[String] = None, networks: Map[NetworkName, NetworkConfiguration] = Map.empty)
+case class PlatformConfiguration(displayName: Option[String],
+                                 visible: Option[Boolean],
+                                 description: Option[String] = None,
+                                 networks: Map[NetworkName, NetworkConfiguration] = Map.empty)
 
 // configuration for network
-case class NetworkConfiguration(displayName: Option[String], visible: Option[Boolean], description: Option[String] = None, entities: Map[EntityName, EntityConfiguration] = Map.empty)
+case class NetworkConfiguration(displayName: Option[String],
+                                visible: Option[Boolean],
+                                description: Option[String] = None,
+                                entities: Map[EntityName, EntityConfiguration] = Map.empty)
 
 // configuration for entity
-case class EntityConfiguration(displayName: Option[String], visible: Option[Boolean], description: Option[String] = None, attributes: Map[AttributeName, AttributeConfiguration] = Map.empty)
+case class EntityConfiguration(displayName: Option[String],
+                               visible: Option[Boolean],
+                               description: Option[String] = None,
+                               attributes: Map[AttributeName, AttributeConfiguration] = Map.empty)
 
 // configuration for attribute
-case class AttributeConfiguration(displayName: Option[String], visible: Option[Boolean], description: Option[String] = None, placeholder: Option[String] = None, dataFormat: Option[String] = None)
+case class AttributeConfiguration(displayName: Option[String],
+                                  visible: Option[Boolean],
+                                  description: Option[String] = None,
+                                  placeholder: Option[String] = None,
+                                  scale: Option[Int] = None,
+                                  dataType: Option[String] = None,
+                                  dataFormat: Option[String] = None,
+                                  valueMap: Option[Map[String, String]] = None)

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/PlatformDiscoveryTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/PlatformDiscoveryTypes.scala
@@ -27,13 +27,15 @@ object PlatformDiscoveryTypes {
     entity: String,
     description: Option[String] = None,
     placeholder: Option[String] = None,
-    dataFormat: Option[String] = None
+    dataFormat: Option[String] = None,
+    valueMap: Option[Map[String, String]] = None,
+    scale: Option[Int] = None
   )
 
   /** Enumeration of data types */
   object DataType extends Enumeration {
     type DataType = Value
-    val Enum, Hex, Binary, Date, DateTime, String, Int, LargeInt, Decimal, Boolean = Value
+    val Enum, Hex, Binary, Date, DateTime, String, Hash, Int, LargeInt, Decimal, Boolean = Value
   }
 
   /** Enumeration of key types */

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/PlatformDiscoveryTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/PlatformDiscoveryTypes.scala
@@ -29,7 +29,8 @@ object PlatformDiscoveryTypes {
     placeholder: Option[String] = None,
     dataFormat: Option[String] = None,
     valueMap: Option[Map[String, String]] = None,
-    scale: Option[Int] = None
+    scale: Option[Int] = None,
+    reference: Option[Map[String, String]] = None
   )
 
   /** Enumeration of data types */

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/PlatformDiscoveryTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/PlatformDiscoveryTypes.scala
@@ -36,7 +36,7 @@ object PlatformDiscoveryTypes {
   /** Enumeration of data types */
   object DataType extends Enumeration {
     type DataType = Value
-    val Enum, Hex, Binary, Date, DateTime, String, Hash, Int, LargeInt, Decimal, Boolean = Value
+    val Enum, Hex, Binary, Date, DateTime, String, Hash, AccountAddress, Int, LargeInt, Decimal, Boolean = Value
   }
 
   /** Enumeration of key types */

--- a/src/main/scala/tech/cryptonomic/conseil/metadata/UnitTransformation.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/metadata/UnitTransformation.scala
@@ -55,6 +55,7 @@ class UnitTransformation(overrides: MetadataOverridesConfiguration) {
       dataFormat = overrideAttribute.flatMap(_.dataFormat),
       scale = overrideAttribute.flatMap(_.scale),
       dataType = overrideAttribute.flatMap(_.dataType).map(mapType).getOrElse(attribute.dataType),
-      valueMap = overrideAttribute.flatMap(_.valueMap).filter(_.nonEmpty))
+      valueMap = overrideAttribute.flatMap(_.valueMap).filter(_.nonEmpty),
+      reference = overrideAttribute.flatMap(_.reference).filter(_.nonEmpty))
   }
 }

--- a/src/main/scala/tech/cryptonomic/conseil/metadata/UnitTransformation.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/metadata/UnitTransformation.scala
@@ -2,6 +2,7 @@ package tech.cryptonomic.conseil.metadata
 
 import tech.cryptonomic.conseil.config.MetadataOverridesConfiguration
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.{Attribute, Entity, Network, Platform}
+import tech.cryptonomic.conseil.tezos.TezosPlatformDiscoveryOperations.mapType
 import tech.cryptonomic.conseil.util.OptionUtil.when
 
 // class for applying overrides configurations
@@ -48,14 +49,12 @@ class UnitTransformation(overrides: MetadataOverridesConfiguration) {
     val overrideAttribute = overrides.attribute(path)
 
     attribute.copy(
-      displayName = overrideAttribute
-        .flatMap(_.displayName)
-        .getOrElse(attribute.displayName),
-      description = overrideAttribute
-        .flatMap(_.description),
-      placeholder = overrideAttribute
-        .flatMap(_.placeholder),
-      dataFormat = overrideAttribute
-        .flatMap(_.dataFormat))
+      displayName = overrideAttribute.flatMap(_.displayName).getOrElse(attribute.displayName),
+      description = overrideAttribute.flatMap(_.description),
+      placeholder = overrideAttribute.flatMap(_.placeholder),
+      dataFormat = overrideAttribute.flatMap(_.dataFormat),
+      scale = overrideAttribute.flatMap(_.scale),
+      dataType = overrideAttribute.flatMap(_.dataType).map(mapType).getOrElse(attribute.dataType),
+      valueMap = overrideAttribute.flatMap(_.valueMap).filter(_.nonEmpty))
   }
 }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperations.scala
@@ -25,6 +25,20 @@ object TezosPlatformDiscoveryOperations {
     cacheTTL: FiniteDuration)
     (implicit executionContext: ExecutionContext): TezosPlatformDiscoveryOperations =
     new TezosPlatformDiscoveryOperations(metadataOperations: MetadataOperations, attributesCache, entitiesCache, cacheTTL)
+
+
+  /** Maps type from DB to type used in query */
+  def mapType(tpe: String): DataType = {
+    tpe match {
+      case "timestamp" => DataType.DateTime
+      case "varchar" => DataType.String
+      case "int4" | "serial" => DataType.Int
+      case "numeric" => DataType.Decimal
+      case "bool" => DataType.Boolean
+      case "hash" => DataType.Hash
+      case _ => DataType.String
+    }
+  }
 }
 
 /** Class providing the implementation of the metadata calls with caching */
@@ -99,23 +113,11 @@ class TezosPlatformDiscoveryOperations(
     Attribute(
       name = col.name,
       displayName = makeDisplayName(col.name),
-      dataType = mapType(col.typeName),
-      cardinality = if (canQueryType(mapType(col.typeName))) Some(count) else None,
+      dataType = TezosPlatformDiscoveryOperations.mapType(col.typeName),
+      cardinality = if (canQueryType(TezosPlatformDiscoveryOperations.mapType(col.typeName))) Some(count) else None,
       keyType = if (isIndex(col, indexes) || isKey(col, primaryKeys)) KeyType.UniqueKey else KeyType.NonKey,
       entity = col.table.name
     )
-
-  /** Maps type from DB to type used in query */
-  private def mapType(tpe: String): DataType = {
-    tpe match {
-      case "timestamp" => DataType.DateTime
-      case "varchar" => DataType.String
-      case "int4" | "serial" => DataType.Int
-      case "numeric" => DataType.Decimal
-      case "bool" => DataType.Boolean
-      case _ => DataType.String
-    }
-  }
 
   /** Checks if given MColumn has primary key */
   private def isKey(column: MColumn, keys: Vector[Vector[MPrimaryKey]]): Boolean = {

--- a/src/test/scala/tech/cryptonomic/conseil/metadata/MetadataServiceTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/metadata/MetadataServiceTest.scala
@@ -281,7 +281,8 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
                 scale = Some(6),
                 dataType = Some("hash"),
                 dataFormat = Some("dataFormat"),
-                valueMap = Some(Map("0" -> "value1", "1" -> "other value"))))))))))
+                valueMap = Some(Map("0" -> "value1", "1" -> "other value")),
+                reference = Some(Map("0" -> "value1", "1" -> "other value"))))))))))
 
       // when
       val result = sut(overwrittenConfiguration).getTableAttributes(EntityPath("entity", NetworkPath("mainnet", PlatformPath("tezos")))).futureValue
@@ -298,6 +299,7 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
         placeholder = Some("placeholder"),
         dataFormat = Some("dataFormat"),
         valueMap = Some(Map("0" -> "value1", "1" -> "other value")),
+        reference = Some(Map("0" -> "value1", "1" -> "other value")),
         scale = Some(6))))
     }
 

--- a/src/test/scala/tech/cryptonomic/conseil/metadata/MetadataServiceTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/metadata/MetadataServiceTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.{Matchers, WordSpec}
 import tech.cryptonomic.conseil.config.Platforms.{PlatformsConfiguration, TezosConfiguration, TezosNodeConfiguration}
 import tech.cryptonomic.conseil.config.Types.PlatformName
 import tech.cryptonomic.conseil.config.{AttributeConfiguration, EntityConfiguration, MetadataOverridesConfiguration, NetworkConfiguration, PlatformConfiguration, Platforms}
-import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.DataType.Int
+import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.DataType.{Hash, Int}
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.KeyType.NonKey
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.{Attribute, Entity, Network, Platform}
 import tech.cryptonomic.conseil.tezos.TezosPlatformDiscoveryOperations
@@ -273,13 +273,32 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
         PlatformConfiguration(None, Some(true), None, Map("mainnet" ->
           NetworkConfiguration(None, Some(true), None, Map("entity" ->
             EntityConfiguration(None, Some(true), None, Map("attribute" ->
-              AttributeConfiguration(Some("overwritten-name"), Some(true), Some("description"), Some("placeholder"), Some("dataFormat")))))))))
+              AttributeConfiguration(
+                Some("overwritten-name"),
+                Some(true),
+                Some("description"),
+                Some("placeholder"),
+                Some(4),
+                Some("hash"),
+                Some("dataFormat"),
+                Some(Map("0" -> "value1", "1" -> "other value"))))))))))
 
       // when
       val result = sut(overwrittenConfiguration).getTableAttributes(EntityPath("entity", NetworkPath("mainnet", PlatformPath("tezos")))).futureValue
 
       // then
-      result shouldBe Some(List(Attribute("attribute", "overwritten-name", Int, None, NonKey, "entity", Some("description"), Some("placeholder"), Some("dataFormat"))))
+      result shouldBe Some(List(Attribute(
+        "attribute",
+        "overwritten-name",
+        Hash,
+        None,
+        NonKey,
+        "entity",
+        Some("description"),
+        Some("placeholder"),
+        Some("dataFormat"),
+        Some(Map("0" -> "value1", "1" -> "other value")))),
+        Some(6))
     }
 
     "filter out a hidden attribute" in {

--- a/src/test/scala/tech/cryptonomic/conseil/metadata/MetadataServiceTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/metadata/MetadataServiceTest.scala
@@ -274,31 +274,31 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
           NetworkConfiguration(None, Some(true), None, Map("entity" ->
             EntityConfiguration(None, Some(true), None, Map("attribute" ->
               AttributeConfiguration(
-                Some("overwritten-name"),
-                Some(true),
-                Some("description"),
-                Some("placeholder"),
-                Some(4),
-                Some("hash"),
-                Some("dataFormat"),
-                Some(Map("0" -> "value1", "1" -> "other value"))))))))))
+                displayName = Some("overwritten-name"),
+                visible = Some(true),
+                description = Some("description"),
+                placeholder = Some("placeholder"),
+                scale = Some(6),
+                dataType = Some("hash"),
+                dataFormat = Some("dataFormat"),
+                valueMap = Some(Map("0" -> "value1", "1" -> "other value"))))))))))
 
       // when
       val result = sut(overwrittenConfiguration).getTableAttributes(EntityPath("entity", NetworkPath("mainnet", PlatformPath("tezos")))).futureValue
 
       // then
       result shouldBe Some(List(Attribute(
-        "attribute",
-        "overwritten-name",
-        Hash,
-        None,
-        NonKey,
-        "entity",
-        Some("description"),
-        Some("placeholder"),
-        Some("dataFormat"),
-        Some(Map("0" -> "value1", "1" -> "other value")))),
-        Some(6))
+        name = "attribute",
+        displayName = "overwritten-name",
+        dataType = Hash,
+        cardinality = None,
+        keyType = NonKey,
+        entity = "entity",
+        description = Some("description"),
+        placeholder = Some("placeholder"),
+        dataFormat = Some("dataFormat"),
+        valueMap = Some(Map("0" -> "value1", "1" -> "other value")),
+        scale = Some(6))))
     }
 
     "filter out a hidden attribute" in {

--- a/src/test/scala/tech/cryptonomic/conseil/routes/PlatformDiscoveryTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/routes/PlatformDiscoveryTest.scala
@@ -166,15 +166,17 @@ class PlatformDiscoveryTest extends WordSpec with Matchers with ScalatestRouteTe
         status shouldEqual StatusCodes.OK
         contentType shouldBe ContentTypes.`application/json`
         val result: List[Map[String, Any]] = toListOfMaps[Any](responseAs[String])
-        result.head("name") shouldBe "attribute"
-        result.head("displayName") shouldBe "attribute-name"
-        result.head("description") shouldBe "description"
-        result.head("placeholder") shouldBe "placeholder"
-        result.head("dataFormat") shouldBe "dataFormat"
-        result.head("scale") shouldBe 6
-        result.head("valueMap") shouldBe Map("0" -> "value")
-        result.head("dataType") shouldBe "Hash"
-        result.head("reference") shouldBe Map("0" -> "value")
+
+        val headResult = toListOfMaps[Any](responseAs[String]).head
+        headResult("name") shouldBe "attribute"
+        headResult("displayName") shouldBe "attribute-name"
+        headResult("description") shouldBe "description"
+        headResult("placeholder") shouldBe "placeholder"
+        headResult("dataFormat") shouldBe "dataFormat"
+        headResult("scale") shouldBe 6
+        headResult("valueMap") shouldBe Map("0" -> "value")
+        headResult("dataType") shouldBe "Hash"
+        headResult("reference") shouldBe Map("0" -> "value")
       }
     }
 

--- a/src/test/scala/tech/cryptonomic/conseil/routes/PlatformDiscoveryTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/routes/PlatformDiscoveryTest.scala
@@ -156,7 +156,8 @@ class PlatformDiscoveryTest extends WordSpec with Matchers with ScalatestRouteTe
                 scale = Some(6),
                 dataType = Some("hash"),
                 dataFormat = Some("dataFormat"),
-                valueMap = Some(Map("0" -> "value"))))))))))
+                valueMap = Some(Map("0" -> "value")),
+                reference = Some(Map("0" -> "value"))))))))))
 
       // when
       Get("/v2/metadata/tezos/mainnet/entity/attributes") ~> addHeader("apiKey", "hooman") ~> sut(overridesConfiguration) ~> check {
@@ -173,6 +174,7 @@ class PlatformDiscoveryTest extends WordSpec with Matchers with ScalatestRouteTe
         result.head("scale") shouldBe 6
         result.head("valueMap") shouldBe Map("0" -> "value")
         result.head("dataType") shouldBe "Hash"
+        result.head("reference") shouldBe Map("0" -> "value")
       }
     }
 

--- a/src/test/scala/tech/cryptonomic/conseil/routes/PlatformDiscoveryTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/routes/PlatformDiscoveryTest.scala
@@ -148,7 +148,15 @@ class PlatformDiscoveryTest extends WordSpec with Matchers with ScalatestRouteTe
         PlatformConfiguration(None, Some(true), None, Map("mainnet" ->
           NetworkConfiguration(None, Some(true), None, Map("entity" ->
             EntityConfiguration(None, Some(true), None, Map("attribute" ->
-              AttributeConfiguration(None, Some(true), Some("description"), Some("placeholder"), Some("dataFormat")))))))))
+              AttributeConfiguration(
+                displayName = None,
+                visible = Some(true),
+                description = Some("description"),
+                placeholder = Some("placeholder"),
+                scale = Some(6),
+                dataType = Some("hash"),
+                dataFormat = Some("dataFormat"),
+                valueMap = Some(Map("0" -> "value"))))))))))
 
       // when
       Get("/v2/metadata/tezos/mainnet/entity/attributes") ~> addHeader("apiKey", "hooman") ~> sut(overridesConfiguration) ~> check {
@@ -156,12 +164,15 @@ class PlatformDiscoveryTest extends WordSpec with Matchers with ScalatestRouteTe
         // then
         status shouldEqual StatusCodes.OK
         contentType shouldBe ContentTypes.`application/json`
-        val result: List[Map[String, String]] = toListOfMaps[String](responseAs[String])
+        val result: List[Map[String, Any]] = toListOfMaps[Any](responseAs[String])
         result.head("name") shouldBe "attribute"
         result.head("displayName") shouldBe "attribute-name"
         result.head("description") shouldBe "description"
         result.head("placeholder") shouldBe "placeholder"
         result.head("dataFormat") shouldBe "dataFormat"
+        result.head("scale") shouldBe 6
+        result.head("valueMap") shouldBe Map("0" -> "value")
+        result.head("dataType") shouldBe "Hash"
       }
     }
 


### PR DESCRIPTION
closes #354, #379

Adds support for 4 additional fields for supplementary metadata:
* `value-map`: `Map[String, String]`, example: `{"0": "Yay", "1": "Nay", "2": "Pass"}`,
* `references`: `Map[String, String]`
* `data-type`: `String`, since this value is later mapped to enum, values are limited to those supported by method [mapType](https://github.com/Cryptonomic/Conseil/blob/feature/354-additional-supplementary-metadata/src/main/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperations.scala#L31),
* `scale`: `Int`