### PR TITLE
441 - Metadata currency info

### DIFF
--- a/src/main/resources/metadata.conf
+++ b/src/main/resources/metadata.conf
@@ -15,6 +15,8 @@
 # * display-priority: relative weight, like title vs subtitle. Allowed values: [0, 1, 2]
 # * display-order: numeric value which the UI can use to sort the attributes for display
 # * sufficient-for-query: Boolean, which is for checking if predicate on this field is sufficient to make a query
+# * currency-symbol: used in context of account balances, example: "ꜩ"
+# * currency-symbol-code: used in context of account balances, example: 42793
 #
 # And on entity level:
 # * display-name-plural: String

--- a/src/main/scala/tech/cryptonomic/conseil/config/MetadataConfiguration.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/config/MetadataConfiguration.scala
@@ -105,5 +105,7 @@ case class AttributeConfiguration(
     reference: Option[Map[String, String]] = None,
     cacheConfig: Option[AttributeCacheConfiguration] = None,
     displayPriority: Option[Int] = None,
-    displayOrder: Option[Int] = None
+    displayOrder: Option[Int] = None,
+    currencySymbol: Option[String] = None,
+    currencySymbolCode: Option[Int] = None
 )

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/PlatformDiscoveryTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/PlatformDiscoveryTypes.scala
@@ -47,7 +47,9 @@ object PlatformDiscoveryTypes {
       reference: Option[Map[String, String]] = None,
       displayPriority: Option[Int] = None,
       displayOrder: Option[Int] = None,
-      sufficientForQuery: Option[Boolean] = None
+      sufficientForQuery: Option[Boolean] = None,
+      currencySymbol: Option[String] = None,
+      currencySymbolCode: Option[Int] = None
   ) {
 
     /** Checks if attribute is valid for predicate */
@@ -62,7 +64,8 @@ object PlatformDiscoveryTypes {
   /** Enumeration of data types */
   object DataType extends Enumeration {
     type DataType = Value
-    val Enum, Hex, Binary, Date, DateTime, String, Hash, AccountAddress, Int, LargeInt, Decimal, Boolean = Value
+    val Enum, Hex, Binary, Date, DateTime, String, Hash, AccountAddress, Int, LargeInt, Decimal, Currency, Boolean =
+      Value
   }
 
   /** Enumeration of key types */

--- a/src/main/scala/tech/cryptonomic/conseil/metadata/UnitTransformation.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/metadata/UnitTransformation.scala
@@ -64,7 +64,9 @@ class UnitTransformation(overrides: MetadataConfiguration) {
         valueMap = overrideAttribute.flatMap(_.valueMap).filter(_.nonEmpty),
         reference = overrideAttribute.flatMap(_.reference).filter(_.nonEmpty),
         displayPriority = overrideAttribute.flatMap(_.displayPriority),
-        displayOrder = overrideAttribute.flatMap(_.displayOrder)
+        displayOrder = overrideAttribute.flatMap(_.displayOrder),
+        currencySymbol = overrideAttribute.flatMap(_.currencySymbol),
+        currencySymbolCode = overrideAttribute.flatMap(_.currencySymbolCode)
       )
     }
 }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperations.scala
@@ -39,6 +39,7 @@ object TezosPlatformDiscoveryOperations {
       case "bool" => DataType.Boolean
       case "hash" => DataType.Hash
       case "accountAddress" => DataType.AccountAddress
+      case "currency" => DataType.Currency
       case _ => DataType.String
     }
 }

--- a/src/test/scala/tech/cryptonomic/conseil/metadata/MetadataServiceTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/metadata/MetadataServiceTest.scala
@@ -527,7 +527,9 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
                                         valueMap = Some(Map("0" -> "value1", "1" -> "other value")),
                                         reference = Some(Map("0" -> "value1", "1" -> "other value")),
                                         displayPriority = Some(1),
-                                        displayOrder = Some(2)
+                                        displayOrder = Some(2),
+                                        currencySymbol = Some("ꜩ"),
+                                        currencySymbolCode = Some(42793)
                                       )
                                 )
                               )
@@ -559,7 +561,9 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
               reference = Some(Map("0" -> "value1", "1" -> "other value")),
               scale = Some(6),
               displayPriority = Some(1),
-              displayOrder = Some(2)
+              displayOrder = Some(2),
+              currencySymbol = Some("ꜩ"),
+              currencySymbolCode = Some(42793)
             )
           )
         )

--- a/src/test/scala/tech/cryptonomic/conseil/routes/PlatformDiscoveryTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/routes/PlatformDiscoveryTest.scala
@@ -6,17 +6,10 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{Matchers, WordSpec}
 import tech.cryptonomic.conseil.config.Platforms.{PlatformsConfiguration, TezosConfiguration, TezosNodeConfiguration}
 import tech.cryptonomic.conseil.config.Types.PlatformName
-import tech.cryptonomic.conseil.config.{
-  AttributeConfiguration,
-  EntityConfiguration,
-  MetadataConfiguration,
-  NetworkConfiguration,
-  PlatformConfiguration,
-  Platforms
-}
+import tech.cryptonomic.conseil.config.{AttributeConfiguration, EntityConfiguration, MetadataConfiguration, NetworkConfiguration, PlatformConfiguration, Platforms}
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.DataType.Int
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.KeyType.NonKey
-import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.{Attribute, Entity}
+import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.{Attribute, AttributeCacheConfiguration, Entity}
 import tech.cryptonomic.conseil.metadata.{AttributeValuesCacheConfiguration, MetadataService, UnitTransformation}
 import tech.cryptonomic.conseil.tezos.TezosPlatformDiscoveryOperations
 import tech.cryptonomic.conseil.util.JsonUtil.toListOfMaps
@@ -253,8 +246,12 @@ class PlatformDiscoveryTest extends WordSpec with Matchers with ScalatestRouteTe
                                         dataType = Some("hash"),
                                         dataFormat = Some("dataFormat"),
                                         valueMap = Some(Map("0" -> "value")),
-                                        reference = Some(Map("0" -> "value"))
-                                      )
+                                        reference = Some(Map("0" -> "value")),
+                                        displayPriority = Some(1),
+                                        displayOrder = Some(1),
+                                        currencySymbol = Some("ꜩ"),
+                                        currencySymbolCode = Some(42793)
+                                    )
                                 )
                               )
                         )
@@ -283,6 +280,10 @@ class PlatformDiscoveryTest extends WordSpec with Matchers with ScalatestRouteTe
           headResult("valueMap") shouldBe Map("0" -> "value")
           headResult("dataType") shouldBe "Hash"
           headResult("reference") shouldBe Map("0" -> "value")
+          headResult("displayPriority") shouldBe 1
+          headResult("displayOrder") shouldBe 1
+          headResult("currencySymbol") shouldBe "ꜩ"
+          headResult("currencySymbolCode") shouldBe 42793
         }
       }
 


### PR DESCRIPTION
closes #441 

Add two new, optional metadata properties at attribute level: currencySymbol and currencySymbolCode. For Tezos, for example, currencySymbolCode in decimal is 42793, currencySymbol might be ꜩ or XTZ.