### PR TITLE
Reduce Lorre sleep interval

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -10,7 +10,7 @@ conseil: {
 
 # Runtime settings for Lorre process
 lorre: {
-  sleepInterval: 60 s
+  sleepInterval: 5 s
   bootupRetryInterval: 10 s
   bootupConnectionCheckTimeout: 10 s
   #Used to make sure Lorre records average fees every n iterations


### PR DESCRIPTION
Lorre currently waits a minute between iterations. As a result, when a user makes a Tezos transaction, they have to wait up to two mins before they see a confirmation through Conseil. To cut this time to under a minute for a better user experience, the Lorre wait time has been reduced. 