### PR TITLE
402 - Add priority column to the blocks table

### DIFF
--- a/doc/conseil.sql
+++ b/doc/conseil.sql
@@ -156,9 +156,9 @@ CREATE TABLE public.blocks (
     meta_cycle_position integer,
     meta_voting_period integer,
     meta_voting_period_position integer,
-    expected_commitment boolean
+    expected_commitment boolean,
+    priority integer
 );
-
 
 --
 -- TOC entry 188 (class 1259 OID 7467507)

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
@@ -100,7 +100,8 @@ object DatabaseConversions {
         metaCyclePosition = metadata.map(_.level.cycle_position),
         metaVotingPeriod = metadata.map(_.level.voting_period),
         metaVotingPeriodPosition = metadata.map(_.level.voting_period_position),
-        expectedCommitment = metadata.map(_.level.expected_commitment)
+        expectedCommitment = metadata.map(_.level.expected_commitment),
+        priority = header.priority
       )
     }
   }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
@@ -415,7 +415,8 @@ trait Tables {
     *  @param metaCyclePosition Database column meta_cycle_position SqlType(int4), Default(None)
     *  @param metaVotingPeriod Database column meta_voting_period SqlType(int4), Default(None)
     *  @param metaVotingPeriodPosition Database column meta_voting_period_position SqlType(int4), Default(None)
-    *  @param expectedCommitment Database column expected_commitment SqlType(bool), Default(None) */
+    *  @param expectedCommitment Database column expected_commitment SqlType(bool), Default(None)
+    *  @param priority Database column priority SqlType(int4), Default(None) */
   case class BlocksRow(
       level: Int,
       proto: Int,
@@ -441,7 +442,8 @@ trait Tables {
       metaCyclePosition: Option[Int] = None,
       metaVotingPeriod: Option[Int] = None,
       metaVotingPeriodPosition: Option[Int] = None,
-      expectedCommitment: Option[Boolean] = None
+      expectedCommitment: Option[Boolean] = None,
+      priority: Option[Int] = None
   )
 
   /** GetResult implicit for fetching BlocksRow objects using plain SQL queries */
@@ -480,20 +482,21 @@ trait Tables {
       <<?[Int],
       <<?[Int],
       <<?[Int],
-      <<?[Boolean]
+      <<?[Boolean],
+      <<?[Int]
     )
   }
 
   /** Table description of table blocks. Objects of this class serve as prototypes for rows in queries. */
   class Blocks(_tableTag: Tag) extends profile.api.Table[BlocksRow](_tableTag, "blocks") {
     def * =
-      (level :: proto :: predecessor :: timestamp :: validationPass :: fitness :: context :: signature :: protocol :: chainId :: hash :: operationsHash :: periodKind :: currentExpectedQuorum :: activeProposal :: baker :: nonceHash :: consumedGas :: metaLevel :: metaLevelPosition :: metaCycle :: metaCyclePosition :: metaVotingPeriod :: metaVotingPeriodPosition :: expectedCommitment :: HNil)
+      (level :: proto :: predecessor :: timestamp :: validationPass :: fitness :: context :: signature :: protocol :: chainId :: hash :: operationsHash :: periodKind :: currentExpectedQuorum :: activeProposal :: baker :: nonceHash :: consumedGas :: metaLevel :: metaLevelPosition :: metaCycle :: metaCyclePosition :: metaVotingPeriod :: metaVotingPeriodPosition :: expectedCommitment :: priority :: HNil)
         .mapTo[BlocksRow]
 
     /** Maps whole row to an option. Useful for outer joins. */
     def ? =
       (Rep.Some(level) :: Rep.Some(proto) :: Rep.Some(predecessor) :: Rep.Some(timestamp) :: Rep.Some(validationPass) :: Rep
-            .Some(fitness) :: context :: signature :: Rep.Some(protocol) :: chainId :: Rep.Some(hash) :: operationsHash :: periodKind :: currentExpectedQuorum :: activeProposal :: baker :: nonceHash :: consumedGas :: metaLevel :: metaLevelPosition :: metaCycle :: metaCyclePosition :: metaVotingPeriod :: metaVotingPeriodPosition :: expectedCommitment :: HNil).shaped
+            .Some(fitness) :: context :: signature :: Rep.Some(protocol) :: chainId :: Rep.Some(hash) :: operationsHash :: periodKind :: currentExpectedQuorum :: activeProposal :: baker :: nonceHash :: consumedGas :: metaLevel :: metaLevelPosition :: metaCycle :: metaCyclePosition :: metaVotingPeriod :: metaVotingPeriodPosition :: expectedCommitment :: priority :: HNil).shaped
         .<>(
           r =>
             BlocksRow(
@@ -521,7 +524,8 @@ trait Tables {
               r(21).asInstanceOf[Option[Int]],
               r(22).asInstanceOf[Option[Int]],
               r(23).asInstanceOf[Option[Int]],
-              r(24).asInstanceOf[Option[Boolean]]
+              r(24).asInstanceOf[Option[Boolean]],
+              r(25).asInstanceOf[Option[Int]]
             ),
           (_: Any) => throw new Exception("Inserting into ? projection not supported.")
         )
@@ -601,6 +605,9 @@ trait Tables {
 
     /** Database column expected_commitment SqlType(bool), Default(None) */
     val expectedCommitment: Rep[Option[Boolean]] = column[Option[Boolean]]("expected_commitment", O.Default(None))
+
+    /** Database column priority SqlType(int4), Default(None) */
+    val priority: Rep[Option[Int]] = column[Option[Int]]("priority", O.Default(None))
 
     /** Uniqueness Index over (hash) (database name blocks_hash_key) */
     val index1 = index("blocks_hash_key", hash :: HNil, unique = true)

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -13,8 +13,7 @@ import tech.cryptonomic.conseil.tezos.michelson.parser.JsonParser.Parser
 import cats.instances.future._
 import cats.syntax.applicative._
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future}
 import scala.math.max
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -102,6 +102,7 @@ object TezosTypes {
       validation_pass: Int,
       operations_hash: Option[String],
       fitness: Seq[String],
+      priority: Option[Int],
       context: String,
       signature: Option[String]
   )

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DatabaseConversionsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DatabaseConversionsTest.scala
@@ -121,7 +121,8 @@ class DatabaseConversionsTest
           'metaCyclePosition (metadata.map(_.level.cycle_position)),
           'metaVotingPeriod (metadata.map(_.level.voting_period)),
           'metaVotingPeriodPosition (metadata.map(_.level.voting_period_position)),
-          'expectedCommitment (metadata.map(_.level.expected_commitment))
+          'expectedCommitment (metadata.map(_.level.expected_commitment)),
+          'priority (block.data.header.priority)
         )
 
         metadata.map(_.consumed_gas) match {

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
@@ -125,6 +125,7 @@ class TezosDatabaseOperationsTest
                 case PositiveDecimal(value) => Some(value)
                 case _ => None
               }
+              row.priority.value shouldEqual block.data.header.priority.value
           }
 
           val dbBlocksAndGroups =
