### PR TITLE
467 - Store originated contracts ids as csv

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
@@ -17,6 +17,9 @@ object DatabaseConversions {
   def concatenateToString[A, T[_] <: scala.collection.GenTraversableOnce[_]](traversable: T[A]): String =
     traversable.mkString("[", ",", "]")
 
+  def toCommaSeparated[A, T[_] <: scala.collection.GenTraversableOnce[_]](traversable: T[A]): String =
+    traversable.mkString(",")
+
   def extractBigDecimal(number: PositiveBigNumber): Option[BigDecimal] = number match {
     case PositiveDecimal(value) => Some(value)
     case _ => None
@@ -259,7 +262,7 @@ object DatabaseConversions {
         consumedGas = metadata.operation_result.consumed_gas.flatMap(extractBigDecimal),
         storageSize = metadata.operation_result.storage_size.flatMap(extractBigDecimal),
         paidStorageSizeDiff = metadata.operation_result.paid_storage_size_diff.flatMap(extractBigDecimal),
-        originatedContracts = metadata.operation_result.originated_contracts.map(_.map(_.id)).map(concatenateToString),
+        originatedContracts = metadata.operation_result.originated_contracts.map(_.map(_.id)).map(toCommaSeparated),
         blockHash = block.data.hash.value,
         blockLevel = block.data.header.level,
         timestamp = toSql(block.data.header.timestamp)

--- a/src/test/scala/tech/cryptonomic/conseil/routes/PlatformDiscoveryTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/routes/PlatformDiscoveryTest.scala
@@ -6,7 +6,14 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{Matchers, WordSpec}
 import tech.cryptonomic.conseil.config.Platforms.{PlatformsConfiguration, TezosConfiguration, TezosNodeConfiguration}
 import tech.cryptonomic.conseil.config.Types.PlatformName
-import tech.cryptonomic.conseil.config.{AttributeConfiguration, EntityConfiguration, MetadataConfiguration, NetworkConfiguration, PlatformConfiguration, Platforms}
+import tech.cryptonomic.conseil.config.{
+  AttributeConfiguration,
+  EntityConfiguration,
+  MetadataConfiguration,
+  NetworkConfiguration,
+  PlatformConfiguration,
+  Platforms
+}
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.DataType.Int
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.KeyType.NonKey
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.{Attribute, AttributeCacheConfiguration, Entity}
@@ -251,7 +258,7 @@ class PlatformDiscoveryTest extends WordSpec with Matchers with ScalatestRouteTe
                                         displayOrder = Some(1),
                                         currencySymbol = Some("ꜩ"),
                                         currencySymbolCode = Some(42793)
-                                    )
+                                      )
                                 )
                               )
                         )

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DatabaseConversionsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DatabaseConversionsTest.scala
@@ -606,7 +606,7 @@ class DatabaseConversionsTest
           case Some(Decimal(bignumber)) => converted.paidStorageSizeDiff.value shouldBe bignumber
           case _ => converted.paidStorageSizeDiff shouldBe 'empty
         }
-        converted.originatedContracts.value shouldBe "[KT1VuJAgTJT5x2Y2S3emAVSbUA5nST7j3QE4]"
+        converted.originatedContracts.value shouldBe "KT1VuJAgTJT5x2Y2S3emAVSbUA5nST7j3QE4,KT1Hx96yGgGk2q7Jmwm1dnYAMdRoLJNn5gnC"
 
         forAll(
           converted.level ::

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DatabaseConversionsTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DatabaseConversionsTestFixtures.scala
@@ -233,7 +233,9 @@ trait DBConversionsData {
               )
             )
           ),
-          originated_contracts = Some(List(ContractId("KT1VuJAgTJT5x2Y2S3emAVSbUA5nST7j3QE4"))),
+          originated_contracts = Some(
+            ContractId("KT1VuJAgTJT5x2Y2S3emAVSbUA5nST7j3QE4") :: ContractId("KT1Hx96yGgGk2q7Jmwm1dnYAMdRoLJNn5gnC") :: Nil
+          ),
           consumed_gas = Some(Decimal(11262)),
           storage_size = Some(Decimal(46)),
           paid_storage_size_diff = Some(Decimal(46)),


### PR DESCRIPTION
fixes #467 
remove the enclosing brackets in conseil storage format for originated_contracts