### PR TITLE
381 - More metadata: displayNamePlural

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -163,6 +163,9 @@ akka {
 # * data-type: String, since this value is later mapped to enum, values are limited to those supported by method
 #                      tech.cryptonomic.conseil.tezos.TezosPlatformDiscoveryOperations.mapType
 # * scale: Int, indicate to the UI how to display a value
+#
+# And on entity level:
+# * display-name-plural: String
 
 metadata-configuration {
   tezos {

--- a/src/main/scala/tech/cryptonomic/conseil/config/MetadataConfiguration.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/config/MetadataConfiguration.scala
@@ -77,6 +77,7 @@ case class NetworkConfiguration(displayName: Option[String],
 
 // configuration for entity
 case class EntityConfiguration(displayName: Option[String],
+                               displayNamePlural: Option[String],
                                visible: Option[Boolean],
                                description: Option[String] = None,
                                attributes: Map[AttributeName, AttributeConfiguration] = Map.empty)

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/PlatformDiscoveryTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/PlatformDiscoveryTypes.scala
@@ -15,7 +15,7 @@ object PlatformDiscoveryTypes {
   final case class Network(name: String, displayName: String, platform: String, network: String, description: Option[String] = None)
 
   /** Case class representing single entity of a given network */
-  final case class Entity(name: String, displayName: String, count: Int, description: Option[String] = None)
+  final case class Entity(name: String, displayName: String, count: Int, displayNamePlural: Option[String] = None, description: Option[String] = None)
 
   /** Case class representing single attribute of given entity from DB */
   final case class Attribute(

--- a/src/main/scala/tech/cryptonomic/conseil/metadata/UnitTransformation.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/metadata/UnitTransformation.scala
@@ -40,6 +40,8 @@ class UnitTransformation(overrides: MetadataConfiguration) {
       displayName = overrideEntity
         .flatMap(_.displayName)
         .getOrElse(entity.displayName),
+      displayNamePlural = overrideEntity
+        .flatMap(_.displayNamePlural),
       description = overrideEntity
         .flatMap(_.description))
   }

--- a/src/test/scala/tech/cryptonomic/conseil/metadata/MetadataServiceTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/metadata/MetadataServiceTest.scala
@@ -134,7 +134,7 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
       val overwrittenConfiguration = Map("tezos" ->
         PlatformConfiguration(None, Some(true), None, Map("mainnet" ->
           NetworkConfiguration(None, Some(true), None, Map("entity" ->
-            EntityConfiguration(None, Some(true)))))))
+            EntityConfiguration(None, None, Some(true)))))))
 
       // when
       val result = sut(overwrittenConfiguration).getEntities(NetworkPath("mainnet", PlatformPath("tezos"))).futureValue
@@ -150,13 +150,29 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
       val overwrittenConfiguration = Map("tezos" ->
         PlatformConfiguration(None, Some(true), None, Map("mainnet" ->
           NetworkConfiguration(None, Some(true), None, Map("entity" ->
-            EntityConfiguration(Some("overwritten name"), Some(true)))))))
+            EntityConfiguration(Some("overwritten name"), None, Some(true)))))))
 
       // when
       val result = sut(overwrittenConfiguration).getEntities(NetworkPath("mainnet", PlatformPath("tezos"))).futureValue
 
       // then
       result shouldBe Some(List(Entity("entity", "overwritten name", 0)))
+    }
+
+    "override the display name plural for an entity" in {
+      // given
+      (tezosPlatformDiscoveryOperations.getEntities _).when().returns(successful(List(Entity("entity", "entity-name", 0))))
+
+      val overwrittenConfiguration = Map("tezos" ->
+        PlatformConfiguration(None, Some(true), None, Map("mainnet" ->
+          NetworkConfiguration(None, Some(true), None, Map("entity" ->
+            EntityConfiguration(None, Some("overwritten display name plural"), Some(true)))))))
+
+      // when
+      val result = sut(overwrittenConfiguration).getEntities(NetworkPath("mainnet", PlatformPath("tezos"))).futureValue
+
+      // then
+      result shouldBe Some(List(Entity("entity", "entity-name", 0, Some("overwritten display name plural"))))
     }
 
     "override description for an entity" in {
@@ -166,13 +182,13 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
       val overwrittenConfiguration = Map("tezos" ->
         PlatformConfiguration(None, Some(true), None, Map("mainnet" ->
           NetworkConfiguration(None, Some(true), None, Map("entity" ->
-            EntityConfiguration(None, Some(true), Some("description")))))))
+            EntityConfiguration(None, None, Some(true), Some("description")))))))
 
       // when
       val result = sut(overwrittenConfiguration).getEntities(NetworkPath("mainnet", PlatformPath("tezos"))).futureValue
 
       // then
