### PR TITLE
416 - More metadata: displayPriority, displayOrder

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -163,6 +163,8 @@ akka {
 # * data-type: String, since this value is later mapped to enum, values are limited to those supported by method
 #                      tech.cryptonomic.conseil.tezos.TezosPlatformDiscoveryOperations.mapType
 # * scale: Int, indicate to the UI how to display a value
+# * display-priority: relative weight, like title vs subtitle. Allowed values: [0, 1, 2]
+# * display-order: numeric value which the UI can use to sort the attributes for display
 #
 # And on entity level:
 # * display-name-plural: String

--- a/src/main/scala/tech/cryptonomic/conseil/config/MetadataConfiguration.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/config/MetadataConfiguration.scala
@@ -92,4 +92,6 @@ case class AttributeConfiguration(displayName: Option[String],
                                   dataFormat: Option[String] = None,
                                   valueMap: Option[Map[String, String]] = None,
                                   reference: Option[Map[String, String]] = None,
-                                  cacheConfig: Option[AttributeCacheConfiguration] = None)
+                                  cacheConfig: Option[AttributeCacheConfiguration] = None,
+                                  displayPriority: Option[Int] = None,
+                                  displayOrder: Option[Int] = None)

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/PlatformDiscoveryTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/PlatformDiscoveryTypes.scala
@@ -30,7 +30,9 @@ object PlatformDiscoveryTypes {
     dataFormat: Option[String] = None,
     valueMap: Option[Map[String, String]] = None,
     scale: Option[Int] = None,
-    reference: Option[Map[String, String]] = None
+    reference: Option[Map[String, String]] = None,
+    displayPriority: Option[Int] = None,
+    displayOrder: Option[Int] = None
   )
 
   /** Enumeration of data types */

--- a/src/main/scala/tech/cryptonomic/conseil/metadata/UnitTransformation.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/metadata/UnitTransformation.scala
@@ -58,6 +58,8 @@ class UnitTransformation(overrides: MetadataConfiguration) {
       scale = overrideAttribute.flatMap(_.scale),
       dataType = overrideAttribute.flatMap(_.dataType).map(mapType).getOrElse(attribute.dataType),
       valueMap = overrideAttribute.flatMap(_.valueMap).filter(_.nonEmpty),
-      reference = overrideAttribute.flatMap(_.reference).filter(_.nonEmpty))
+      reference = overrideAttribute.flatMap(_.reference).filter(_.nonEmpty),
+      displayPriority = overrideAttribute.flatMap(_.displayPriority),
+      displayOrder = overrideAttribute.flatMap(_.displayOrder))
   }
 }

--- a/src/test/scala/tech/cryptonomic/conseil/metadata/MetadataServiceTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/metadata/MetadataServiceTest.scala
@@ -300,7 +300,9 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
                 dataType = Some("hash"),
                 dataFormat = Some("dataFormat"),
                 valueMap = Some(Map("0" -> "value1", "1" -> "other value")),
-                reference = Some(Map("0" -> "value1", "1" -> "other value"))))))))))
+                reference = Some(Map("0" -> "value1", "1" -> "other value")),
+                displayPriority = Some(1),
+                displayOrder = Some(2)))))))))
 
       // when
       val result = sut(overwrittenConfiguration).getTableAttributes(EntityPath("entity", NetworkPath("mainnet", PlatformPath("tezos")))).futureValue
@@ -318,7 +320,9 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
         dataFormat = Some("dataFormat"),
         valueMap = Some(Map("0" -> "value1", "1" -> "other value")),
         reference = Some(Map("0" -> "value1", "1" -> "other value")),
-        scale = Some(6))))
+        scale = Some(6),
+        displayPriority = Some(1),
+        displayOrder = Some(2))))
     }
 
     "filter out a hidden attribute" in {


### PR DESCRIPTION
closes #416 

We need to add two more metadata properties at attribute level: displayPriority and displayOrder.

Priority will specify relative weight, like title vs subtitle. It would be 0, 1, 2 (high, medium, low). The idea is that we may drop items marked as "low" depending on display context.

Order is a numeric value which the UI can use to sort the attributes for display.