### PR TITLE
Fixes for Lorre sync issues, part II.

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -256,16 +256,14 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
 
       val fetchCurrentQuorum =
         node.runAsyncGetQuery(network, s"blocks/$hashString~$offsetString/votes/current_quorum") flatMap { json =>
-          var json2 = json
-          if(json=="") json2="0"
-          decodeLiftingTo[Future, Option[Int]](json2)
+          val nonEmptyJson = if (json.isEmpty) "0" else json
+          decodeLiftingTo[Future, Option[Int]](nonEmptyJson)
         }
 
       val fetchCurrentProposal =
         node.runAsyncGetQuery(network, s"blocks/$hashString~$offsetString/votes/current_proposal") flatMap { json =>
-          var json2 = json
-          if(json=="") json2="\"3M\""
-          decodeLiftingTo[Future, Option[ProtocolId]](json2)
+          val nonEmptyJson = if (json.isEmpty) """ "3M" """.trim else json
+          decodeLiftingTo[Future, Option[ProtocolId]](nonEmptyJson)
         }
 
       (fetchCurrentQuorum, fetchCurrentProposal).mapN(CurrentVotes.apply)

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -257,7 +257,6 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
       val fetchCurrentQuorum =
         node.runAsyncGetQuery(network, s"blocks/$hashString~$offsetString/votes/current_quorum") flatMap { json =>
           var json2 = json
-          decodeLiftingTo[Future, Option[Int]](json)
           if(json=="") json2="0"
           decodeLiftingTo[Future, Option[Int]](json2)
         }
@@ -265,7 +264,6 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
       val fetchCurrentProposal =
         node.runAsyncGetQuery(network, s"blocks/$hashString~$offsetString/votes/current_proposal") flatMap { json =>
           var json2 = json
-          decodeLiftingTo[Future, Option[ProtocolId]](json)
           if(json=="") json2="\"3M\""
           decodeLiftingTo[Future, Option[ProtocolId]](json2)
         }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -256,12 +256,18 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
 
       val fetchCurrentQuorum =
         node.runAsyncGetQuery(network, s"blocks/$hashString~$offsetString/votes/current_quorum") flatMap { json =>
+          var json2 = json
           decodeLiftingTo[Future, Option[Int]](json)
+          if(json=="") json2="0"
+          decodeLiftingTo[Future, Option[Int]](json2)
         }
 
       val fetchCurrentProposal =
         node.runAsyncGetQuery(network, s"blocks/$hashString~$offsetString/votes/current_proposal") flatMap { json =>
+          var json2 = json
           decodeLiftingTo[Future, Option[ProtocolId]](json)
+          if(json=="") json2="\"3M\""
+          decodeLiftingTo[Future, Option[ProtocolId]](json2)
         }
 
       (fetchCurrentQuorum, fetchCurrentProposal).mapN(CurrentVotes.apply)


### PR DESCRIPTION
This is a tactical follow up to #425. 

This PR adds a hack by entering placeholder values for certain governance data for blocks which were baked before governance data was available for Tezos. 