### PR TITLE
More verbose logging for Lorre

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
@@ -303,8 +303,8 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
       }
 
     val saveAccounts = db.run(TezosDb.getLatestAccountsFromCheckpoint) map { checkpoints =>
-          logger.debug(
-            "I loaded all stored account references and will proceed to fetch updated information from the chain"
+          logger.info(
+            "I loaded all checkpointed accounts from the DB and will proceed to fetch updated accounts information from the chain"
           )
           val (pages, total) = tezosNodeOperator.getAccountsForBlocks(checkpoints)
 
@@ -323,17 +323,17 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
           checkpoints
         }
 
-    logger.debug("Selecting all accounts touched in the checkpoint table, this might take a while...")
+    logger.info("Selecting all accounts touched in the checkpoint table, this might take a while...")
     saveAccounts.andThen {
       //additional cleanup, that can fail with no downsides
       case Success(checkpoints) =>
         val processed = Some(checkpoints.keySet)
-        logger.debug("Cleaning checkpointed accounts..")
+        logger.info("Cleaning checkpointed accounts..")
         Await.result(
           db.run(TezosDb.cleanAccountsCheckpoint(processed)),
           atMost = batchingConf.accountPageProcessingTimeout
         )
-        logger.debug("Done cleaning checkpointed accounts.")
+        logger.info("Done cleaning checkpointed accounts.")
       case _ =>
         ()
     }.transform {
@@ -365,7 +365,7 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
       }
 
     val saveDelegates = db.run(TezosDb.getLatestDelegatesFromCheckpoint) map { checkpoints =>
-          logger.debug(
+          logger.info(
             "I loaded all stored delegate references and will proceed to fetch updated information from the chain"
           )
           val (pages, total) = tezosNodeOperator.getDelegatesForBlocks(checkpoints)
@@ -389,12 +389,12 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
       //additional cleanup, that can fail with no downsides
       case Success(checkpoints) =>
         val processed = Some(checkpoints.keySet)
-        logger.debug("Cleaning checkpointed delegates..")
+        logger.info("Cleaning checkpointed delegates..")
         Await.result(
           db.run(TezosDb.cleanDelegatesCheckpoint(processed)),
           atMost = batchingConf.delegatePageProcessingTimeout
         )
-        logger.debug("Done cleaning checkpointed delegates.")
+        logger.info("Done cleaning checkpointed delegates.")
       case _ =>
         ()
     }.transform {

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
@@ -342,7 +342,7 @@ object TezosDatabaseOperations extends LazyLogging {
 
   /** Writes ballots to the database */
   def writeVotingBallots(ballots: List[Voting.Ballot], block: Block): DBIO[Option[Int]] = {
-    logger.info(s"""Writing ${ballots.length} ballots to the DB..""")
+    logger.info(s"""Writing ${ballots.length} ballots for block ${block.data.hash.value} at level ${block.data.header.level} to the DB..""")
     Tables.Ballots ++= (block, ballots).convertToA[List, Tables.BallotsRow]
   }
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeFetchers.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeFetchers.scala
@@ -69,7 +69,8 @@ trait BlocksDataFetchers {
     private def makeUrl = (offset: Offset) => s"blocks/${hashRef.value}~${String.valueOf(offset)}"
 
     //fetch a future stream of values
-    override val fetchData =
+    override val fetchData = {
+      logger.info("Fetching blocks")
       Kleisli(
         offsets =>
           node.runBatchedGetQuery(network, offsets, makeUrl, fetchConcurrency).onError {
@@ -85,6 +86,7 @@ trait BlocksDataFetchers {
                 .pure[Future]
           }
       )
+    }
 
     // decode with `JsonDecoders`
     override val decodeData = Kleisli { json =>
@@ -115,7 +117,8 @@ trait BlocksDataFetchers {
 
     private val makeUrl = (hash: BlockHash) => s"blocks/${hash.value}/operations"
 
-    override val fetchData =
+    override val fetchData = {
+      logger.info("Fetching operations")
       Kleisli(
         hashes =>
           node.runBatchedGetQuery(network, hashes, makeUrl, fetchConcurrency).onError {
@@ -130,6 +133,7 @@ trait BlocksDataFetchers {
                 .pure[Future]
           }
       )
+    }
 
     override val decodeData = Kleisli(
       json =>

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeFetchers.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeFetchers.scala
@@ -70,9 +70,9 @@ trait BlocksDataFetchers {
 
     //fetch a future stream of values
     override val fetchData = {
-      logger.info("Fetching blocks")
       Kleisli(
-        offsets =>
+        offsets => {
+          logger.info("Fetching blocks")
           node.runBatchedGetQuery(network, offsets, makeUrl, fetchConcurrency).onError {
             case err =>
               logger
@@ -85,6 +85,7 @@ trait BlocksDataFetchers {
                 )
                 .pure[Future]
           }
+        }
       )
     }
 
@@ -118,9 +119,9 @@ trait BlocksDataFetchers {
     private val makeUrl = (hash: BlockHash) => s"blocks/${hash.value}/operations"
 
     override val fetchData = {
-      logger.info("Fetching operations")
       Kleisli(
-        hashes =>
+        hashes => {
+          logger.info("Fetching operations")
           node.runBatchedGetQuery(network, hashes, makeUrl, fetchConcurrency).onError {
             case err =>
               logger
@@ -132,6 +133,7 @@ trait BlocksDataFetchers {
                 )
                 .pure[Future]
           }
+        }
       )
     }
 
@@ -165,7 +167,8 @@ trait BlocksDataFetchers {
 
     override val fetchData =
       Kleisli(
-        hashes =>
+        hashes => {
+          logger.info("Fetching current quorum")
           node.runBatchedGetQuery(network, hashes, makeUrl, fetchConcurrency).onError {
             case err =>
               logger
@@ -177,6 +180,7 @@ trait BlocksDataFetchers {
                 )
                 .pure[Future]
           }
+        }
       )
 
     override val decodeData = Kleisli(
@@ -204,7 +208,8 @@ trait BlocksDataFetchers {
 
     override val fetchData =
       Kleisli(
-        hashes =>
+        hashes => {
+          logger.info("Fetching current proposal")
           node.runBatchedGetQuery(network, hashes, makeUrl, fetchConcurrency).onError {
             case err =>
               logger
@@ -216,6 +221,7 @@ trait BlocksDataFetchers {
                 )
                 .pure[Future]
           }
+        }
       )
 
     override val decodeData = Kleisli(
@@ -246,7 +252,8 @@ trait BlocksDataFetchers {
 
     override val fetchData =
       Kleisli(
-        blocks =>
+        blocks => {
+          logger.info("Fetching all proposals")
           node.runBatchedGetQuery(network, blocks, makeUrl, fetchConcurrency).onError {
             case err =>
               logger
@@ -258,6 +265,7 @@ trait BlocksDataFetchers {
                 )
                 .pure[Future]
           }
+        }
       )
 
     override val decodeData = Kleisli { json =>
@@ -288,7 +296,8 @@ trait BlocksDataFetchers {
 
     override val fetchData =
       Kleisli(
-        blocks =>
+        blocks => {
+          logger.info("Fetching bakers")
           node.runBatchedGetQuery(network, blocks, makeUrl, fetchConcurrency).onError {
             case err =>
               logger
@@ -300,6 +309,7 @@ trait BlocksDataFetchers {
                 )
                 .pure[Future]
           }
+        }
       )
 
     override val decodeData = Kleisli { json =>
@@ -330,7 +340,8 @@ trait BlocksDataFetchers {
 
     override val fetchData =
       Kleisli(
-        blocks =>
+        blocks => {
+          logger.info("Fetching ballots")
           node.runBatchedGetQuery(network, blocks, makeUrl, fetchConcurrency).onError {
             case err =>
               logger
@@ -342,6 +353,7 @@ trait BlocksDataFetchers {
                 )
                 .pure[Future]
           }
+        }
       )
 
     override val decodeData = Kleisli { json =>
@@ -410,7 +422,8 @@ trait AccountsDataFetchers {
     private val makeUrl = (id: AccountId) => s"blocks/${referenceBlock.value}/context/contracts/${id.id}"
 
     override val fetchData = Kleisli(
-      ids =>
+      ids => {
+        logger.info("Fetching accounts")
         node.runBatchedGetQuery(network, ids, makeUrl, accountsFetchConcurrency).onError {
           case err =>
             logger
@@ -422,6 +435,7 @@ trait AccountsDataFetchers {
               )
               .pure[Future]
         }
+      }
     )
 
     override def decodeData = Kleisli { json =>
@@ -445,7 +459,8 @@ trait AccountsDataFetchers {
     private val makeUrl = (pkh: PublicKeyHash) => s"blocks/${referenceBlock.value}/context/delegates/${pkh.value}"
 
     override val fetchData = Kleisli(
-      keyHashes =>
+      keyHashes => {
+        logger.info("Fetching delegated contracts")
         node.runBatchedGetQuery(network, keyHashes, makeUrl, accountsFetchConcurrency).onError {
           case err =>
             logger
@@ -457,6 +472,7 @@ trait AccountsDataFetchers {
               )
               .pure[Future]
         }
+      }
     )
 
     override def decodeData = Kleisli { json =>

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeFetchers.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeFetchers.scala
@@ -72,7 +72,7 @@ trait BlocksDataFetchers {
     override val fetchData = {
       Kleisli(
         offsets => {
-          logger.info("Fetching blocks for offsets ${offsets.min} to ${offsets.max}")
+          logger.info(s"""Fetching blocks for offsets ${offsets.min} to ${offsets.max}""")
           node.runBatchedGetQuery(network, offsets, makeUrl, fetchConcurrency).onError {
             case err =>
               logger

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeFetchers.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeFetchers.scala
@@ -72,7 +72,7 @@ trait BlocksDataFetchers {
     override val fetchData = {
       Kleisli(
         offsets => {
-          logger.info("Fetching blocks")
+          logger.info("Fetching blocks for offsets ${offsets.min} to ${offsets.max}")
           node.runBatchedGetQuery(network, offsets, makeUrl, fetchConcurrency).onError {
             case err =>
               logger

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -534,6 +534,8 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
     import cats.instances.list._
     import tech.cryptonomic.conseil.generic.chain.DataFetcher.{fetch, fetchMerge}
 
+    logger.info("Fetching block data in range: " + levelRange)
+
     val (hashRef, levelRef) = reference
     require(levelRange.start >= 0 && levelRange.end <= levelRef)
     val offsets = levelRange.map(lvl => levelRef - lvl).toList


### PR DESCRIPTION
It is currently difficult to operate Lorre as it is hard to follow what it is specifically doing at any point. Especially when there is a failure, no diagnosis can be made unless an informed developer runs Lorre locally and tries to recreate the failure conditions with full debug logging.

As Lorre follows a pretty well defined pipeline of actions, it would be immensely valuable to verbosely print information about all interactions it is undertaking with the database and the blockchain node. This way, it becomes much easier to diagnose issues and choke points without even having deep knowledge of the system. We should, in fact, err in favour of verbose logging.

This PR adds several logging statements to make it clearer when Lorre is interacting with the databases or starting a new step of its pipeline. Some debug statements have been changed into info statements. 

This is only a beginning as much more granular logging can be added.  