@@ -1272,7 +1273,8 @@ class TezosDatabaseOperationsTest
             "meta_cycle_position" -> None,
             "meta_voting_period" -> None,
             "meta_voting_period_position" -> None,
-            "expected_commitment" -> None
+            "expected_commitment" -> None,
+            "priority" -> None
           ),
           Map(
             "operations_hash" -> None,
@@ -1299,7 +1301,8 @@ class TezosDatabaseOperationsTest
             "meta_cycle_position" -> None,
             "meta_voting_period" -> None,
             "meta_voting_period_position" -> None,
-            "expected_commitment" -> None
+            "expected_commitment" -> None,
+            "priority" -> None
           )
         )
       }

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
@@ -130,6 +130,7 @@ trait TezosDataGeneration extends RandomGenerationKit {
             validation_pass = 0,
             operations_hash = None,
             fitness = Seq.empty,
+            priority = Some(0),
             context = s"context$level",
             signature = Some(s"sig${generateHash(10)}")
           ),

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
@@ -10,7 +10,11 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{Matchers, OptionValues, WordSpec}
 import slick.dbio
 import tech.cryptonomic.conseil.config.MetadataConfiguration
-import tech.cryptonomic.conseil.generic.chain.DataTypes.{HighCardinalityAttribute, InvalidAttributeDataType, InvalidAttributeFilterLength}
+import tech.cryptonomic.conseil.generic.chain.DataTypes.{
+  HighCardinalityAttribute,
+  InvalidAttributeDataType,
+  InvalidAttributeFilterLength
+}
 import tech.cryptonomic.conseil.generic.chain.MetadataOperations
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes._
 import tech.cryptonomic.conseil.metadata.AttributeValuesCacheConfiguration
@@ -171,7 +175,8 @@ class TezosPlatformDiscoveryOperationsTest
                 KeyType.NonKey,
                 "blocks"
               ),
-              Attribute("expected_commitment", "Expected commitment", DataType.Boolean, None, KeyType.NonKey, "blocks")
+              Attribute("expected_commitment", "Expected commitment", DataType.Boolean, None, KeyType.NonKey, "blocks"),
+              Attribute("priority", "Priority", DataType.Int, None, KeyType.NonKey, "blocks")
             )
           )
       }

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosTypesTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosTypesTest.scala
@@ -83,6 +83,7 @@ class TezosTypesTest extends WordSpec with Matchers with OptionValues {
             validation_pass = 0,
             operations_hash = None,
             fitness = Seq.empty,
+            priority = None,
             context = "_",
             signature = None
           ),


### PR DESCRIPTION
Closes #402 
Maps the priority in the tezos block to the corresponding db table.

## Required changes to DB Schema
A column was added to the `blocks` table

```sql
ALTER TABLE public.blocks ADD COLUMN priority integer`;
```