### PR TITLE
400 - Use relevant blockhash when loading accounts and delegates details

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -72,6 +72,9 @@ batchedFetches {
 
   #Used to specify the max-time allowed for each accounts-page to finish processing
   accountPageProcessingTimeout = 5 minutes
+
+  #Used to specify the max-time allowed for each delegate-page to finish processing
+  delegatePageProcessingTimeout = 5 minutes
 }
 
 # Settings for blockchains Conseil can connect to. Nested by blockchain name and network.
@@ -712,7 +715,7 @@ metadata-configuration {
                 visible: true
               }
               grace_period {
-                visible: true  
+                visible: true
               }
               block_level {
                 visible: true
@@ -1271,7 +1274,7 @@ metadata-configuration {
                 visible: true
               }
               grace_period {
-                visible: true  
+                visible: true
               }
               block_level {
                 visible: true

--- a/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
@@ -280,8 +280,6 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
       checkpoints =>
         logger.debug("I loaded all stored account references and will proceed to fetch updated information from the chain")
         val (pages, total) = tezosNodeOperator.getAccountsForBlocks(checkpoints)
-        // //custom progress tracking for accounts
-        // val logProgress = logProcessingProgress(entityName = "account", totalToProcess = total, processStartNanos = System.nanoTime()) _
 
         /* Process in a strictly sequential way, to avoid opening an unbounded number of requests on the http-client.
         * The size and partition of results is driven by the NodeOperator itself, were each page contains a

--- a/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
@@ -92,7 +92,7 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
      * Otherwise, any error will make Lorre proceed as expected by default (stop or wait for next cycle)
      */
     val attemptedProcessing =
-      if (ignoreProcessFailures.forall(ignore => ignore == "true" || ignore == "yes"))
+      if (ignoreProcessFailures.exists(ignore => ignore == "true" || ignore == "yes"))
         processing.recover {
           //swallow the error and proceed with the default behaviour
           case f@(AccountsProcessingFailed(_, _) | BlocksProcessingFailed(_, _) | DelegatesProcessingFailed(_, _)) =>

--- a/src/main/scala/tech/cryptonomic/conseil/config/Shared.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/config/Shared.scala
@@ -21,7 +21,8 @@ final case class BatchFetchConfiguration(
   blockOperationsConcurrencyLevel: Int,
   blockPageSize: Int,
   blockPageProcessingTimeout: FiniteDuration,
-  accountPageProcessingTimeout: FiniteDuration
+  accountPageProcessingTimeout: FiniteDuration,
+  delegatePageProcessingTimeout: FiniteDuration
 )
 
 /** configurations related to a chain-node network calls */

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
@@ -268,10 +268,12 @@ object TezosDatabaseOperations extends LazyLogging {
       copyAccountsToDelegateContracts(
         delegates.flatMap(_.content.values.flatMap(_.delegated_contracts)).toSet
       )
-    for {
+
+    (for {
       updated <- delegatesUpdateAction.map(_.sum)
       _ <- contractsUpdateAction
-    } yield updated
+    } yield updated).transactionally
+
   }
 
   /* Selects accounts corresponding to the given ids and copy the rows

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -184,7 +184,7 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
     import TezosTypes.Syntax._
 
     val reverseIndex =
-      accountsBlocksIndex.groupBy{case (id, blockRef) => blockRef._1}
+      accountsBlocksIndex.groupBy{ case (id, (blockHash, level)) => blockHash }
         .mapValues(_.keySet)
         .toMap
 
@@ -300,7 +300,7 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
     import TezosTypes.Syntax._
 
     val reverseIndex =
-      keysBlocksIndex.groupBy { case (pkh, blockRef) => blockRef._1 }
+      keysBlocksIndex.groupBy { case (pkh, (blockHash, level)) => blockHash }
        .mapValues(_.keySet)
        .toMap
 

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperatorTest.scala
@@ -13,7 +13,7 @@ import scala.concurrent.duration._
 class TezosNodeOperatorTest extends FlatSpec with MockFactory with Matchers with LazyLogging with ScalaFutures with IntegrationPatience {
   import ExecutionContext.Implicits.global
 
-  val config = BatchFetchConfiguration(1, 1, 500, 10 seconds, 10 seconds)
+  val config = BatchFetchConfiguration(1, 1, 500, 10 seconds, 10 seconds, 10 seconds)
 
   "getBlock" should "correctly fetch the genesis block" in {
     //given


### PR DESCRIPTION
Fixes #400 

The change loads accounts data and delegates data, using an endpoint based on the actual blockhash that referred the specific account, as to load the data as it was when the block was included in the chain.
This should improve consistency of the stored data, considering that now Lorre may consumes nodes' data only partially, in case of any unexpected issue.
After the change we should always expect conseil to provide a consistent picture of the chain.

As a side-effect, this change correctly implement the option to let Lorre proceed with the next cycle even in the case of a failure during block fetching.
This behaviour is now correctly activated by setting the environment variable
`LORRE_FAILURE_IGNORE` to `true` of `yes` 