-      result shouldBe Some(List(Entity("entity", "entity-name", 0, Some("description"))))
+      result shouldBe Some(List(Entity("entity", "entity-name", 0, None, Some("description"))))
     }
 
     "filter out a hidden entity" in {
@@ -182,7 +198,7 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
       val overwrittenConfiguration = Map("tezos" ->
         PlatformConfiguration(None, Some(true), None, Map("mainnet" ->
           NetworkConfiguration(None, Some(true), None, Map("entity" ->
-            EntityConfiguration(None, Some(false)))))))
+            EntityConfiguration(None, None, Some(false)))))))
 
       // when
       val result = sut(overwrittenConfiguration).getEntities(NetworkPath("mainnet", PlatformPath("tezos"))).futureValue
@@ -198,7 +214,7 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
       val overwrittenConfiguration = Map("tezos" ->
         PlatformConfiguration(None, Some(true), None, Map("mainnet" ->
           NetworkConfiguration(None, Some(true), None, Map("entity" ->
-            EntityConfiguration(None, None))))))
+            EntityConfiguration(None, None, None))))))
 
       // when
       val result = sut(overwrittenConfiguration).getEntities(NetworkPath("mainnet", PlatformPath("tezos"))).futureValue
@@ -256,7 +272,7 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
       val overwrittenConfiguration = Map("tezos" ->
         PlatformConfiguration(None, Some(true), None, Map("mainnet" ->
           NetworkConfiguration(None, Some(true), None, Map("entity" ->
-            EntityConfiguration(None, Some(true), None, Map("attribute" ->
+            EntityConfiguration(None, None, Some(true), None, Map("attribute" ->
               AttributeConfiguration(None, Some(true)))))))))
 
       // when
@@ -274,7 +290,7 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
       val overwrittenConfiguration = Map("tezos" ->
         PlatformConfiguration(None, Some(true), None, Map("mainnet" ->
           NetworkConfiguration(None, Some(true), None, Map("entity" ->
-            EntityConfiguration(None, Some(true), None, Map("attribute" ->
+            EntityConfiguration(None, None, Some(true), None, Map("attribute" ->
               AttributeConfiguration(
                 displayName = Some("overwritten-name"),
                 visible = Some(true),
@@ -313,7 +329,7 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
       val overwrittenConfiguration = Map("tezos" ->
         PlatformConfiguration(None, Some(true), None, Map("mainnet" ->
           NetworkConfiguration(None, Some(true), None, Map("entity" ->
-            EntityConfiguration(None, Some(true), None, Map("attribute" ->
+            EntityConfiguration(None, None, Some(true), None, Map("attribute" ->
               AttributeConfiguration(None, Some(false)))))))))
 
       // when
@@ -331,7 +347,7 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
       val overwrittenConfiguration = Map("tezos" ->
         PlatformConfiguration(None, Some(true), None, Map("mainnet" ->
           NetworkConfiguration(None, Some(true), None, Map("entity" ->
-            EntityConfiguration(None, Some(true), None, Map("attribute" ->
+            EntityConfiguration(None, None, Some(true), None, Map("attribute" ->
               AttributeConfiguration(None, None))))))))
 
       // when

--- a/src/test/scala/tech/cryptonomic/conseil/routes/PlatformDiscoveryTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/routes/PlatformDiscoveryTest.scala
@@ -103,7 +103,7 @@ class PlatformDiscoveryTest extends WordSpec with Matchers with ScalatestRouteTe
       val overridesConfiguration = Map("tezos" ->
         PlatformConfiguration(None, Some(true), None, Map("mainnet" ->
           NetworkConfiguration(None, Some(true), None, Map("entity" ->
-            EntityConfiguration(None, Some(true)))))))
+            EntityConfiguration(None, None, Some(true)))))))
 
       // when
       Get("/v2/metadata/tezos/mainnet/entities") ~> addHeader("apiKey", "hooman") ~> sut(overridesConfiguration) ~> check {
@@ -126,7 +126,7 @@ class PlatformDiscoveryTest extends WordSpec with Matchers with ScalatestRouteTe
       val overridesConfiguration = Map("tezos" ->
         PlatformConfiguration(None, Some(true), None, Map("mainnet" ->
           NetworkConfiguration(None, Some(true), None, Map("entity" ->
-            EntityConfiguration(None, Some(true), None, Map("attribute" ->
+            EntityConfiguration(None, None, Some(true), None, Map("attribute" ->
               AttributeConfiguration(None, Some(true)))))))))
 
       // when
@@ -149,7 +149,7 @@ class PlatformDiscoveryTest extends WordSpec with Matchers with ScalatestRouteTe
       val overridesConfiguration = Map("tezos" ->
         PlatformConfiguration(None, Some(true), None, Map("mainnet" ->
           NetworkConfiguration(None, Some(true), None, Map("entity" ->
-            EntityConfiguration(None, Some(true), None, Map("attribute" ->
+            EntityConfiguration(None, None, Some(true), None, Map("attribute" ->
               AttributeConfiguration(
                 displayName = None,
                 visible = Some(true),


### PR DESCRIPTION
closes #381 

Add another metadata property at the entity level: displayNamePlural. The existing displayName will store the singular version. This will improve UI and simplify i18n.