### PR TITLE
412 - removed `IS TRUE` from query when `inverse = false`

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/util/DatabaseUtil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/util/DatabaseUtil.scala
@@ -194,7 +194,11 @@ object DatabaseUtil {
         case OperationType.endsWith => sql"LIKE '%#${vals.head}'"
         case OperationType.isnull => sql"ISNULL"
       }
-      concatenateSqlActions(op, sql" IS #${!inverse}")
+      if(inverse) {
+        concatenateSqlActions(op, sql" IS #${!inverse}")
+      } else {
+        op
+      }
     }
   }
 


### PR DESCRIPTION
fixes #412 

When `inverse` is set to `false`, `IS TRUE` won't be added. This will improve the query performance.