### PR TITLE
411 - Add the block level column to the operations group data

### DIFF
--- a/doc/conseil.sql
+++ b/doc/conseil.sql
@@ -226,7 +226,8 @@ CREATE TABLE public.operation_groups (
     hash character varying NOT NULL,
     branch character varying NOT NULL,
     signature character varying,
-    block_id character varying NOT NULL
+    block_id character varying NOT NULL,
+    block_level integer NOT NULL
 );
 
 
@@ -396,6 +397,7 @@ ALTER TABLE ONLY public.operations
 
 CREATE INDEX fki_block ON public.operation_groups USING btree (block_id);
 
+CREATE INDEX ix_operation_groups_block_level ON public.operation_groups USING btree (block_level);
 
 --
 -- TOC entry 2065 (class 1259 OID 7467562)

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
@@ -114,7 +114,8 @@ object DatabaseConversions {
           hash = og.hash.value,
           branch = og.branch.value,
           signature = og.signature.map(_.value),
-          blockId = from.data.hash.value
+          blockId = from.data.hash.value,
+          blockLevel = from.data.header.level
         )
       }
   }

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
@@ -290,7 +290,8 @@ trait TezosDataGeneration extends RandomGenerationKit {
             hash = generateHash(10),
             branch = generateHash(10),
             signature = Some(s"sig${generateHash(10)}"),
-            blockId = block.hash
+            blockId = block.hash,
+            blockLevel = block.level
           )
       )
       .toList

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
@@ -249,7 +249,8 @@ class TezosPlatformDiscoveryOperationsTest
               Attribute("hash", "Hash", DataType.String, None, KeyType.UniqueKey, "operation_groups"),
               Attribute("branch", "Branch", DataType.String, None, KeyType.NonKey, "operation_groups"),
               Attribute("signature", "Signature", DataType.String, None, KeyType.NonKey, "operation_groups"),
-              Attribute("block_id", "Block id", DataType.String, None, KeyType.NonKey, "operation_groups")
+              Attribute("block_id", "Block id", DataType.String, None, KeyType.NonKey, "operation_groups"),
+              Attribute("block_level", "Block level", DataType.Int, None, KeyType.UniqueKey, "operation_groups")
             )
           )
       }


### PR DESCRIPTION
closes #411 

## requires database schema changes

The `operation_groups` table acquires a new indexed column

```sql
ALTER TABLE operation_groups ADD column block_level integer NOT NULL;
 CREATE INDEX ix_operation_groups_block_level ON public.operation_groups USING btree (block_level); 
```