### PR TITLE
238 - Make conversion for db using chimney lib, when convenient

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
@@ -4,9 +4,12 @@ import tech.cryptonomic.conseil.tezos.TezosTypes._
 import tech.cryptonomic.conseil.tezos.FeeOperations._
 import tech.cryptonomic.conseil.util.Conversion
 import cats.{Id, Show}
+import cats.syntax.option._
+import mouse.any._
 import java.sql.Timestamp
 import monocle.Getter
 import io.scalaland.chimney.dsl._
+import io.scalaland.chimney.Transformer
 
 object DatabaseConversions {
 
@@ -33,91 +36,85 @@ object DatabaseConversions {
   //implicit conversions to database row types
 
   implicit val averageFeesToFeeRow = new Conversion[Id, AverageFees, Tables.FeesRow] {
-    override def convert(from: AverageFees) =
-      Tables.FeesRow(
-        low = from.low,
-        medium = from.medium,
-        high = from.high,
-        timestamp = from.timestamp,
-        kind = from.kind
-      )
+    override def convert(from: AverageFees) = from.transformInto[Tables.FeesRow]
   }
 
   implicit val blockAccountsToAccountRows =
     new Conversion[List, BlockTagged[Map[AccountId, Account]], Tables.AccountsRow] {
       override def convert(from: BlockTagged[Map[AccountId, Account]]) = {
         val BlockTagged(hash, level, accounts) = from
-        accounts.map {
-          case (id, Account(manager, balance, spendable, delegate, script, counter)) =>
-            Tables.AccountsRow(
-              accountId = id.id,
-              blockId = hash.value,
-              manager = manager.value,
-              spendable = spendable,
-              delegateSetable = delegate.setable,
-              delegateValue = delegate.value.map(_.value),
-              counter = counter,
-              script = script.map(_.code.expression),
-              storage = script.map(_.storage.expression),
-              balance = balance,
-              blockLevel = level
-            )
-        }.toList
+
+        implicit val rowTransformer: Transformer[(AccountId, Account), Tables.AccountsRow] =
+          (entry: (AccountId, Account)) => {
+            val (id, acc) = entry
+            acc
+              .into[Tables.AccountsRow]
+              .withFieldConst(_.accountId, id.id)
+              .withFieldConst(_.blockId, hash.value)
+              .withFieldConst(_.blockLevel, BigDecimal(level))
+              .withFieldComputed(_.delegateSetable, _.delegate.setable)
+              .withFieldComputed(_.delegateValue, _.delegate.value.map((_.value)))
+              .withFieldComputed(_.script, _.script.map(_.code.expression))
+              .withFieldComputed(_.storage, _.script.map(_.storage.expression))
+              .transform
+          }
+
+        accounts.toList.transformInto[List[Tables.AccountsRow]]
       }
     }
 
   implicit val accountRowsToContractRows = new Conversion[Id, Tables.AccountsRow, Tables.DelegatedContractsRow] {
-    override def convert(from: Tables.AccountsRow) = from.into[Tables.DelegatedContractsRow].transform
+    override def convert(from: Tables.AccountsRow) = from.transformInto[Tables.DelegatedContractsRow]
   }
 
   implicit val blockToBlocksRow = new Conversion[Id, Block, Tables.BlocksRow] {
     override def convert(from: Block) = {
-      val header = from.data.header
       val metadata = discardGenesis.lift(from.data.metadata)
-      val CurrentVotes(expectedQuorum, proposal) = from.votes
-      Tables.BlocksRow(
-        level = header.level,
-        proto = header.proto,
-        predecessor = header.predecessor.value,
-        timestamp = toSql(header.timestamp),
-        validationPass = header.validation_pass,
-        fitness = header.fitness.mkString(","),
-        context = Some(header.context), //put in later
-        signature = header.signature,
-        protocol = from.data.protocol,
-        chainId = from.data.chain_id,
-        hash = from.data.hash.value,
-        operationsHash = header.operations_hash,
-        periodKind = metadata.map(_.voting_period_kind.toString),
-        currentExpectedQuorum = expectedQuorum,
-        activeProposal = proposal.map(_.id),
-        baker = metadata.map(_.baker.value),
-        nonceHash = metadata.flatMap(_.nonce_hash.map(_.value)),
-        consumedGas = metadata.flatMap(md => extractBigDecimal(md.consumed_gas)),
-        metaLevel = metadata.map(_.level.level),
-        metaLevelPosition = metadata.map(_.level.level_position),
-        metaCycle = metadata.map(_.level.cycle),
-        metaCyclePosition = metadata.map(_.level.cycle_position),
-        metaVotingPeriod = metadata.map(_.level.voting_period),
-        metaVotingPeriodPosition = metadata.map(_.level.voting_period_position),
-        expectedCommitment = metadata.map(_.level.expected_commitment)
-      )
+      from
+        .into[Tables.BlocksRow]
+        .withFieldComputed(_.level, _.data.header.level)
+        .withFieldComputed(_.proto, _.data.header.proto)
+        .withFieldComputed(_.predecessor, _.data.header.predecessor.value)
+        .withFieldComputed(_.timestamp, _.data.header.timestamp |> toSql)
+        .withFieldComputed(_.validationPass, _.data.header.validation_pass)
+        .withFieldComputed(_.fitness, _.data.header.fitness |> toCommaSeparated)
+        .withFieldComputed(_.context, _.data.header.context.some)
+        .withFieldComputed(_.signature, _.data.header.signature)
+        .withFieldComputed(_.protocol, _.data.protocol)
+        .withFieldComputed(_.chainId, _.data.chain_id)
+        .withFieldComputed(_.hash, _.data.hash.value)
+        .withFieldComputed(_.operationsHash, _.data.header.operations_hash)
+        .withFieldConst(_.periodKind, metadata.map(_.voting_period_kind.toString))
+        .withFieldComputed(_.currentExpectedQuorum, _.votes.quorum)
+        .withFieldComputed(_.activeProposal, _.votes.active.map(_.id))
+        .withFieldConst(_.baker, metadata.map(_.baker.value))
+        .withFieldConst(_.nonceHash, metadata.flatMap(_.nonce_hash.map(_.value)))
+        .withFieldConst(_.consumedGas, metadata.flatMap(_.consumed_gas |> extractBigDecimal))
+        .withFieldConst(_.metaLevel, metadata.map(_.level.level))
+        .withFieldConst(_.metaLevelPosition, metadata.map(_.level.level_position))
+        .withFieldConst(_.metaCycle, metadata.map(_.level.cycle))
+        .withFieldConst(_.metaCyclePosition, metadata.map(_.level.cycle_position))
+        .withFieldConst(_.metaVotingPeriod, metadata.map(_.level.voting_period))
+        .withFieldConst(_.metaVotingPeriodPosition, metadata.map(_.level.voting_period_position))
+        .withFieldConst(_.expectedCommitment, metadata.map(_.level.expected_commitment))
+        .transform
     }
   }
 
   implicit val blockToOperationGroupsRow = new Conversion[List, Block, Tables.OperationGroupsRow] {
-    override def convert(from: Block) =
-      from.operationGroups.map { og =>
-        Tables.OperationGroupsRow(
-          protocol = og.protocol,
-          chainId = og.chain_id.map(_.id),
-          hash = og.hash.value,
-          branch = og.branch.value,
-          signature = og.signature.map(_.value),
-          blockId = from.data.hash.value,
-          blockLevel = from.data.header.level
-        )
-      }
+    override def convert(from: Block) = {
+      val rowTransformation =
+        (og: OperationsGroup) => {
+          og.into[Tables.OperationGroupsRow]
+            .withFieldConst(_.blockId, from.data.hash.value)
+            .withFieldConst(_.blockLevel, from.data.header.level)
+            .withFieldComputed(_.chainId, _.chain_id.map(_.id))
+            .withFieldComputed(_.signature, _.signature.map(_.value))
+            .transform
+        }
+
+      from.operationGroups.map(rowTransformation)
+    }
   }
 
   //Cannot directly convert a single operation to a row, because we need the block and operation-group info to build the database row
@@ -339,33 +336,21 @@ object DatabaseConversions {
     import cats.syntax.show._
 
     override def convert(from: T) =
-      balances
-        .get(from)
-        .flatMap {
-          case (tag, updates) =>
-            updates.map {
-              case OperationMetadata.BalanceUpdate(
-                  kind,
-                  change,
-                  category,
-                  contract,
-                  delegate,
-                  level
-                  ) =>
-                Tables.BalanceUpdatesRow(
-                  id = 0,
-                  source = tag.show,
-                  sourceHash = hashing.get(from),
-                  kind = kind,
-                  contract = contract.map(_.id),
-                  change = BigDecimal(change),
-                  level = level.map(BigDecimal(_)),
-                  delegate = delegate.map(_.value),
-                  category = category
-                )
-            }
-        }
-        .toList
+      for {
+        (label, updates) <- balances.get(from).toList
+        update <- updates
+      } yield
+        Tables.BalanceUpdatesRow(
+          id = 0,
+          source = label.show,
+          sourceHash = hashing.get(from),
+          kind = update.kind,
+          contract = update.contract.map(_.id),
+          change = BigDecimal(update.change),
+          level = update.level.map(BigDecimal(_)),
+          delegate = update.delegate.map(_.value),
+          category = update.category
+        )
   }
 
   /** Utility alias when we need to keep related data paired together */
@@ -428,17 +413,17 @@ object DatabaseConversions {
   implicit val delegateToRow = new Conversion[Id, (BlockHash, Int, PublicKeyHash, Delegate), Tables.DelegatesRow] {
     override def convert(from: (BlockHash, Int, PublicKeyHash, Delegate)) = {
       val (blockHash, blockLevel, keyHash, delegate) = from
-      Tables.DelegatesRow(
-        pkh = keyHash.value,
-        blockId = blockHash.value,
-        balance = extractBigDecimal(delegate.balance),
-        frozenBalance = extractBigDecimal(delegate.frozen_balance),
-        stakingBalance = extractBigDecimal(delegate.staking_balance),
-        delegatedBalance = extractBigDecimal(delegate.delegated_balance),
-        deactivated = delegate.deactivated,
-        gracePeriod = delegate.grace_period,
-        blockLevel = blockLevel
-      )
+      delegate
+        .into[Tables.DelegatesRow]
+        .withFieldConst(_.pkh, keyHash.value)
+        .withFieldConst(_.blockId, blockHash.value)
+        .withFieldConst(_.blockLevel, blockLevel)
+        .withFieldComputed(_.balance, _.balance |> extractBigDecimal)
+        .withFieldComputed(_.frozenBalance, _.frozen_balance |> extractBigDecimal)
+        .withFieldComputed(_.stakingBalance, _.staking_balance |> extractBigDecimal)
+        .withFieldComputed(_.delegatedBalance, _.delegated_balance |> extractBigDecimal)
+        .withFieldRenamed(_.grace_period, _.gracePeriod)
+        .transform
     }
   }
 
@@ -462,34 +447,25 @@ object DatabaseConversions {
   implicit val ballotsToRows = new Conversion[List, (Block, List[Voting.Ballot]), Tables.BallotsRow] {
     override def convert(from: (Block, List[Voting.Ballot])) = {
       val (block, ballots) = from
-      val blockHash = block.data.hash.value
-      val blockLevel = block.data.header.level
-      ballots.map {
-        case Voting.Ballot(PublicKeyHash(hash), Voting.Vote(vote)) =>
-          Tables.BallotsRow(
-            pkh = hash,
-            ballot = vote,
-            blockId = blockHash,
-            blockLevel = blockLevel
-          )
-      }
+
+      ballots.map(
+        _.into[Tables.BallotsRow]
+          .withFieldConst(_.blockId, block.data.hash.value)
+          .withFieldConst(_.blockLevel, block.data.header.level)
+          .transform
+      )
     }
   }
 
   implicit val rollsToRows = new Conversion[List, (Block, List[Voting.BakerRolls]), Tables.RollsRow] {
     override def convert(from: (Block, List[Voting.BakerRolls])) = {
       val (block, bakers) = from
-      val blockHash = block.data.hash.value
-      val blockLevel = block.data.header.level
-      bakers.map {
-        case Voting.BakerRolls(PublicKeyHash(hash), rolls) =>
-          Tables.RollsRow(
-            pkh = hash,
-            rolls = rolls,
-            blockId = blockHash,
-            blockLevel = blockLevel
-          )
-      }
+      bakers.map(
+        _.into[Tables.RollsRow]
+          .withFieldConst(_.blockId, block.data.hash.value)
+          .withFieldConst(_.blockLevel, block.data.header.level)
+          .transform
+      )
     }
   }
 


### PR DESCRIPTION
Closes #238 

Make use of the (already imported) library chimney for value object transformation, simplifying a bit the syntax.

In some cases the macro expansion seems to diverge (e.g. for any of the operation's subtypes).
For these and for cases where the added value was negligible, the old conversion code was kept.