### PR TITLE
Fixes for Lorre sync issues

### DIFF
--- a/doc/conseil.sql
+++ b/doc/conseil.sql
@@ -424,8 +424,9 @@ CREATE INDEX ix_proposals_protocol ON public.proposals USING btree (protocol_has
 ALTER TABLE ONLY public.accounts
     ADD CONSTRAINT accounts_block_id_fkey FOREIGN KEY (block_id) REFERENCES public.blocks(hash);
 
-ALTER TABLE ONLY public.delegated_contracts
-    ADD CONSTRAINT contracts_delegate_pkh_fkey FOREIGN KEY (delegate_value) REFERENCES public.delegates(pkh);
+-- Disabling this constraint due to Tezos node issues preventing some delegates from being fetched.
+--ALTER TABLE ONLY public.delegated_contracts
+--    ADD CONSTRAINT contracts_delegate_pkh_fkey FOREIGN KEY (delegate_value) REFERENCES public.delegates(pkh);
 
 ALTER TABLE ONLY public.delegated_contracts
     ADD CONSTRAINT contracts_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.accounts(account_id);

--- a/doc/conseil.sql
+++ b/doc/conseil.sql
@@ -427,9 +427,6 @@ ALTER TABLE ONLY public.accounts
 ALTER TABLE ONLY public.delegated_contracts
     ADD CONSTRAINT contracts_delegate_pkh_fkey FOREIGN KEY (delegate_value) REFERENCES public.delegates(pkh);
 
-ALTER TABLE ONLY public.delegated_contracts
-    ADD CONSTRAINT contracts_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.accounts(account_id);
-
 ALTER TABLE ONLY public.delegates
     ADD CONSTRAINT delegates_block_id_fkey FOREIGN KEY (block_id) REFERENCES public.blocks(hash);
 

--- a/doc/conseil.sql
+++ b/doc/conseil.sql
@@ -425,7 +425,7 @@ ALTER TABLE ONLY public.accounts
     ADD CONSTRAINT accounts_block_id_fkey FOREIGN KEY (block_id) REFERENCES public.blocks(hash);
 
 ALTER TABLE ONLY public.delegated_contracts
-    ADD CONSTRAINT contracts_delegate_pkh_fkey FOREIGN KEY (delegate_value) REFERENCES public.delegates(pkh);
+    ADD CONSTRAINT contracts_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.accounts(account_id);
 
 ALTER TABLE ONLY public.delegates
     ADD CONSTRAINT delegates_block_id_fkey FOREIGN KEY (block_id) REFERENCES public.blocks(hash);

--- a/doc/conseil.sql
+++ b/doc/conseil.sql
@@ -425,6 +425,9 @@ ALTER TABLE ONLY public.accounts
     ADD CONSTRAINT accounts_block_id_fkey FOREIGN KEY (block_id) REFERENCES public.blocks(hash);
 
 ALTER TABLE ONLY public.delegated_contracts
+    ADD CONSTRAINT contracts_delegate_pkh_fkey FOREIGN KEY (delegate_value) REFERENCES public.delegates(pkh);
+
+ALTER TABLE ONLY public.delegated_contracts
     ADD CONSTRAINT contracts_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.accounts(account_id);
 
 ALTER TABLE ONLY public.delegates

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -11,11 +11,8 @@
 
     <logger name="com.base22" level="TRACE"/>
     <logger name="de.flapdoodle.embed.process" level="OFF"/>
-    <logger name="com.typesafe.slick" level="OFF"/>
-    <logger name="com.zaxxer.hikari" level="OFF"/>
-    <logger name="slick" level="OFF"/>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -11,8 +11,11 @@
 
     <logger name="com.base22" level="TRACE"/>
     <logger name="de.flapdoodle.embed.process" level="OFF"/>
+    <logger name="com.typesafe.slick" level="OFF"/>
+    <logger name="com.zaxxer.hikari" level="OFF"/>
+    <logger name="slick" level="OFF"/>
 
-    <root level="info">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
@@ -63,7 +63,7 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
   @tailrec
   private[this] def checkTezosConnection(): Unit = {
     Try {
-      Await.result(tezosNodeOperator.getBlockHead(), lorreConf.bootupConnectionCheckTimeout)
+      Await.result(tezosNodeOperator.getBlockHeadOnly(), lorreConf.bootupConnectionCheckTimeout)
     } match {
       case Failure(e) =>
         logger.error("Could not make initial connection to Tezos", e)

--- a/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
@@ -63,7 +63,7 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
   @tailrec
   private[this] def checkTezosConnection(): Unit = {
     Try {
-      Await.result(tezosNodeOperator.getBlockHeadOnly(), lorreConf.bootupConnectionCheckTimeout)
+      Await.result(tezosNodeOperator.getBareBlockHead(), lorreConf.bootupConnectionCheckTimeout)
     } match {
       case Failure(e) =>
         logger.error("Could not make initial connection to Tezos", e)

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -401,7 +401,7 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
     * @param hash      Hash of the block
     * @return          the block data wrapped in a `Future`
     */
-  def getBlockOnly(hash: BlockHash, offset: Option[Offset] = None): Future[BlockData] = {
+  def getBareBlock(hash: BlockHash, offset: Option[Offset] = None): Future[BlockData] = {
     import JsonDecoders.Circe.decodeLiftingTo
     import JsonDecoders.Circe.Blocks._
 
@@ -424,8 +424,8 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
     * Gets just the block head without associated data.
     * @return Block head
     */
-  def getBlockHeadOnly(): Future[BlockData]= {
-    getBlockOnly(blockHeadHash)
+  def getBareBlockHead(): Future[BlockData]= {
+    getBareBlock(blockHeadHash)
   }
 
   /**

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -13,7 +13,8 @@ import tech.cryptonomic.conseil.tezos.michelson.parser.JsonParser.Parser
 import cats.instances.future._
 import cats.syntax.applicative._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.math.max
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
@@ -222,12 +223,16 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
 
       val fetchCurrentQuorum =
         node.runAsyncGetQuery(network, s"blocks/$hashString~$offsetString/votes/current_quorum") flatMap { json =>
-          decodeLiftingTo[Future, Option[Int]](json)
+          var json2 = json
+          if(json=="") json2="0"
+          decodeLiftingTo[Future, Option[Int]](json2)
         }
 
-      val fetchCurrentProposal =
+      val fetchCurrentProposal: Future[Option[ProtocolId]] =
         node.runAsyncGetQuery(network, s"blocks/$hashString~$offsetString/votes/current_proposal") flatMap { json =>
-          decodeLiftingTo[Future, Option[ProtocolId]](json)
+          var json2 = json
+          if(json=="") json2="\"3M\""
+          decodeLiftingTo[Future, Option[ProtocolId]](json2)
         }
 
       (fetchCurrentQuorum, fetchCurrentProposal).mapN(CurrentVotes.apply)

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -259,7 +259,7 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
           decodeLiftingTo[Future, Option[Int]](json)
         }
 
-      val fetchCurrentProposal: Future[Option[ProtocolId]] =
+      val fetchCurrentProposal =
         node.runAsyncGetQuery(network, s"blocks/$hashString~$offsetString/votes/current_proposal") flatMap { json =>
           decodeLiftingTo[Future, Option[ProtocolId]](json)
         }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -332,7 +332,7 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
   }
 
   /**
-    * Fetches a single block from the chain, without waiting for the result
+    * Fetches a single block along with associated data from the chain, without waiting for the result
     * @param hash      Hash of the block
     * @return          the block data wrapped in a `Future`
     */
@@ -356,11 +356,35 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
   }
 
   /**
-    * Gets the block head.
+    * Fetches a single block from the chain without associated data, without waiting for the result
+    * @param hash      Hash of the block
+    * @return          the block data wrapped in a `Future`
+    */
+  def getBlockOnly(hash: BlockHash, offset: Option[Offset] = None): Future[BlockData] = {
+    import JsonDecoders.Circe.decodeLiftingTo
+    import JsonDecoders.Circe.Blocks._
+
+    val offsetString = offset.map(_.toString).getOrElse("")
+
+    node.runAsyncGetQuery(network, s"blocks/${hash.value}~$offsetString") flatMap { json =>
+      decodeLiftingTo[Future, BlockData](JS.sanitize(json))
+    }
+  }
+
+  /**
+    * Gets the block head along with associated data.
     * @return Block head
     */
   def getBlockHead(): Future[Block]= {
     getBlock(blockHeadHash)
+  }
+
+  /**
+    * Gets just the block head without associated data.
+    * @return Block head
+    */
+  def getBlockHeadOnly(): Future[BlockData]= {
+    getBlockOnly(blockHeadHash)
   }
 
   /**

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -256,16 +256,12 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
 
       val fetchCurrentQuorum =
         node.runAsyncGetQuery(network, s"blocks/$hashString~$offsetString/votes/current_quorum") flatMap { json =>
-          var json2 = json
-          if(json=="") json2="0"
-          decodeLiftingTo[Future, Option[Int]](json2)
+          decodeLiftingTo[Future, Option[Int]](json)
         }
 
       val fetchCurrentProposal: Future[Option[ProtocolId]] =
         node.runAsyncGetQuery(network, s"blocks/$hashString~$offsetString/votes/current_proposal") flatMap { json =>
-          var json2 = json
-          if(json=="") json2="\"3M\""
-          decodeLiftingTo[Future, Option[ProtocolId]](json2)
+          decodeLiftingTo[Future, Option[ProtocolId]](json)
         }
 
       (fetchCurrentQuorum, fetchCurrentProposal).mapN(CurrentVotes.apply)


### PR DESCRIPTION
This PR makes two changes to make Lorre more compliant with the recent behaviour of Tezos nodes:

- Lorre makes an initial connection check to Tezos by querying for the block head. While querying for the head, it also tried to fetch associated data related to governance, etc. However, since governance only kicked in, for example, on block ~210,000 on the Tezos `mainnet` the initial connection check keeps failing until the block data complies with the expected format. To get around this, new functions have been added to query only the block head and not any associated data.

- The newest version of the Tezos node returns error messages for certain `delegates` queries (see example below) and the corresponding data is not populated into our tables. Due to this, a foreign key constraint is violated when `delegated_contracts` are written (see screenshot below). Until we learn more about this Tezos issue and its resolution, the specific foreign key constraint has been removed.

Example of failed delegates query:

```json
[
  {
    "kind": "temporary",
    "id": "proto.001-PtCJ7pwo.tez.subtraction_underflow",
    "amounts": [
      "0",
      "13763256500"
    ]
  }
]
```

Example of foreign key issue:

![image](https://user-images.githubusercontent.com/931163/59653719-3e9f6700-9161-11e9-94f0-2e3eab50bd70.png)
