### PR TITLE
333 - Switch the now commonly used (year month)-based format for release tags

### DIFF
--- a/project/versioning.scala
+++ b/project/versioning.scala
@@ -15,11 +15,14 @@ object Versioning {
     * implement the logic for versioning explained in the build file
     * the tag parameter should have a format like:
     *
-    *   ci-release-1-3-d3a9863 <-- this latter part is the result of `git describe`
-    *   ^          ^
-    *   |          |- this is the version we care about
+    *                  *--------*
+    *                  |        | <-- this latter part is the result of `git describe`
+    * <free>-release-1-3-d3a9863           and should be missing on the release commit
+    *   ^            ^
+    *   |            |
+    *   |            *-- this is the version we care about
     *   |
-    *   |- freeform ('ci' would be the one used by sbt tagging)
+    *   *- freeform (year-month would be the one used by sbt tagging)
     */
   def generate(major: Int, date: LocalDate, tag: String): String = {
     val week = zeroPadded(2)(date.get(temporal.ChronoField.ALIGNED_WEEK_OF_YEAR).toString)
@@ -37,7 +40,8 @@ object Versioning {
   lazy val prepareReleaseTagDef = Def.task {
     val currentVersion = version.value
     val tag = currentVersion.split('.').last.dropWhile(_ == '0')
-    s"ci-release-$tag"
+    val date = LocalDate.now().formatted("%1$tY-%1$tB").toLowerCase
+    s"$date-release-$tag"
   }
 
 }


### PR DESCRIPTION
Closes #333
Make the automatic task for release (`sbt gitTag`) use year and month to format the tag itself, as we've done previously with manual releases.

This means that to tag from the local code (in sync with `master`) it should be enough to run
```bash
sbt gitTag
git push origin --tags
```

This will produce a tag like `2019-july-release-10` on a properly aligned branch (that is, with no uncommitted code)

The sbt command will output the actually produced tag so you can check if doing it locally, and eventually remove the tag if something wicked happened