### PR TITLE
Logging/388 reference data overrides validation process

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/Conseil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Conseil.scala
@@ -66,7 +66,8 @@ object Conseil
         case Success(_) => logger.info("Pre-caching attributes successful!")
       }
 
-      lazy val metadataService =
+      // this val is not lazy to force to fetch metadata and trigger logging at the start of the application
+      val metadataService =
         new MetadataService(platforms, transformation, cacheOverrides, tezosPlatformDiscoveryOperations)
       lazy val platformDiscovery = PlatformDiscovery(metadataService)(tezosDispatcher)
       lazy val data = Data(platforms, metadataService, server)(tezosDispatcher)

--- a/src/main/scala/tech/cryptonomic/conseil/config/MetadataConfiguration.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/config/MetadataConfiguration.scala
@@ -1,7 +1,7 @@
 package tech.cryptonomic.conseil.config
 
 import tech.cryptonomic.conseil.config.Types.{AttributeName, EntityName, NetworkName, PlatformName}
-import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.AttributeCacheConfiguration
+import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.{AttributeCacheConfiguration, Network}
 import tech.cryptonomic.conseil.metadata._
 
 object Types {
@@ -41,6 +41,11 @@ case class MetadataConfiguration(metadataConfiguration: Map[PlatformName, Platfo
     case (platformName, platformConfiguration) => PlatformPath(platformName) -> platformConfiguration
   }
 
+  // fetches networks based on a given path
+  def networks(path: PlatformPath): Map[NetworkPath, NetworkConfiguration] = allNetworks.collect {
+    case (networkPath @ NetworkPath(_, `path`), networkConfiguration) => networkPath -> networkConfiguration
+  }
+
   // fetches all networks
   def allNetworks: Map[NetworkPath, NetworkConfiguration] = allPlatforms.flatMap {
     case (platformPath, platformConfiguration) =>
@@ -49,12 +54,20 @@ case class MetadataConfiguration(metadataConfiguration: Map[PlatformName, Platfo
       }
   }
 
+  def entities(networkPath: NetworkPath): Map[EntityPath, EntityConfiguration] = allEntities.collect {
+    case (entityPath @ EntityPath(_, `networkPath`), entityConfiguration) => entityPath -> entityConfiguration
+  }
+
   // fetches all entities
   def allEntities: Map[EntityPath, EntityConfiguration] = allNetworks.flatMap {
     case (networkPath, networkConfiguration) =>
       networkConfiguration.entities.map {
         case (entityName, entityConfiguration) => (networkPath.addLevel(entityName), entityConfiguration)
       }
+  }
+
+  def attributes(path: EntityPath): Map[AttributePath, AttributeConfiguration] = allAttributes.collect {
+    case (attributePath @ AttributePath(_, `path`), attributeConfiguration) => attributePath -> attributeConfiguration
   }
 
   // fetches all attributes

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
@@ -63,7 +63,7 @@ object DataTypes {
 
     fields.traverse {
       case (source, field) =>
-        metadataService.isAttributeValid(path.entity, field).map((_, source, field))
+        metadataService.attributeExists(path.entity, field).map((_, source, field))
     }.map {
       _.collect {
         case (false, 'query, field) => InvalidQueryField(field)

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/PlatformDiscoveryOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/PlatformDiscoveryOperations.scala
@@ -15,5 +15,4 @@ trait PlatformDiscoveryOperations {
       withFilter: Option[String] = None,
       attributesCacheConfig: Option[AttributeCacheConfiguration] = None
   ): Future[Either[List[AttributesValidationError], List[String]]]
-  def isAttributeValid(tableName: String, columnName: String): Future[Boolean]
 }

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/PlatformDiscoveryOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/PlatformDiscoveryOperations.scala
@@ -1,0 +1,19 @@
+package tech.cryptonomic.conseil.generic.chain
+
+import tech.cryptonomic.conseil.generic.chain.DataTypes.AttributesValidationError
+import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.{Attribute, AttributeCacheConfiguration, Entity}
+
+import scala.concurrent.Future
+
+trait PlatformDiscoveryOperations {
+  def getEntities: Future[List[Entity]]
+  def getTableAttributes(tableName: String): Future[Option[List[Attribute]]]
+  def getTableAttributesWithoutUpdatingCache(tableName: String): Future[Option[List[Attribute]]]
+  def listAttributeValues(
+      tableName: String,
+      column: String,
+      withFilter: Option[String] = None,
+      attributesCacheConfig: Option[AttributeCacheConfiguration] = None
+  ): Future[Either[List[AttributesValidationError], List[String]]]
+  def isAttributeValid(tableName: String, columnName: String): Future[Boolean]
+}

--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/PlatformDiscoveryTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/PlatformDiscoveryTypes.scala
@@ -3,6 +3,7 @@ package tech.cryptonomic.conseil.generic.chain
 import tech.cryptonomic.conseil.generic.chain.DataTypes.InvalidPredicateFiltering
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.DataType.DataType
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.KeyType.KeyType
+import tech.cryptonomic.conseil.metadata.{NetworkPath, PlatformPath}
 
 /**
   * Classes used for Platform routes
@@ -10,7 +11,9 @@ import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.KeyType.Key
 object PlatformDiscoveryTypes {
 
   /** Case class representing network */
-  final case class Platform(name: String, displayName: String, description: Option[String] = None)
+  final case class Platform(name: String, displayName: String, description: Option[String] = None) {
+    val path = PlatformPath(name)
+  }
 
   /** Case class representing network */
   final case class Network(
@@ -19,7 +22,9 @@ object PlatformDiscoveryTypes {
       platform: String,
       network: String,
       description: Option[String] = None
-  )
+  ) {
+    lazy val path = NetworkPath(network, PlatformPath(platform))
+  }
 
   /** Case class representing single entity of a given network */
   final case class Entity(

--- a/src/main/scala/tech/cryptonomic/conseil/metadata/MetadataService.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/metadata/MetadataService.scala
@@ -1,15 +1,17 @@
 package tech.cryptonomic.conseil.metadata
 
+import scala.concurrent.duration._
 import tech.cryptonomic.conseil.config.Platforms.PlatformsConfiguration
 import tech.cryptonomic.conseil.generic.chain.DataTypes
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes._
 import tech.cryptonomic.conseil.tezos.TezosPlatformDiscoveryOperations
-import tech.cryptonomic.conseil.util.CollectionOps.{ExtendedFuture, ExtendedOptionalList}
+import tech.cryptonomic.conseil.util.CollectionOps.ExtendedOptionalList
 import tech.cryptonomic.conseil.util.ConfigUtil
 import tech.cryptonomic.conseil.util.OptionUtil.when
 
 import scala.concurrent.Future.successful
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.language.postfixOps
 
 // service class for metadata
 class MetadataService(
@@ -17,31 +19,68 @@ class MetadataService(
     transformation: UnitTransformation,
     cacheConfiguration: AttributeValuesCacheConfiguration,
     tezosPlatformDiscoveryOperations: TezosPlatformDiscoveryOperations
-) {
+)(implicit apiExecutionContext: ExecutionContext) {
 
-  // checks if attribute is valid
-  def isAttributeValid(entity: String, attribute: String): Future[Boolean] =
-    tezosPlatformDiscoveryOperations.isAttributeValid(entity, attribute)
+  private lazy val platforms = ConfigUtil
+    .getPlatforms(config)
+    .flatMap(platform => transformation.overridePlatform(platform, PlatformPath(platform.name)))
+
+  private lazy val networks = platforms.flatMap { platform =>
+    ConfigUtil
+      .getNetworks(config, platform.name)
+      .flatMap(network => transformation.overrideNetwork(network, platform.path.addLevel(network.name)))
+  }
+
+  private lazy val entities = {
+    lazy val allEntities = Await.result(tezosPlatformDiscoveryOperations.getEntities, 1 second)
+
+    networks
+      .map(_.path)
+      .map(
+        networkPath =>
+          networkPath -> allEntities
+                .flatMap(entity => transformation.overrideEntity(entity, networkPath.addLevel(entity.name)))
+      )
+      .toMap
+  }
+
+  private lazy val tableAttributes = {
+    val networkPaths = entities.flatMap {
+      case (networkPath: NetworkPath, entities: List[Entity]) =>
+        entities.map(entity => networkPath.addLevel(entity.name))
+    }.toSet
+
+    networkPaths.flatMap { path =>
+      Await
+        .result(
+          getAttributesHelper(path)(tezosPlatformDiscoveryOperations.getTableAttributes),
+          1 second
+        )
+        .map(path -> _)
+    }.toMap
+  }
+
+  // fetches platforms
+  def getPlatforms: List[Platform] = platforms
+
+  // fetches networks
+  def getNetworks(path: PlatformPath): Option[List[Network]] = when(exists(path)) {
+    networks.filter(_.platform == path.platform)
+  }
 
   // fetches entities
-  def getEntities(path: NetworkPath)(implicit apiExecutionContext: ExecutionContext): Future[Option[List[Entity]]] =
-    if (exists(path))
-      tezosPlatformDiscoveryOperations.getEntities
-        .mapNested(entity => transformation.overrideEntity(entity, path.addLevel(entity.name)))
-        .map(Some(_))
-    else
-      successful(None)
+  def getEntities(path: NetworkPath): Future[Option[List[Entity]]] =
+    successful(entities.get(path))
 
   // fetches table attributes
   def getTableAttributes(
       path: EntityPath
-  )(implicit apiExecutionContext: ExecutionContext): Future[Option[List[Attribute]]] =
-    getAttributesHelper(path)(tezosPlatformDiscoveryOperations.getTableAttributes)
+  ): Future[Option[List[Attribute]]] = {
+    successful(tableAttributes.get(path))
+  }
 
   // fetches table attributes without updating cache
-  def getTableAttributesWithoutUpdatingCache(
-      path: EntityPath
-  )(implicit apiExecutionContext: ExecutionContext): Future[Option[List[Attribute]]] =
+  def getTableAttributesWithoutUpdatingCache(path: EntityPath): Future[Option[List[Attribute]]] =
     getAttributesHelper(path)(tezosPlatformDiscoveryOperations.getTableAttributesWithoutUpdatingCache)
 
   // fetches attribute values
@@ -51,8 +90,6 @@ class MetadataService(
       entity: String,
       attribute: String,
       filter: Option[String] = None
-  )(
-      implicit apiExecutionContext: ExecutionContext
   ): Future[Option[Either[List[DataTypes.AttributesValidationError], List[String]]]] = {
 
     val path = NetworkPath(network, PlatformPath(platform))
@@ -65,28 +102,19 @@ class MetadataService(
       successful(None)
   }
 
+  // checks if attribute is valid
+  def isAttributeValid(entity: String, attribute: String): Future[Boolean] =
+    tezosPlatformDiscoveryOperations.isAttributeValid(entity, attribute)
+
   private def exists(path: NetworkPath): Boolean =
     getNetworks(path.up).getOrElse(List.empty).exists(_.network == path.network) && exists(path.up)
 
-  // fetches networks
-  def getNetworks(path: PlatformPath): Option[List[Network]] = when(exists(path)) {
-    ConfigUtil
-      .getNetworks(config, path.platform)
-      .flatMap(network => transformation.overrideNetwork(network, path.addLevel(network.name)))
-  }
-
   private def exists(path: PlatformPath): Boolean = getPlatforms.exists(_.name == path.platform)
-
-  // fetches platforms
-  def getPlatforms: List[Platform] =
-    ConfigUtil
-      .getPlatforms(config)
-      .flatMap(platform => transformation.overridePlatform(platform, PlatformPath(platform.name)))
 
   // fetches attributes with given function
   private def getAttributesHelper(path: EntityPath)(
       getAttributes: String => Future[Option[List[Attribute]]]
-  )(implicit apiExecutionContext: ExecutionContext): Future[Option[List[Attribute]]] =
+  ): Future[Option[List[Attribute]]] =
     exists(path).flatMap {
       case true =>
         getAttributes(path.entity).map(
@@ -96,6 +124,6 @@ class MetadataService(
         Future.successful(None)
     }
 
-  private def exists(path: EntityPath)(implicit apiExecutionContext: ExecutionContext): Future[Boolean] =
+  private def exists(path: EntityPath): Future[Boolean] =
     getEntities(path.up).map(_.getOrElse(List.empty).exists(_.name == path.entity) && exists(path.up))
 }

--- a/src/main/scala/tech/cryptonomic/conseil/metadata/MetadataService.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/metadata/MetadataService.scala
@@ -20,13 +20,13 @@ class MetadataService(
     tezosPlatformDiscoveryOperations: TezosPlatformDiscoveryOperations
 )(implicit apiExecutionContext: ExecutionContext) {
 
-  private val platforms = transformation.overridePlatforms(ConfigUtil.getPlatforms(config))
+  private lazy val platforms = transformation.overridePlatforms(ConfigUtil.getPlatforms(config))
 
-  private val networks = platforms.map { platform =>
+  private lazy val networks = platforms.map { platform =>
     platform.path -> transformation.overrideNetworks(platform.path, ConfigUtil.getNetworks(config, platform.name))
   }.toMap
 
-  private val entities = {
+  private lazy val entities = {
     lazy val allEntities = Await.result(tezosPlatformDiscoveryOperations.getEntities, 1 second)
 
     networks.values.flatten
@@ -37,7 +37,7 @@ class MetadataService(
       .toMap
   }
 
-  private val tableAttributes: Map[EntityPath, List[Attribute]] = {
+  private lazy val tableAttributes: Map[EntityPath, List[Attribute]] = {
     val networkPaths = entities.flatMap {
       case (networkPath: NetworkPath, entities: List[Entity]) =>
         entities.map(entity => networkPath.addLevel(entity.name))

--- a/src/main/scala/tech/cryptonomic/conseil/metadata/Path.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/metadata/Path.scala
@@ -10,24 +10,29 @@ sealed trait Path {
 case class EmptyPath() extends Path {
   override def up: Path = this
   override def addLevel(platform: String): Path = PlatformPath(platform, this)
+  override def toString: String = ""
 }
 
 // case class representing a path for a platform
 case class PlatformPath(platform: String, up: EmptyPath = EmptyPath()) extends Path {
   override def addLevel(networkPath: String): NetworkPath = NetworkPath(networkPath, this)
+  override def toString: String = platform
 }
 
 // case class representing a path for a network
 case class NetworkPath(network: String, up: PlatformPath) extends Path {
   override def addLevel(entity: String): EntityPath = EntityPath(entity, this)
+  override def toString: String = s"${up.toString} / $network"
 }
 
 // case class representing a path for an entity
 case class EntityPath(entity: String, up: NetworkPath) extends Path {
   override def addLevel(attribute: String): AttributePath = AttributePath(attribute, this)
+  override def toString: String = s"${up.toString} / $entity"
 }
 
 // case class representing a path for an attribute
 case class AttributePath(attribute: String, up: EntityPath) extends Path {
   override def addLevel(nextLabel: String): Path = throw new NotImplementedError()
+  override def toString: String = s"${up.toString} / $attribute"
 }

--- a/src/main/scala/tech/cryptonomic/conseil/metadata/Path.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/metadata/Path.scala
@@ -22,17 +22,17 @@ case class PlatformPath(platform: String, up: EmptyPath = EmptyPath()) extends P
 // case class representing a path for a network
 case class NetworkPath(network: String, up: PlatformPath) extends Path {
   override def addLevel(entity: String): EntityPath = EntityPath(entity, this)
-  override def toString: String = s"${up.toString} / $network"
+  override def toString: String = s"$up / $network"
 }
 
 // case class representing a path for an entity
 case class EntityPath(entity: String, up: NetworkPath) extends Path {
   override def addLevel(attribute: String): AttributePath = AttributePath(attribute, this)
-  override def toString: String = s"${up.toString} / $entity"
+  override def toString: String = s"$up / $entity"
 }
 
 // case class representing a path for an attribute
 case class AttributePath(attribute: String, up: EntityPath) extends Path {
   override def addLevel(nextLabel: String): Path = throw new NotImplementedError()
-  override def toString: String = s"${up.toString} / $attribute"
+  override def toString: String = s"$up / $attribute"
 }

--- a/src/main/scala/tech/cryptonomic/conseil/metadata/UnitTransformation.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/metadata/UnitTransformation.scala
@@ -1,16 +1,41 @@
 package tech.cryptonomic.conseil.metadata
 
-import tech.cryptonomic.conseil.config.MetadataConfiguration
+import com.typesafe.scalalogging.LazyLogging
+import tech.cryptonomic.conseil.config.{MetadataConfiguration, PlatformConfiguration}
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.{Attribute, Entity, Network, Platform}
 import tech.cryptonomic.conseil.tezos.TezosPlatformDiscoveryOperations.mapType
 import tech.cryptonomic.conseil.util.OptionUtil.when
 
 // class for applying overrides configurations
-class UnitTransformation(overrides: MetadataConfiguration) {
+class UnitTransformation(overrides: MetadataConfiguration) extends LazyLogging {
+
+  // overrides platforms
+  def overridePlatforms(platforms: List[Platform]): List[Platform] = {
+    logDifferences(platforms.map(_.path), overrides.allPlatforms.keys.toList)
+    platforms.flatMap(platform => overridePlatform(platform, PlatformPath(platform.name)))
+  }
+
+  // overrides networks
+  def overrideNetworks(platformPath: PlatformPath, networks: List[Network]): List[Network] = {
+    logDifferences(networks.map(_.path), overrides.networks(platformPath).keys.toList)
+    networks.flatMap(network => overrideNetwork(network, network.path))
+  }
+
+  // overrides entities
+  def overrideEntities(networkPath: NetworkPath, entities: List[Entity]): List[Entity] = {
+    logDifferences(entities.map(entity => networkPath.addLevel(entity.name)), overrides.entities(networkPath).keys.toList)
+    entities.flatMap(entity => overrideEntity(entity, networkPath.addLevel(entity.name)))
+  }
+
+  // overrides attributes
+  def overrideAttributes(path: EntityPath, attributes: List[Attribute]): List[Attribute] = {
+    logDifferences(attributes.map(attribute => path.addLevel(attribute.name)), overrides.attributes(path).keys.toList)
+    attributes.flatMap(attribute => overrideAttribute(attribute, path.addLevel(attribute.name)))
+  }
 
   // overrides platform
-  def overridePlatform(platform: Platform, path: PlatformPath): Option[Platform] = when(overrides.isVisible(path)) {
-    val overridePlatform = overrides.platform(path)
+  def overridePlatform(platform: Platform, path: PlatformPath): Option[Platform] = when(overrides.isVisible(path.up)) {
+    val overridePlatform: Option[PlatformConfiguration] = overrides.platform(path)
 
     platform.copy(
       displayName = overridePlatform
@@ -69,4 +94,14 @@ class UnitTransformation(overrides: MetadataConfiguration) {
         currencySymbolCode = overrideAttribute.flatMap(_.currencySymbolCode)
       )
     }
+
+  private def logDifferences(paths: List[Path], overridePahts: List[Path]): Unit = {
+    paths
+      .filterNot(overridePahts.toSet)
+      .foreach(logger.warn("""There's a missing metadata overrides for "{}"""", _))
+
+    overridePahts
+      .filterNot(paths.toSet)
+      .foreach(logger.error("""Metadata overrides "{}" overrides nothing""", _))
+  }
 }

--- a/src/main/scala/tech/cryptonomic/conseil/metadata/UnitTransformation.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/metadata/UnitTransformation.scala
@@ -34,7 +34,7 @@ class UnitTransformation(overrides: MetadataConfiguration) extends LazyLogging {
   }
 
   // overrides platform
-  def overridePlatform(platform: Platform, path: PlatformPath): Option[Platform] = when(overrides.isVisible(path.up)) {
+  def overridePlatform(platform: Platform, path: PlatformPath): Option[Platform] = when(overrides.isVisible(path)) {
     val overridePlatform: Option[PlatformConfiguration] = overrides.platform(path)
 
     platform.copy(
@@ -95,13 +95,13 @@ class UnitTransformation(overrides: MetadataConfiguration) extends LazyLogging {
       )
     }
 
-  private def logDifferences(paths: List[Path], overridePahts: List[Path]): Unit = {
+  private def logDifferences(paths: List[Path], overriddenPaths: List[Path]): Unit = {
     paths
-      .filterNot(overridePahts.toSet)
-      .foreach(logger.warn("""There's a missing metadata overrides for "{}"""", _))
+      .filterNot(overriddenPaths.toSet)
+      .foreach(logger.warn("""There're missing metadata overrides for "{}"""", _))
 
-    overridePahts
+    overriddenPaths
       .filterNot(paths.toSet)
-      .foreach(logger.error("""Metadata overrides "{}" overrides nothing""", _))
+      .foreach(logger.error("""Metadata overrides "{}" override nothing""", _))
   }
 }

--- a/src/main/scala/tech/cryptonomic/conseil/metadata/UnitTransformation.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/metadata/UnitTransformation.scala
@@ -34,7 +34,7 @@ class UnitTransformation(overrides: MetadataConfiguration) extends LazyLogging {
   }
 
   // overrides platform
-  def overridePlatform(platform: Platform, path: PlatformPath): Option[Platform] = when(overrides.isVisible(path)) {
+  private def overridePlatform(platform: Platform, path: PlatformPath): Option[Platform] = when(overrides.isVisible(path)) {
     val overridePlatform: Option[PlatformConfiguration] = overrides.platform(path)
 
     platform.copy(
@@ -47,7 +47,7 @@ class UnitTransformation(overrides: MetadataConfiguration) extends LazyLogging {
   }
 
   // overrides network
-  def overrideNetwork(network: Network, path: NetworkPath): Option[Network] = when(overrides.isVisible(path)) {
+  private def overrideNetwork(network: Network, path: NetworkPath): Option[Network] = when(overrides.isVisible(path)) {
     val overrideNetwork = overrides.network(path)
 
     network.copy(
@@ -60,7 +60,7 @@ class UnitTransformation(overrides: MetadataConfiguration) extends LazyLogging {
   }
 
   // overrides entity
-  def overrideEntity(entity: Entity, path: EntityPath): Option[Entity] = when(overrides.isVisible(path)) {
+  private def overrideEntity(entity: Entity, path: EntityPath): Option[Entity] = when(overrides.isVisible(path)) {
     val overrideEntity = overrides.entity(path)
 
     entity.copy(
@@ -75,7 +75,7 @@ class UnitTransformation(overrides: MetadataConfiguration) extends LazyLogging {
   }
 
   // overrides attribute
-  def overrideAttribute(attribute: Attribute, path: AttributePath): Option[Attribute] =
+  private def overrideAttribute(attribute: Attribute, path: AttributePath): Option[Attribute] =
     when(overrides.isVisible(path)) {
       val overrideAttribute = overrides.attribute(path)
 

--- a/src/main/scala/tech/cryptonomic/conseil/metadata/UnitTransformation.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/metadata/UnitTransformation.scala
@@ -96,12 +96,10 @@ class UnitTransformation(overrides: MetadataConfiguration) extends LazyLogging {
     }
 
   private def logDifferences(paths: List[Path], overriddenPaths: List[Path]): Unit = {
-    paths
-      .filterNot(overriddenPaths.toSet)
+    (paths.toSet diff overriddenPaths.toSet)
       .foreach(logger.warn("""There're missing metadata overrides for "{}"""", _))
 
-    overriddenPaths
-      .filterNot(paths.toSet)
+    (overriddenPaths.toSet diff paths.toSet)
       .foreach(logger.error("""Metadata overrides "{}" override nothing""", _))
   }
 }

--- a/src/main/scala/tech/cryptonomic/conseil/routes/PlatformDiscovery.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/PlatformDiscovery.scala
@@ -39,12 +39,12 @@ class PlatformDiscovery(metadataService: MetadataService)(implicit apiExecutionC
   }
 
   /** Metadata route implementation for entities endpoint */
-  private lazy val entitiesRoute = entitiesEndpoint.implementedByAsync {
+  private lazy val entitiesRoute = entitiesEndpoint.implementedBy {
     case (platform, network, _) => metadataService.getEntities(NetworkPath(network, PlatformPath(platform)))
   }
 
   /** Metadata route implementation for attributes endpoint */
-  private lazy val attributesRoute = attributesEndpoint.implementedByAsync {
+  private lazy val attributesRoute = attributesEndpoint.implementedBy {
     case ((platform, network, entity), _) =>
       metadataService.getTableAttributes(EntityPath(entity, NetworkPath(network, PlatformPath(platform))))
   }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperations.scala
@@ -147,23 +147,6 @@ class TezosPlatformDiscoveryOperations(
       }
     }.map(_.toMap)
 
-  /** Checks if attribute is valid for given entity
-    *
-    * @param tableName  name of the table(entity) which needs to be checked
-    * @param columnName name of the column(attribute) which needs to be checked
-    * @return boolean which tells us if attribute is valid for given entity
-    */
-  override def isAttributeValid(tableName: String, columnName: String): Future[Boolean] =
-    caching
-      .getAttributes(tableName)
-      .map { attributesOpt =>
-        attributesOpt.exists {
-          case CacheEntry(_, attributes) =>
-            attributes.exists(_.name == columnName)
-        }
-      }
-      .unsafeToFuture()
-
   /**
     * Extracts entities in the DB for the given network
     *

--- a/src/test/scala/tech/cryptonomic/conseil/metadata/MetadataServiceTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/metadata/MetadataServiceTest.scala
@@ -206,7 +206,7 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
 
         // when
         val result =
-          sut(overwrittenConfiguration).getEntities(NetworkPath("mainnet", PlatformPath("tezos"))).futureValue
+          sut(overwrittenConfiguration).getEntities(NetworkPath("mainnet", PlatformPath("tezos")))
 
         // then
         result shouldBe Some(List(Entity("entity", "entity-name", 0)))
@@ -241,7 +241,7 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
 
         // when
         val result =
-          sut(overwrittenConfiguration).getEntities(NetworkPath("mainnet", PlatformPath("tezos"))).futureValue
+          sut(overwrittenConfiguration).getEntities(NetworkPath("mainnet", PlatformPath("tezos")))
 
         // then
         result shouldBe Some(List(Entity("entity", "overwritten name", 0)))
@@ -276,7 +276,7 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
 
         // when
         val result =
-          sut(overwrittenConfiguration).getEntities(NetworkPath("mainnet", PlatformPath("tezos"))).futureValue
+          sut(overwrittenConfiguration).getEntities(NetworkPath("mainnet", PlatformPath("tezos")))
 
         // then
         result shouldBe Some(List(Entity("entity", "entity-name", 0, Some("overwritten display name plural"))))
@@ -311,7 +311,7 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
 
         // when
         val result =
-          sut(overwrittenConfiguration).getEntities(NetworkPath("mainnet", PlatformPath("tezos"))).futureValue
+          sut(overwrittenConfiguration).getEntities(NetworkPath("mainnet", PlatformPath("tezos")))
 
         // then
         result shouldBe Some(List(Entity("entity", "entity-name", 0, None, Some("description"))))
@@ -346,7 +346,7 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
 
         // when
         val result =
-          sut(overwrittenConfiguration).getEntities(NetworkPath("mainnet", PlatformPath("tezos"))).futureValue
+          sut(overwrittenConfiguration).getEntities(NetworkPath("mainnet", PlatformPath("tezos")))
 
         // then
         result shouldBe Some(List.empty)
@@ -381,7 +381,7 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
 
         // when
         val result =
-          sut(overwrittenConfiguration).getEntities(NetworkPath("mainnet", PlatformPath("tezos"))).futureValue
+          sut(overwrittenConfiguration).getEntities(NetworkPath("mainnet", PlatformPath("tezos")))
 
         // then
         result shouldBe Some(List.empty)
@@ -390,7 +390,7 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
       "return None when fetching entities for a non existing platform" in {
         // when
         val result =
-          sut(Map.empty).getEntities(NetworkPath("mainnet", PlatformPath("non-existing-platform"))).futureValue
+          sut(Map.empty).getEntities(NetworkPath("mainnet", PlatformPath("non-existing-platform")))
 
         // then
         result shouldBe None
@@ -401,7 +401,7 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
         val overriddenConfiguration = Map("tezos" -> PlatformConfiguration(None, Some(true)))
 
         // when
-        val result = sut(overriddenConfiguration).getEntities(NetworkPath("tezos", PlatformPath("mainnet"))).futureValue
+        val result = sut(overriddenConfiguration).getEntities(NetworkPath("tezos", PlatformPath("mainnet")))
 
         // then
         result shouldBe None
@@ -412,9 +412,8 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
         val overriddenConfiguration = Map("tezos" -> PlatformConfiguration(None, Some(true)))
 
         // when
-        val result = sut(overriddenConfiguration)
-          .getEntities(NetworkPath("non-existing-network", PlatformPath("tezos")))
-          .futureValue
+        val result =
+          sut(overriddenConfiguration).getEntities(NetworkPath("non-existing-network", PlatformPath("tezos")))
 
         // then
         result shouldBe None
@@ -432,7 +431,7 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
         )
 
         // when
-        val result = sut(overriddenConfiguration).getEntities(NetworkPath("tezos", PlatformPath("mainnet"))).futureValue
+        val result = sut(overriddenConfiguration).getEntities(NetworkPath("tezos", PlatformPath("mainnet")))
 
         // then
         result shouldBe None
@@ -480,7 +479,6 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
         // when
         val result = sut(overwrittenConfiguration)
           .getTableAttributes(EntityPath("entity", NetworkPath("mainnet", PlatformPath("tezos"))))
-          .futureValue
 
         // then
         result shouldBe Some(List(Attribute("attribute", "attribute-name", Int, None, NonKey, "entity")))
@@ -542,7 +540,6 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
         // when
         val result = sut(overwrittenConfiguration)
           .getTableAttributes(EntityPath("entity", NetworkPath("mainnet", PlatformPath("tezos"))))
-          .futureValue
 
         // then
         result shouldBe Some(
@@ -611,7 +608,6 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
         // when
         val result = sut(overwrittenConfiguration)
           .getTableAttributes(EntityPath("entity", NetworkPath("mainnet", PlatformPath("tezos"))))
-          .futureValue
 
         // then
         result shouldBe Some(List.empty)
@@ -659,7 +655,6 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
         // when
         val result = sut(overwrittenConfiguration)
           .getTableAttributes(EntityPath("entity", NetworkPath("mainnet", PlatformPath("tezos"))))
-          .futureValue
 
         // then
         result shouldBe Some(List.empty)
@@ -677,7 +672,6 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
         // when
         val result = sut(Map.empty)
           .getTableAttributes(EntityPath("entity", NetworkPath("mainnet", PlatformPath("non-existing-platform"))))
-          .futureValue
 
         // then
         result shouldBe None
@@ -697,7 +691,6 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
         // when
         val result = sut(overriddenConfiguration)
           .getTableAttributes(EntityPath("entity", NetworkPath("mainnet", PlatformPath("tezos"))))
-          .futureValue
 
         // then
         result shouldBe None
@@ -715,7 +708,6 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
         // when
         val result = sut(Map.empty)
           .getTableAttributes(EntityPath("entity", NetworkPath("non-existing-network", PlatformPath("tezos"))))
-          .futureValue
 
         // then
         result shouldBe None
@@ -743,7 +735,6 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
         // when
         val result = sut(overriddenConfiguration)
           .getTableAttributes(EntityPath("entity", NetworkPath("mainnet", PlatformPath("tezos"))))
-          .futureValue
 
         // then
         result shouldBe None
@@ -759,7 +750,6 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
         // when
         val result = sut(Map.empty)
           .getTableAttributes(EntityPath("entity", NetworkPath("mainnet", PlatformPath("tezos"))))
-          .futureValue
 
         // then
         result shouldBe None
@@ -790,7 +780,6 @@ class MetadataServiceTest extends WordSpec with Matchers with ScalatestRouteTest
         // when
         val result = sut(overriddenConfiguration)
           .getTableAttributes(EntityPath("entity", NetworkPath("mainnet", PlatformPath("tezos"))))
-          .futureValue
 
         // then
         result shouldBe None

--- a/src/test/scala/tech/cryptonomic/conseil/metadata/MetadataServiceTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/metadata/MetadataServiceTest.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
-import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfterEach, Matchers, OneInstancePerTest, WordSpec}
 import tech.cryptonomic.conseil.config.Platforms.{PlatformsConfiguration, TezosConfiguration, TezosNodeConfiguration}
 import tech.cryptonomic.conseil.config.Types.PlatformName
 import tech.cryptonomic.conseil.config._
@@ -12,15 +12,14 @@ import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.DataType.{H
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.KeyType.NonKey
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.{Attribute, Entity, Network, Platform}
 
-import scala.concurrent.Future
-
 class MetadataServiceTest
     extends WordSpec
     with Matchers
     with ScalatestRouteTest
     with MockFactory
     with ScalaFutures
-    with BeforeAndAfterEach {
+    with BeforeAndAfterEach
+    with OneInstancePerTest {
 
   implicit override val patienceConfig = PatienceConfig(timeout = Span(2, Seconds), interval = Span(20, Millis))
 
@@ -41,11 +40,6 @@ class MetadataServiceTest
       cacheOverrides,
       platformDiscoveryOperations
     )
-
-  override protected def beforeEach(): Unit = {
-    super.beforeEach()
-    platformDiscoveryOperations.clear()
-  }
 
   "The metadata service" should {
 

--- a/src/test/scala/tech/cryptonomic/conseil/metadata/TestPlatformDiscoveryOperations.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/metadata/TestPlatformDiscoveryOperations.scala
@@ -10,23 +10,23 @@ class TestPlatformDiscoveryOperations extends PlatformDiscoveryOperations {
   var entities: List[Entity] = List.empty
   var attributes: List[Attribute] = List.empty
 
-  def addEntity(entity: Entity) = entities = entities :+ entity
+  def addEntity(entity: Entity): Unit = entities = entities :+ entity
 
   override def getEntities: Future[List[Entity]] = Future.successful(entities)
 
-  def addAttribute(attribute: Attribute) = attributes = attributes :+ attribute
+  def addAttribute(attribute: Attribute): Unit = attributes = attributes :+ attribute
 
   override def getTableAttributes(tableName: String): Future[Option[List[Attribute]]] =
     Future.successful(Some(attributes.filter(_.entity == tableName)))
 
-  override def getTableAttributesWithoutUpdatingCache(tableName: String): Future[Option[List[Attribute]]] = ???
+  override def getTableAttributesWithoutUpdatingCache(tableName: String): Future[Option[List[Attribute]]] = getTableAttributes(tableName)
+
   override def listAttributeValues(
                                     tableName: String,
                                     column: String,
                                     withFilter: Option[String],
                                     attributesCacheConfig: Option[PlatformDiscoveryTypes.AttributeCacheConfiguration]
                                   ): Future[Either[List[DataTypes.AttributesValidationError], List[String]]] = ???
-  override def isAttributeValid(tableName: String, columnName: String): Future[Boolean] = ???
 
   def clear(): Unit = {
     entities = List.empty

--- a/src/test/scala/tech/cryptonomic/conseil/metadata/TestPlatformDiscoveryOperations.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/metadata/TestPlatformDiscoveryOperations.scala
@@ -5,30 +5,42 @@ import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.{Attribute,
 
 import scala.concurrent.Future
 
+/* Implementation of PlatformDiscoveryOperations for tests purposes. It's fully functional and keeps entities and
+ * attributes in memory
+ *
+ * */
 class TestPlatformDiscoveryOperations extends PlatformDiscoveryOperations {
 
   var entities: List[Entity] = List.empty
   var attributes: List[Attribute] = List.empty
 
-  def addEntity(entity: Entity): Unit = entities = entities :+ entity
+  def addEntity(entity: Entity): Unit = this.synchronized {
+    entities = entities :+ entity
+  }
 
-  override def getEntities: Future[List[Entity]] = Future.successful(entities)
+  override def getEntities: Future[List[Entity]] = this.synchronized {
+    Future.successful(entities)
+  }
 
-  def addAttribute(attribute: Attribute): Unit = attributes = attributes :+ attribute
+  def addAttribute(attribute: Attribute): Unit = this.synchronized {
+    attributes = attributes :+ attribute
+  }
 
-  override def getTableAttributes(tableName: String): Future[Option[List[Attribute]]] =
+  override def getTableAttributes(tableName: String): Future[Option[List[Attribute]]] = this.synchronized {
     Future.successful(Some(attributes.filter(_.entity == tableName)))
+  }
 
-  override def getTableAttributesWithoutUpdatingCache(tableName: String): Future[Option[List[Attribute]]] = getTableAttributes(tableName)
+  override def getTableAttributesWithoutUpdatingCache(tableName: String): Future[Option[List[Attribute]]] =
+    getTableAttributes(tableName)
 
   override def listAttributeValues(
-                                    tableName: String,
-                                    column: String,
-                                    withFilter: Option[String],
-                                    attributesCacheConfig: Option[PlatformDiscoveryTypes.AttributeCacheConfiguration]
-                                  ): Future[Either[List[DataTypes.AttributesValidationError], List[String]]] = ???
+      tableName: String,
+      column: String,
+      withFilter: Option[String],
+      attributesCacheConfig: Option[PlatformDiscoveryTypes.AttributeCacheConfiguration]
+  ): Future[Either[List[DataTypes.AttributesValidationError], List[String]]] = ???
 
-  def clear(): Unit = {
+  def clear(): Unit = this.synchronized {
     entities = List.empty
     attributes = List.empty
   }

--- a/src/test/scala/tech/cryptonomic/conseil/metadata/TestPlatformDiscoveryOperations.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/metadata/TestPlatformDiscoveryOperations.scala
@@ -1,0 +1,35 @@
+package tech.cryptonomic.conseil.metadata
+
+import tech.cryptonomic.conseil.generic.chain.{DataTypes, PlatformDiscoveryOperations, PlatformDiscoveryTypes}
+import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.{Attribute, Entity}
+
+import scala.concurrent.Future
+
+class TestPlatformDiscoveryOperations extends PlatformDiscoveryOperations {
+
+  var entities: List[Entity] = List.empty
+  var attributes: List[Attribute] = List.empty
+
+  def addEntity(entity: Entity) = entities = entities :+ entity
+
+  override def getEntities: Future[List[Entity]] = Future.successful(entities)
+
+  def addAttribute(attribute: Attribute) = attributes = attributes :+ attribute
+
+  override def getTableAttributes(tableName: String): Future[Option[List[Attribute]]] =
+    Future.successful(Some(attributes.filter(_.entity == tableName)))
+
+  override def getTableAttributesWithoutUpdatingCache(tableName: String): Future[Option[List[Attribute]]] = ???
+  override def listAttributeValues(
+                                    tableName: String,
+                                    column: String,
+                                    withFilter: Option[String],
+                                    attributesCacheConfig: Option[PlatformDiscoveryTypes.AttributeCacheConfiguration]
+                                  ): Future[Either[List[DataTypes.AttributesValidationError], List[String]]] = ???
+  override def isAttributeValid(tableName: String, columnName: String): Future[Boolean] = ???
+
+  def clear(): Unit = {
+    entities = List.empty
+    attributes = List.empty
+  }
+}

--- a/src/test/scala/tech/cryptonomic/conseil/metadata/TransparentUnitTransformation.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/metadata/TransparentUnitTransformation.scala
@@ -3,8 +3,8 @@ package tech.cryptonomic.conseil.metadata
 import tech.cryptonomic.conseil.config.MetadataConfiguration
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes
 
-class TransparentUnitTransformation(overrides: MetadataConfiguration = MetadataConfiguration(Map.empty))
-    extends UnitTransformation(overrides) {
+/* UnitTransformation implementation for test purposes. It overrides nothing. */
+object TransparentUnitTransformation extends UnitTransformation(MetadataConfiguration(Map.empty)) {
   override def overridePlatforms(
       platforms: List[PlatformDiscoveryTypes.Platform]
   ): List[PlatformDiscoveryTypes.Platform] = platforms

--- a/src/test/scala/tech/cryptonomic/conseil/metadata/TransparentUnitTransformation.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/metadata/TransparentUnitTransformation.scala
@@ -1,0 +1,26 @@
+package tech.cryptonomic.conseil.metadata
+
+import tech.cryptonomic.conseil.config.MetadataConfiguration
+import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes
+
+class TransparentUnitTransformation(overrides: MetadataConfiguration = MetadataConfiguration(Map.empty))
+    extends UnitTransformation(overrides) {
+  override def overridePlatforms(
+      platforms: List[PlatformDiscoveryTypes.Platform]
+  ): List[PlatformDiscoveryTypes.Platform] = platforms
+
+  override def overrideNetworks(
+      platformPath: PlatformPath,
+      networks: List[PlatformDiscoveryTypes.Network]
+  ): List[PlatformDiscoveryTypes.Network] = networks
+
+  override def overrideEntities(
+      networkPath: NetworkPath,
+      entities: List[PlatformDiscoveryTypes.Entity]
+  ): List[PlatformDiscoveryTypes.Entity] = entities
+
+  override def overrideAttributes(
+      path: EntityPath,
+      attributes: List[PlatformDiscoveryTypes.Attribute]
+  ): List[PlatformDiscoveryTypes.Attribute] = attributes
+}

--- a/src/test/scala/tech/cryptonomic/conseil/routes/PlatformDiscoveryTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/routes/PlatformDiscoveryTest.scala
@@ -6,10 +6,17 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{Matchers, WordSpec}
 import tech.cryptonomic.conseil.config.Platforms.{PlatformsConfiguration, TezosConfiguration, TezosNodeConfiguration}
 import tech.cryptonomic.conseil.config.Types.PlatformName
-import tech.cryptonomic.conseil.config.{AttributeConfiguration, EntityConfiguration, MetadataConfiguration, NetworkConfiguration, PlatformConfiguration, Platforms}
+import tech.cryptonomic.conseil.config.{
+  AttributeConfiguration,
+  EntityConfiguration,
+  MetadataConfiguration,
+  NetworkConfiguration,
+  PlatformConfiguration,
+  Platforms
+}
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.DataType.Int
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.KeyType.NonKey
-import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.{Attribute, AttributeCacheConfiguration, Entity}
+import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.{Attribute, Entity}
 import tech.cryptonomic.conseil.metadata.{AttributeValuesCacheConfiguration, MetadataService, UnitTransformation}
 import tech.cryptonomic.conseil.tezos.TezosPlatformDiscoveryOperations
 import tech.cryptonomic.conseil.util.JsonUtil.toListOfMaps
@@ -251,7 +258,7 @@ class PlatformDiscoveryTest extends WordSpec with Matchers with ScalatestRouteTe
                                         displayOrder = Some(1),
                                         currencySymbol = Some("ꜩ"),
                                         currencySymbolCode = Some(42793)
-                                    )
+                                      )
                                 )
                               )
                         )

--- a/src/test/scala/tech/cryptonomic/conseil/routes/PlatformDiscoveryTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/routes/PlatformDiscoveryTest.scala
@@ -6,18 +6,11 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{Matchers, WordSpec}
 import tech.cryptonomic.conseil.config.Platforms.{PlatformsConfiguration, TezosConfiguration, TezosNodeConfiguration}
 import tech.cryptonomic.conseil.config.Types.PlatformName
-import tech.cryptonomic.conseil.config.{
-  AttributeConfiguration,
-  EntityConfiguration,
-  MetadataConfiguration,
-  NetworkConfiguration,
-  PlatformConfiguration,
-  Platforms
-}
+import tech.cryptonomic.conseil.config.{AttributeConfiguration, EntityConfiguration, MetadataConfiguration, NetworkConfiguration, PlatformConfiguration, Platforms}
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.DataType.Int
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.KeyType.NonKey
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.{Attribute, Entity}
-import tech.cryptonomic.conseil.metadata.{AttributeValuesCacheConfiguration, MetadataService, UnitTransformation}
+import tech.cryptonomic.conseil.metadata.{AttributeValuesCacheConfiguration, MetadataService, TestPlatformDiscoveryOperations, UnitTransformation}
 import tech.cryptonomic.conseil.tezos.TezosPlatformDiscoveryOperations
 import tech.cryptonomic.conseil.util.JsonUtil.toListOfMaps
 
@@ -27,7 +20,7 @@ class PlatformDiscoveryTest extends WordSpec with Matchers with ScalatestRouteTe
 
   "The platform discovery route" should {
 
-      val tezosPlatformDiscoveryOperations = stub[TezosPlatformDiscoveryOperations]
+      val tezosPlatformDiscoveryOperations = new TestPlatformDiscoveryOperations
       val cacheOverrides = stub[AttributeValuesCacheConfiguration]
 
       val sut = (metadataOverridesConfiguration: Map[PlatformName, PlatformConfiguration]) =>
@@ -123,9 +116,7 @@ class PlatformDiscoveryTest extends WordSpec with Matchers with ScalatestRouteTe
 
       "expose an endpoint to get the list of supported entities" in {
         // given
-        (tezosPlatformDiscoveryOperations.getEntities _)
-          .when()
-          .returns(successful(List(Entity("entity", "entity-name", 1))))
+        tezosPlatformDiscoveryOperations.addEntity(Entity("entity", "entity-name", 1))
 
         val overridesConfiguration = Map(
           "tezos" ->
@@ -163,12 +154,8 @@ class PlatformDiscoveryTest extends WordSpec with Matchers with ScalatestRouteTe
 
       "expose an endpoint to get the list of supported attributes" in {
         // given
-        (tezosPlatformDiscoveryOperations.getEntities _)
-          .when()
-          .returns(successful(List(Entity("entity", "entity-name", 1))))
-        (tezosPlatformDiscoveryOperations.getTableAttributes _)
-          .when("entity")
-          .returns(successful(Some(List(Attribute("attribute", "attribute-name", Int, None, NonKey, "entity")))))
+        tezosPlatformDiscoveryOperations.addEntity(Entity("entity", "entity-name", 1))
+        tezosPlatformDiscoveryOperations.addAttribute(Attribute("attribute", "attribute-name", Int, None, NonKey, "entity"))
 
         val overridesConfiguration = Map(
           "tezos" ->
@@ -216,12 +203,8 @@ class PlatformDiscoveryTest extends WordSpec with Matchers with ScalatestRouteTe
 
       "override additional data for attributes" in {
         // given
-        (tezosPlatformDiscoveryOperations.getEntities _)
-          .when()
-          .returns(successful(List(Entity("entity", "entity-name", 1))))
-        (tezosPlatformDiscoveryOperations.getTableAttributes _)
-          .when("entity")
-          .returns(successful(Some(List(Attribute("attribute", "attribute-name", Int, None, NonKey, "entity")))))
+        tezosPlatformDiscoveryOperations.addEntity(Entity("entity", "entity-name", 1))
+        tezosPlatformDiscoveryOperations.addAttribute(Attribute("attribute", "attribute-name", Int, None, NonKey, "entity"))
 
         val overridesConfiguration = Map(
           "tezos" ->
@@ -296,12 +279,8 @@ class PlatformDiscoveryTest extends WordSpec with Matchers with ScalatestRouteTe
 
       "return 404 on getting attributes when parent entity is not enabled" in {
         // given
-        (tezosPlatformDiscoveryOperations.getEntities _)
-          .when()
-          .returns(successful(List(Entity("entity", "entity-name", 1))))
-        (tezosPlatformDiscoveryOperations.getTableAttributes _)
-          .when("entity")
-          .returns(successful(Some(List(Attribute("attribute", "attribute-name", Int, None, NonKey, "entity")))))
+        tezosPlatformDiscoveryOperations.addEntity(Entity("entity", "entity-name", 1))
+        tezosPlatformDiscoveryOperations.addAttribute(Attribute("attribute", "attribute-name", Int, None, NonKey, "entity"))
 
         val overridesConfiguration = Map(
           "tezos" ->
@@ -328,12 +307,8 @@ class PlatformDiscoveryTest extends WordSpec with Matchers with ScalatestRouteTe
 
       "return 404 on getting attributes when parent network is not enabled" in {
         // given
-        (tezosPlatformDiscoveryOperations.getEntities _)
-          .when()
-          .returns(successful(List(Entity("entity", "entity-name", 1))))
-        (tezosPlatformDiscoveryOperations.getTableAttributes _)
-          .when("entity")
-          .returns(successful(Some(List(Attribute("attribute", "attribute-name", Int, None, NonKey, "entity")))))
+        tezosPlatformDiscoveryOperations.addEntity(Entity("entity", "entity-name", 1))
+        tezosPlatformDiscoveryOperations.addAttribute(Attribute("attribute", "attribute-name", Int, None, NonKey, "entity"))
 
         val overridesConfiguration = Map(
           "tezos" ->
@@ -352,12 +327,8 @@ class PlatformDiscoveryTest extends WordSpec with Matchers with ScalatestRouteTe
 
       "return 404 on getting attributes when parent platform is not enabled" in {
         // given
-        (tezosPlatformDiscoveryOperations.getEntities _)
-          .when()
-          .returns(successful(List(Entity("entity", "entity-name", 1))))
-        (tezosPlatformDiscoveryOperations.getTableAttributes _)
-          .when("entity")
-          .returns(successful(Some(List(Attribute("attribute", "attribute-name", Int, None, NonKey, "entity")))))
+        tezosPlatformDiscoveryOperations.addEntity(Entity("entity", "entity-name", 1))
+        tezosPlatformDiscoveryOperations.addAttribute(Attribute("attribute", "attribute-name", Int, None, NonKey, "entity"))
 
         // when
         Get("/v2/metadata/tezos/mainnet/entity/attributes") ~> addHeader("apiKey", "hooman") ~> sut(Map.empty) ~> check {

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DataTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DataTest.scala
@@ -148,7 +148,7 @@ class DataTest extends WordSpec with Matchers with ScalatestRouteTest with Scala
         (metadataServiceStub
           .getEntities(_: NetworkPath))
           .when(*)
-          .returns(Future.successful(Some(List(testEntity))))
+          .returns(Some(List(testEntity)))
 
         val postRequest = HttpRequest(
           HttpMethods.POST,
@@ -172,7 +172,7 @@ class DataTest extends WordSpec with Matchers with ScalatestRouteTest with Scala
         (metadataServiceStub
           .getEntities(_: NetworkPath))
           .when(*)
-          .returns(Future.successful(Some(List(testEntity))))
+          .returns(Some(List(testEntity)))
         val postRequest = HttpRequest(
           HttpMethods.POST,
           uri = "/v2/data/notSupportedPlatform/alphanet/accounts",
@@ -192,7 +192,7 @@ class DataTest extends WordSpec with Matchers with ScalatestRouteTest with Scala
         (metadataServiceStub
           .getEntities(_: NetworkPath))
           .when(*)
-          .returns(Future.successful(Some(List(testEntity))))
+          .returns(Some(List(testEntity)))
         val postRequest = HttpRequest(
           HttpMethods.POST,
           uri = "/v2/data/tezos/notSupportedNetwork/accounts",

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DataTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DataTest.scala
@@ -21,7 +21,6 @@ import tech.cryptonomic.conseil.routes.Data
 import scala.concurrent.{ExecutionContext, Future}
 
 class DataTest extends WordSpec with Matchers with ScalatestRouteTest with ScalaFutures with MockFactory {
-  val ec: ExecutionContext = system.dispatcher
 
   val jsonStringRequest: String =
     """
@@ -134,21 +133,21 @@ class DataTest extends WordSpec with Matchers with ScalatestRouteTest with Scala
 
   val metadataServiceStub = stub[MetadataService]
 
-  val postRoute: Route = new Data(cfg, fakeQPP, metadataServiceStub)(ec).postRoute
+  val postRoute: Route = new Data(cfg, fakeQPP, metadataServiceStub).postRoute
 
-  val getRoute: Route = new Data(cfg, fakeQPP, metadataServiceStub)(ec).getRoute
+  val getRoute: Route = new Data(cfg, fakeQPP, metadataServiceStub).getRoute
 
   "Query protocol" should {
 
       "return a correct response with OK status code with POST" in {
         (metadataServiceStub.isAttributeValid _).when(*, *).returns(Future.successful(true))
         (metadataServiceStub
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath)(_: ExecutionContext))
-          .when(*, *)
+          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
+          .when(*)
           .returns(Future.successful(Some(accountAttributes)))
         (metadataServiceStub
-          .getEntities(_: NetworkPath)(_: ExecutionContext))
-          .when(*, *)
+          .getEntities(_: NetworkPath))
+          .when(*)
           .returns(Future.successful(Some(List(testEntity))))
 
         val postRequest = HttpRequest(
@@ -167,12 +166,12 @@ class DataTest extends WordSpec with Matchers with ScalatestRouteTest with Scala
       "return 404 NotFound status code for request for the not supported platform with POST" in {
         (metadataServiceStub.isAttributeValid _).when(*, *).returns(Future.successful(true))
         (metadataServiceStub
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath)(_: ExecutionContext))
-          .when(*, *)
+          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
+          .when(*)
           .returns(Future.successful(Some(accountAttributes)))
         (metadataServiceStub
-          .getEntities(_: NetworkPath)(_: ExecutionContext))
-          .when(*, *)
+          .getEntities(_: NetworkPath))
+          .when(*)
           .returns(Future.successful(Some(List(testEntity))))
         val postRequest = HttpRequest(
           HttpMethods.POST,
@@ -187,12 +186,12 @@ class DataTest extends WordSpec with Matchers with ScalatestRouteTest with Scala
       "return 404 NotFound status code for request for the not supported network with POST" in {
         (metadataServiceStub.isAttributeValid _).when(*, *).returns(Future.successful(true))
         (metadataServiceStub
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath)(_: ExecutionContext))
-          .when(*, *)
+          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
+          .when(*)
           .returns(Future.successful(Some(accountAttributes)))
         (metadataServiceStub
-          .getEntities(_: NetworkPath)(_: ExecutionContext))
-          .when(*, *)
+          .getEntities(_: NetworkPath))
+          .when(*)
           .returns(Future.successful(Some(List(testEntity))))
         val postRequest = HttpRequest(
           HttpMethods.POST,

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DataTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DataTest.scala
@@ -140,7 +140,7 @@ class DataTest extends WordSpec with Matchers with ScalatestRouteTest with Scala
   "Query protocol" should {
 
       "return a correct response with OK status code with POST" in {
-        (metadataServiceStub.isAttributeValid _).when(*, *).returns(Future.successful(true))
+        (metadataServiceStub.attributeExists _).when(*, *).returns(Future.successful(true))
         (metadataServiceStub
           .getTableAttributesWithoutUpdatingCache(_: EntityPath))
           .when(*)
@@ -164,7 +164,7 @@ class DataTest extends WordSpec with Matchers with ScalatestRouteTest with Scala
       }
 
       "return 404 NotFound status code for request for the not supported platform with POST" in {
-        (metadataServiceStub.isAttributeValid _).when(*, *).returns(Future.successful(true))
+        (metadataServiceStub.attributeExists _).when(*, *).returns(Future.successful(true))
         (metadataServiceStub
           .getTableAttributesWithoutUpdatingCache(_: EntityPath))
           .when(*)
@@ -184,7 +184,7 @@ class DataTest extends WordSpec with Matchers with ScalatestRouteTest with Scala
       }
 
       "return 404 NotFound status code for request for the not supported network with POST" in {
-        (metadataServiceStub.isAttributeValid _).when(*, *).returns(Future.successful(true))
+        (metadataServiceStub.attributeExists _).when(*, *).returns(Future.successful(true))
         (metadataServiceStub
           .getTableAttributesWithoutUpdatingCache(_: EntityPath))
           .when(*)

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DataTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DataTest.scala
@@ -148,7 +148,7 @@ class DataTest
               )
         )
       ),
-      new TransparentUnitTransformation(),
+      TransparentUnitTransformation,
       cacheOverrides,
       platformDiscoveryOperations
     )

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
@@ -28,7 +28,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           keyType = KeyType.UniqueKey,
           entity = "testEntity"
         )
-        (ms.isAttributeValid _).when("testEntity", "valid").returns(Future.successful(true))
+        (ms.attributeExists _).when("testEntity", "valid").returns(Future.successful(true))
         (ms
           .getTableAttributesWithoutUpdatingCache(_: EntityPath))
           .when(*)
@@ -53,7 +53,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
       }
 
       "return error with incorrect query fields" in {
-        (ms.isAttributeValid _).when("testEntity", "invalid").returns(Future.successful(false))
+        (ms.attributeExists _).when("testEntity", "invalid").returns(Future.successful(false))
         (ms
           .getEntities(_: NetworkPath))
           .when(*)
@@ -82,7 +82,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           keyType = KeyType.UniqueKey,
           entity = "test"
         )
-        (ms.isAttributeValid _).when("testEntity", "valid").returns(Future.successful(true))
+        (ms.attributeExists _).when("testEntity", "valid").returns(Future.successful(true))
         (ms
           .getTableAttributesWithoutUpdatingCache(_: EntityPath))
           .when(*)
@@ -115,7 +115,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           keyType = KeyType.UniqueKey,
           entity = "test"
         )
-        (ms.isAttributeValid _).when("testEntity", "invalid").returns(Future.successful(false))
+        (ms.attributeExists _).when("testEntity", "invalid").returns(Future.successful(false))
         (ms
           .getTableAttributesWithoutUpdatingCache(_: EntityPath))
           .when(*)
@@ -150,7 +150,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           entity = "testEntity"
         )
 
-        (ms.isAttributeValid _).when("testEntity", "valid").returns(Future.successful(true))
+        (ms.attributeExists _).when("testEntity", "valid").returns(Future.successful(true))
         (ms
           .getTableAttributesWithoutUpdatingCache(_: EntityPath))
           .when(*)
@@ -176,7 +176,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
       }
 
       "return error with incorrect orderBy fields" in {
-        (ms.isAttributeValid _).when("testEntity", "invalid").returns(Future.successful(false))
+        (ms.attributeExists _).when("testEntity", "invalid").returns(Future.successful(false))
         (ms
           .getEntities(_: NetworkPath))
           .when(*)
@@ -206,7 +206,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           entity = "test"
         )
 
-        (ms.isAttributeValid _).when("testEntity", "valid").returns(Future.successful(true))
+        (ms.attributeExists _).when("testEntity", "valid").returns(Future.successful(true))
         (ms
           .getTableAttributesWithoutUpdatingCache(_: EntityPath))
           .when(*)
@@ -243,7 +243,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           entity = "test"
         )
 
-        (ms.isAttributeValid _).when("testEntity", "invalid").returns(Future.successful(true))
+        (ms.attributeExists _).when("testEntity", "invalid").returns(Future.successful(true))
         (ms
           .getTableAttributesWithoutUpdatingCache(_: EntityPath))
           .when(*)
@@ -276,8 +276,8 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           keyType = KeyType.NonKey,
           entity = "test"
         )
-        (ms.isAttributeValid _).when("testEntity", "valid").returns(Future.successful(true)) once ()
-        (ms.isAttributeValid _).when("testEntity", "invalid").returns(Future.successful(false)) once ()
+        (ms.attributeExists _).when("testEntity", "valid").returns(Future.successful(true)) once ()
+        (ms.attributeExists _).when("testEntity", "invalid").returns(Future.successful(false)) once ()
         (ms
           .getTableAttributesWithoutUpdatingCache(_: EntityPath))
           .when(*)
@@ -314,7 +314,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           entity = "test"
         )
 
-        (ms.isAttributeValid _).when("testEntity", "InvalidAttribute").returns(Future.successful(true))
+        (ms.attributeExists _).when("testEntity", "InvalidAttribute").returns(Future.successful(true))
         (ms
           .getTableAttributesWithoutUpdatingCache(_: EntityPath))
           .when(*)
@@ -348,7 +348,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           entity = "test"
         )
 
-        (ms.isAttributeValid _).when("testEntity", "valid").returns(Future.successful(true))
+        (ms.attributeExists _).when("testEntity", "valid").returns(Future.successful(true))
         (ms
           .getTableAttributesWithoutUpdatingCache(_: EntityPath))
           .when(*)
@@ -386,7 +386,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           entity = "testEntity"
         )
 
-        (ms.isAttributeValid _).when("testEntity", "valid").returns(Future.successful(true))
+        (ms.attributeExists _).when("testEntity", "valid").returns(Future.successful(true))
         (ms
           .getTableAttributesWithoutUpdatingCache(_: EntityPath))
           .when(*)
@@ -425,7 +425,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           keyType = KeyType.NonKey,
           entity = "testEntity"
         )
-        (ms.isAttributeValid _).when("testEntity", "validAttribute").returns(Future.successful(true)).anyNumberOfTimes()
+        (ms.attributeExists _).when("testEntity", "validAttribute").returns(Future.successful(true)).anyNumberOfTimes()
         (ms
           .getTableAttributesWithoutUpdatingCache(_: EntityPath))
           .when(testEntityPath)
@@ -462,7 +462,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           keyType = KeyType.NonKey,
           entity = "testEntity"
         )
-        (ms.isAttributeValid _).when("testEntity", "validAttribute").returns(Future.successful(true)).anyNumberOfTimes()
+        (ms.attributeExists _).when("testEntity", "validAttribute").returns(Future.successful(true)).anyNumberOfTimes()
         (ms
           .getTableAttributesWithoutUpdatingCache(_: EntityPath))
           .when(testEntityPath)

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
@@ -4,14 +4,20 @@ import java.sql.Timestamp
 
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfterEach, Matchers, OneInstancePerTest, WordSpec}
 import tech.cryptonomic.conseil.config.Platforms
 import tech.cryptonomic.conseil.config.Platforms.{PlatformsConfiguration, TezosConfiguration, TezosNodeConfiguration}
 import tech.cryptonomic.conseil.generic.chain.DataTypes._
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.{Attribute, DataType, Entity, KeyType}
 import tech.cryptonomic.conseil.metadata._
 
-class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFactory with BeforeAndAfterEach {
+class DataTypesTest
+    extends WordSpec
+    with Matchers
+    with ScalaFutures
+    with MockFactory
+    with BeforeAndAfterEach
+    with OneInstancePerTest {
   import scala.concurrent.ExecutionContext.Implicits.global
 
   val platformDiscoveryOperations = new TestPlatformDiscoveryOperations
@@ -28,7 +34,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
               )
         )
       ),
-      new TransparentUnitTransformation(),
+      TransparentUnitTransformation,
       cacheOverrides,
       platformDiscoveryOperations
     )
@@ -36,8 +42,6 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
 
   val testEntityPath = EntityPath("testEntity", NetworkPath("alphanet", PlatformPath("tezos")))
   val testEntity = Entity("testEntity", "Test Entity", 0)
-
-  override protected def beforeEach(): Unit = platformDiscoveryOperations.clear()
 
   "DataTypes" should {
       "validate correct query field" in {

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
@@ -4,19 +4,40 @@ import java.sql.Timestamp
 
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
+import tech.cryptonomic.conseil.config.Platforms
+import tech.cryptonomic.conseil.config.Platforms.{PlatformsConfiguration, TezosConfiguration, TezosNodeConfiguration}
 import tech.cryptonomic.conseil.generic.chain.DataTypes._
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.{Attribute, DataType, Entity, KeyType}
-import tech.cryptonomic.conseil.metadata.{EntityPath, MetadataService, NetworkPath, PlatformPath}
+import tech.cryptonomic.conseil.metadata._
 
-import scala.concurrent.Future
-
-class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFactory {
+class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFactory with BeforeAndAfterEach {
   import scala.concurrent.ExecutionContext.Implicits.global
 
-  val ms = stub[MetadataService]
-  val testEntityPath = EntityPath("testEntity", NetworkPath("testNetwork", PlatformPath("testPlatform")))
+  val platformDiscoveryOperations = new TestPlatformDiscoveryOperations
+  val cacheOverrides = stub[AttributeValuesCacheConfiguration]
+
+  def createMetadataService(stubbing: => Unit = ()): MetadataService = {
+    stubbing
+
+    new MetadataService(
+      PlatformsConfiguration(
+        Map(
+          Platforms.Tezos -> List(
+                TezosConfiguration("alphanet", TezosNodeConfiguration("tezos-host", 123, "https://"))
+              )
+        )
+      ),
+      new TransparentUnitTransformation(),
+      cacheOverrides,
+      platformDiscoveryOperations
+    )
+  }
+
+  val testEntityPath = EntityPath("testEntity", NetworkPath("alphanet", PlatformPath("tezos")))
   val testEntity = Entity("testEntity", "Test Entity", 0)
+
+  override protected def beforeEach(): Unit = platformDiscoveryOperations.clear()
 
   "DataTypes" should {
       "validate correct query field" in {
@@ -28,15 +49,10 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           keyType = KeyType.UniqueKey,
           entity = "testEntity"
         )
-        (ms.attributeExists _).when("testEntity", "valid").returns(Future.successful(true))
-        (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
-          .when(*)
-          .returns(Future.successful(Some(List(attribute))))
-        (ms
-          .getEntities(_: NetworkPath))
-          .when(*)
-          .returns(Some(List(testEntity)))
+        val metadataService = createMetadataService {
+          platformDiscoveryOperations.addEntity(testEntity)
+          platformDiscoveryOperations.addAttribute(attribute)
+        }
 
         val query = ApiQuery(
           fields = Some(List("valid")),
@@ -47,17 +63,12 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           aggregation = None
         )
 
-        val result = query.validate(testEntityPath, ms)
-        result.futureValue.right.get shouldBe Query(fields = List("valid"))
-
+        val result = query.validate(testEntityPath, metadataService).futureValue
+        result.right.get shouldBe Query(fields = List("valid"))
       }
 
       "return error with incorrect query fields" in {
-        (ms.attributeExists _).when("testEntity", "invalid").returns(Future.successful(false))
-        (ms
-          .getEntities(_: NetworkPath))
-          .when(*)
-          .returns(Some(List(testEntity)))
+        platformDiscoveryOperations.addEntity(testEntity)
 
         val query = ApiQuery(
           fields = Some(List("invalid")),
@@ -68,7 +79,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           aggregation = None
         )
 
-        val result = query.validate(testEntityPath, ms)
+        val result = query.validate(testEntityPath, createMetadataService())
 
         result.futureValue.left.get shouldBe List(InvalidQueryField("invalid"))
       }
@@ -80,17 +91,13 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           dataType = DataType.Int,
           cardinality = None,
           keyType = KeyType.UniqueKey,
-          entity = "test"
+          entity = "testEntity"
         )
-        (ms.attributeExists _).when("testEntity", "valid").returns(Future.successful(true))
-        (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
-          .when(*)
-          .returns(Future.successful(Some(List(attribute))))
-        (ms
-          .getEntities(_: NetworkPath))
-          .when(*)
-          .returns(Some(List(testEntity)))
+
+        val metadataService = createMetadataService {
+          platformDiscoveryOperations.addEntity(testEntity)
+          platformDiscoveryOperations.addAttribute(attribute)
+        }
 
         val query = ApiQuery(
           fields = None,
@@ -101,9 +108,9 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           aggregation = None
         )
 
-        val result = query.validate(testEntityPath, ms)
+        val result = query.validate(testEntityPath, metadataService).futureValue
 
-        result.futureValue.right.get shouldBe Query(predicates = List(Predicate("valid", OperationType.in)))
+        result.right.get shouldBe Query(predicates = List(Predicate("valid", OperationType.in)))
       }
 
       "return error with incorrect predicate fields" in {
@@ -115,16 +122,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           keyType = KeyType.UniqueKey,
           entity = "test"
         )
-        (ms.attributeExists _).when("testEntity", "invalid").returns(Future.successful(false))
-        (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
-          .when(*)
-          .returns(Future.successful(Some(List(attribute))))
-          .anyNumberOfTimes()
-        (ms
-          .getEntities(_: NetworkPath))
-          .when(*)
-          .returns(Some(List(testEntity)))
+        platformDiscoveryOperations.addEntity(testEntity)
 
         val query = ApiQuery(
           fields = None,
@@ -135,7 +133,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           aggregation = None
         )
 
-        val result = query.validate(testEntityPath, ms)
+        val result = query.validate(testEntityPath, createMetadataService())
 
         result.futureValue.left.get shouldBe List(InvalidPredicateField("invalid"))
       }
@@ -150,16 +148,10 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           entity = "testEntity"
         )
 
-        (ms.attributeExists _).when("testEntity", "valid").returns(Future.successful(true))
-        (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
-          .when(*)
-          .returns(Future.successful(Some(List(attribute))))
-          .anyNumberOfTimes()
-        (ms
-          .getEntities(_: NetworkPath))
-          .when(*)
-          .returns(Some(List(testEntity)))
+        val metadataService = createMetadataService {
+          platformDiscoveryOperations.addEntity(testEntity)
+          platformDiscoveryOperations.addAttribute(attribute)
+        }
 
         val query = ApiQuery(
           fields = None,
@@ -170,17 +162,13 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           aggregation = None
         )
 
-        val result = query.validate(testEntityPath, ms)
+        val result = query.validate(testEntityPath, metadataService)
 
         result.futureValue.right.get shouldBe Query(orderBy = List(QueryOrdering("valid", OrderDirection.asc)))
       }
 
       "return error with incorrect orderBy fields" in {
-        (ms.attributeExists _).when("testEntity", "invalid").returns(Future.successful(false))
-        (ms
-          .getEntities(_: NetworkPath))
-          .when(*)
-          .returns(Some(List(testEntity)))
+        platformDiscoveryOperations.addEntity(testEntity)
 
         val query = ApiQuery(
           fields = None,
@@ -191,7 +179,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           aggregation = None
         )
 
-        val result = query.validate(testEntityPath, ms)
+        val result = query.validate(testEntityPath, createMetadataService())
 
         result.futureValue.left.get shouldBe List(InvalidOrderByField("invalid"))
       }
@@ -203,18 +191,13 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           dataType = DataType.Int,
           cardinality = None,
           keyType = KeyType.UniqueKey,
-          entity = "test"
+          entity = "testEntity"
         )
 
-        (ms.attributeExists _).when("testEntity", "valid").returns(Future.successful(true))
-        (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
-          .when(*)
-          .returns(Future.successful(Some(List(attribute))))
-        (ms
-          .getEntities(_: NetworkPath))
-          .when(*)
-          .returns(Some(List(testEntity)))
+        val metadataService = createMetadataService {
+          platformDiscoveryOperations.addAttribute(attribute)
+          platformDiscoveryOperations.addEntity(testEntity)
+        }
 
         val query = ApiQuery(
           fields = Some(List("valid")),
@@ -225,7 +208,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           aggregation = Some(List(ApiAggregation(field = "valid")))
         )
 
-        val result = query.validate(testEntityPath, ms)
+        val result = query.validate(testEntityPath, metadataService)
 
         result.futureValue.right.get shouldBe Query(
           fields = List("valid"),
@@ -240,18 +223,13 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           dataType = DataType.String,
           cardinality = None,
           keyType = KeyType.UniqueKey,
-          entity = "test"
+          entity = "testEntity"
         )
 
-        (ms.attributeExists _).when("testEntity", "invalid").returns(Future.successful(true))
-        (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
-          .when(*)
-          .returns(Future.successful(Some(List(attribute))))
-        (ms
-          .getEntities(_: NetworkPath))
-          .when(*)
-          .returns(Some(List(testEntity)))
+        val metadataService = createMetadataService {
+          platformDiscoveryOperations.addAttribute(attribute)
+          platformDiscoveryOperations.addEntity(testEntity)
+        }
 
         val query = ApiQuery(
           fields = Some(List("invalid")),
@@ -262,7 +240,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           aggregation = Some(List(ApiAggregation(field = "invalid")))
         )
 
-        val result = query.validate(testEntityPath, ms)
+        val result = query.validate(testEntityPath, metadataService)
 
         result.futureValue.left.get shouldBe List(InvalidAggregationFieldForType("invalid"))
       }
@@ -274,18 +252,13 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           dataType = DataType.String,
           cardinality = None,
           keyType = KeyType.NonKey,
-          entity = "test"
+          entity = "testEntity"
         )
-        (ms.attributeExists _).when("testEntity", "valid").returns(Future.successful(true)) once ()
-        (ms.attributeExists _).when("testEntity", "invalid").returns(Future.successful(false)) once ()
-        (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
-          .when(*)
-          .returns(Future.successful(Some(List(attribute))))
-        (ms
-          .getEntities(_: NetworkPath))
-          .when(*)
-          .returns(Some(List(testEntity)))
+
+        val metadataService = createMetadataService {
+          platformDiscoveryOperations.addAttribute(attribute)
+          platformDiscoveryOperations.addEntity(testEntity)
+        }
 
         val query = ApiQuery(
           fields = Some(List("valid")),
@@ -296,10 +269,10 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           aggregation = Some(List(ApiAggregation(field = "invalid")))
         )
 
-        val result = query.validate(testEntityPath, ms)
+        val result = query.validate(testEntityPath, metadataService)
 
         result.futureValue.left.get should contain theSameElementsAs List(
-          InvalidAggregationField("invalid"),
+          InvalidQueryField("valid"),
           InvalidAggregationFieldForType("invalid")
         )
       }
@@ -311,18 +284,13 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           dataType = DataType.String,
           cardinality = None,
           keyType = KeyType.NonKey,
-          entity = "test"
+          entity = "testEntity"
         )
 
-        (ms.attributeExists _).when("testEntity", "InvalidAttribute").returns(Future.successful(true))
-        (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
-          .when(*)
-          .returns(Future.successful(Some(List(attribute))))
-        (ms
-          .getEntities(_: NetworkPath))
-          .when(*)
-          .returns(Some(List(testEntity.copy(limitedQuery = Some(true)))))
+        val metadataService = createMetadataService {
+          platformDiscoveryOperations.addAttribute(attribute)
+          platformDiscoveryOperations.addEntity(testEntity.copy(limitedQuery = Some(true)))
+        }
 
         val query = ApiQuery(
           fields = None,
@@ -333,7 +301,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           aggregation = None
         )
 
-        val result = query.validate(testEntityPath, ms)
+        val result = query.validate(testEntityPath, metadataService)
 
         result.futureValue.left.get.head shouldBe a[InvalidPredicateFiltering]
       }
@@ -345,19 +313,13 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           dataType = DataType.String, // only COUNT function can be used on types other than numeric and DateTime
           cardinality = None,
           keyType = KeyType.UniqueKey,
-          entity = "test"
+          entity = "testEntity"
         )
 
-        (ms.attributeExists _).when("testEntity", "valid").returns(Future.successful(true))
-        (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
-          .when(*)
-          .returns(Future.successful(Some(List(attribute))))
-          .anyNumberOfTimes()
-        (ms
-          .getEntities(_: NetworkPath))
-          .when(*)
-          .returns(Some(List(testEntity)))
+        val metadataService = createMetadataService {
+          platformDiscoveryOperations.addAttribute(attribute)
+          platformDiscoveryOperations.addEntity(testEntity)
+        }
 
         val query = ApiQuery(
           fields = Some(List("valid")),
@@ -368,7 +330,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           aggregation = Some(List(ApiAggregation(field = "valid", function = AggregationType.count)))
         )
 
-        val result = query.validate(testEntityPath, ms)
+        val result = query.validate(testEntityPath, metadataService)
 
         result.futureValue.right.get shouldBe Query(
           fields = List("valid"),
@@ -386,16 +348,10 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           entity = "testEntity"
         )
 
-        (ms.attributeExists _).when("testEntity", "valid").returns(Future.successful(true))
-        (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
-          .when(*)
-          .returns(Future.successful(Some(List(attribute))))
-          .anyNumberOfTimes()
-        (ms
-          .getEntities(_: NetworkPath))
-          .when(*)
-          .returns(Some(List(testEntity)))
+        val metadataService = createMetadataService {
+          platformDiscoveryOperations.addAttribute(attribute)
+          platformDiscoveryOperations.addEntity(testEntity)
+        }
 
         val query = ApiQuery(
           fields = None,
@@ -407,7 +363,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           aggregation = None
         )
 
-        val result = query.validate(testEntityPath, ms)
+        val result = query.validate(testEntityPath, metadataService)
 
         result.futureValue.right.get shouldBe Query(
           predicates = List(
@@ -425,15 +381,11 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           keyType = KeyType.NonKey,
           entity = "testEntity"
         )
-        (ms.attributeExists _).when("testEntity", "validAttribute").returns(Future.successful(true)).anyNumberOfTimes()
-        (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
-          .when(testEntityPath)
-          .returns(Future.successful(Some(List(attribute))))
-        (ms
-          .getEntities(_: NetworkPath))
-          .when(*)
-          .returns(Some(List(testEntity)))
+
+        val metadataService = createMetadataService {
+          platformDiscoveryOperations.addAttribute(attribute)
+          platformDiscoveryOperations.addEntity(testEntity)
+        }
 
         val query = ApiQuery(
           fields = Some(List("validAttribute")),
@@ -444,7 +396,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           aggregation = Some(List(ApiAggregation(field = "validAttribute", function = AggregationType.count)))
         )
 
-        val result = query.validate(testEntityPath, ms)
+        val result = query.validate(testEntityPath, metadataService)
 
         result.futureValue.right.get shouldBe Query(
           fields = List("validAttribute"),
@@ -462,15 +414,11 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           keyType = KeyType.NonKey,
           entity = "testEntity"
         )
-        (ms.attributeExists _).when("testEntity", "validAttribute").returns(Future.successful(true)).anyNumberOfTimes()
-        (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
-          .when(testEntityPath)
-          .returns(Future.successful(Some(List(attribute))))
-        (ms
-          .getEntities(_: NetworkPath))
-          .when(*)
-          .returns(Some(List(testEntity)))
+
+        val metadataService = createMetadataService {
+          platformDiscoveryOperations.addAttribute(attribute)
+          platformDiscoveryOperations.addEntity(testEntity)
+        }
 
         val query = ApiQuery(
           fields = Some(List("validAttribute")),
@@ -481,7 +429,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
           aggregation = Some(List(ApiAggregation(field = "validAttribute", function = AggregationType.count)))
         )
 
-        val result = query.validate(testEntityPath, ms)
+        val result = query.validate(testEntityPath, metadataService)
 
         result.futureValue.right.get shouldBe Query(
           fields = List("validAttribute"),
@@ -491,5 +439,4 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
       }
 
     }
-
 }

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
@@ -9,7 +9,7 @@ import tech.cryptonomic.conseil.generic.chain.DataTypes._
 import tech.cryptonomic.conseil.generic.chain.PlatformDiscoveryTypes.{Attribute, DataType, Entity, KeyType}
 import tech.cryptonomic.conseil.metadata.{EntityPath, MetadataService, NetworkPath, PlatformPath}
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFactory {
   import scala.concurrent.ExecutionContext.Implicits.global
@@ -30,12 +30,12 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
         )
         (ms.isAttributeValid _).when("testEntity", "valid").returns(Future.successful(true))
         (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath)(_: ExecutionContext))
-          .when(*, *)
+          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
+          .when(*)
           .returns(Future.successful(Some(List(attribute))))
         (ms
-          .getEntities(_: NetworkPath)(_: ExecutionContext))
-          .when(*, *)
+          .getEntities(_: NetworkPath))
+          .when(*)
           .returns(Future.successful(Some(List(testEntity))))
 
         val query = ApiQuery(
@@ -55,8 +55,8 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
       "return error with incorrect query fields" in {
         (ms.isAttributeValid _).when("testEntity", "invalid").returns(Future.successful(false))
         (ms
-          .getEntities(_: NetworkPath)(_: ExecutionContext))
-          .when(*, *)
+          .getEntities(_: NetworkPath))
+          .when(*)
           .returns(Future.successful(Some(List(testEntity))))
 
         val query = ApiQuery(
@@ -84,12 +84,12 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
         )
         (ms.isAttributeValid _).when("testEntity", "valid").returns(Future.successful(true))
         (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath)(_: ExecutionContext))
-          .when(*, *)
+          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
+          .when(*)
           .returns(Future.successful(Some(List(attribute))))
         (ms
-          .getEntities(_: NetworkPath)(_: ExecutionContext))
-          .when(*, *)
+          .getEntities(_: NetworkPath))
+          .when(*)
           .returns(Future.successful(Some(List(testEntity))))
 
         val query = ApiQuery(
@@ -117,13 +117,13 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
         )
         (ms.isAttributeValid _).when("testEntity", "invalid").returns(Future.successful(false))
         (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath)(_: ExecutionContext))
-          .when(*, *)
+          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
+          .when(*)
           .returns(Future.successful(Some(List(attribute))))
           .anyNumberOfTimes()
         (ms
-          .getEntities(_: NetworkPath)(_: ExecutionContext))
-          .when(*, *)
+          .getEntities(_: NetworkPath))
+          .when(*)
           .returns(Future.successful(Some(List(testEntity))))
 
         val query = ApiQuery(
@@ -152,13 +152,13 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
 
         (ms.isAttributeValid _).when("testEntity", "valid").returns(Future.successful(true))
         (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath)(_: ExecutionContext))
-          .when(*, *)
+          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
+          .when(*)
           .returns(Future.successful(Some(List(attribute))))
           .anyNumberOfTimes()
         (ms
-          .getEntities(_: NetworkPath)(_: ExecutionContext))
-          .when(*, *)
+          .getEntities(_: NetworkPath))
+          .when(*)
           .returns(Future.successful(Some(List(testEntity))))
 
         val query = ApiQuery(
@@ -178,8 +178,8 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
       "return error with incorrect orderBy fields" in {
         (ms.isAttributeValid _).when("testEntity", "invalid").returns(Future.successful(false))
         (ms
-          .getEntities(_: NetworkPath)(_: ExecutionContext))
-          .when(*, *)
+          .getEntities(_: NetworkPath))
+          .when(*)
           .returns(Future.successful(Some(List(testEntity))))
 
         val query = ApiQuery(
@@ -208,12 +208,12 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
 
         (ms.isAttributeValid _).when("testEntity", "valid").returns(Future.successful(true))
         (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath)(_: ExecutionContext))
-          .when(*, *)
+          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
+          .when(*)
           .returns(Future.successful(Some(List(attribute))))
         (ms
-          .getEntities(_: NetworkPath)(_: ExecutionContext))
-          .when(*, *)
+          .getEntities(_: NetworkPath))
+          .when(*)
           .returns(Future.successful(Some(List(testEntity))))
 
         val query = ApiQuery(
@@ -245,12 +245,12 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
 
         (ms.isAttributeValid _).when("testEntity", "invalid").returns(Future.successful(true))
         (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath)(_: ExecutionContext))
-          .when(*, *)
+          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
+          .when(*)
           .returns(Future.successful(Some(List(attribute))))
         (ms
-          .getEntities(_: NetworkPath)(_: ExecutionContext))
-          .when(*, *)
+          .getEntities(_: NetworkPath))
+          .when(*)
           .returns(Future.successful(Some(List(testEntity))))
 
         val query = ApiQuery(
@@ -279,12 +279,12 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
         (ms.isAttributeValid _).when("testEntity", "valid").returns(Future.successful(true)) once ()
         (ms.isAttributeValid _).when("testEntity", "invalid").returns(Future.successful(false)) once ()
         (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath)(_: ExecutionContext))
-          .when(*, *)
+          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
+          .when(*)
           .returns(Future.successful(Some(List(attribute))))
         (ms
-          .getEntities(_: NetworkPath)(_: ExecutionContext))
-          .when(*, *)
+          .getEntities(_: NetworkPath))
+          .when(*)
           .returns(Future.successful(Some(List(testEntity))))
 
         val query = ApiQuery(
@@ -316,12 +316,12 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
 
         (ms.isAttributeValid _).when("testEntity", "InvalidAttribute").returns(Future.successful(true))
         (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath)(_: ExecutionContext))
-          .when(*, *)
+          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
+          .when(*)
           .returns(Future.successful(Some(List(attribute))))
         (ms
-          .getEntities(_: NetworkPath)(_: ExecutionContext))
-          .when(*, *)
+          .getEntities(_: NetworkPath))
+          .when(*)
           .returns(Future.successful(Some(List(testEntity.copy(limitedQuery = Some(true))))))
 
         val query = ApiQuery(
@@ -350,13 +350,13 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
 
         (ms.isAttributeValid _).when("testEntity", "valid").returns(Future.successful(true))
         (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath)(_: ExecutionContext))
-          .when(*, *)
+          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
+          .when(*)
           .returns(Future.successful(Some(List(attribute))))
           .anyNumberOfTimes()
         (ms
-          .getEntities(_: NetworkPath)(_: ExecutionContext))
-          .when(*, *)
+          .getEntities(_: NetworkPath))
+          .when(*)
           .returns(Future.successful(Some(List(testEntity))))
 
         val query = ApiQuery(
@@ -388,13 +388,13 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
 
         (ms.isAttributeValid _).when("testEntity", "valid").returns(Future.successful(true))
         (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath)(_: ExecutionContext))
-          .when(*, *)
+          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
+          .when(*)
           .returns(Future.successful(Some(List(attribute))))
           .anyNumberOfTimes()
         (ms
-          .getEntities(_: NetworkPath)(_: ExecutionContext))
-          .when(*, *)
+          .getEntities(_: NetworkPath))
+          .when(*)
           .returns(Future.successful(Some(List(testEntity))))
 
         val query = ApiQuery(
@@ -427,12 +427,12 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
         )
         (ms.isAttributeValid _).when("testEntity", "validAttribute").returns(Future.successful(true)).anyNumberOfTimes()
         (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath)(_: ExecutionContext))
-          .when(testEntityPath, *)
+          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
+          .when(testEntityPath)
           .returns(Future.successful(Some(List(attribute))))
         (ms
-          .getEntities(_: NetworkPath)(_: ExecutionContext))
-          .when(*, *)
+          .getEntities(_: NetworkPath))
+          .when(*)
           .returns(Future.successful(Some(List(testEntity))))
 
         val query = ApiQuery(
@@ -464,12 +464,12 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
         )
         (ms.isAttributeValid _).when("testEntity", "validAttribute").returns(Future.successful(true)).anyNumberOfTimes()
         (ms
-          .getTableAttributesWithoutUpdatingCache(_: EntityPath)(_: ExecutionContext))
-          .when(testEntityPath, *)
+          .getTableAttributesWithoutUpdatingCache(_: EntityPath))
+          .when(testEntityPath)
           .returns(Future.successful(Some(List(attribute))))
         (ms
-          .getEntities(_: NetworkPath)(_: ExecutionContext))
-          .when(*, *)
+          .getEntities(_: NetworkPath))
+          .when(*)
           .returns(Future.successful(Some(List(testEntity))))
 
         val query = ApiQuery(

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DataTypesTest.scala
@@ -36,7 +36,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
         (ms
           .getEntities(_: NetworkPath))
           .when(*)
-          .returns(Future.successful(Some(List(testEntity))))
+          .returns(Some(List(testEntity)))
 
         val query = ApiQuery(
           fields = Some(List("valid")),
@@ -57,7 +57,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
         (ms
           .getEntities(_: NetworkPath))
           .when(*)
-          .returns(Future.successful(Some(List(testEntity))))
+          .returns(Some(List(testEntity)))
 
         val query = ApiQuery(
           fields = Some(List("invalid")),
@@ -90,7 +90,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
         (ms
           .getEntities(_: NetworkPath))
           .when(*)
-          .returns(Future.successful(Some(List(testEntity))))
+          .returns(Some(List(testEntity)))
 
         val query = ApiQuery(
           fields = None,
@@ -124,7 +124,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
         (ms
           .getEntities(_: NetworkPath))
           .when(*)
-          .returns(Future.successful(Some(List(testEntity))))
+          .returns(Some(List(testEntity)))
 
         val query = ApiQuery(
           fields = None,
@@ -159,7 +159,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
         (ms
           .getEntities(_: NetworkPath))
           .when(*)
-          .returns(Future.successful(Some(List(testEntity))))
+          .returns(Some(List(testEntity)))
 
         val query = ApiQuery(
           fields = None,
@@ -180,7 +180,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
         (ms
           .getEntities(_: NetworkPath))
           .when(*)
-          .returns(Future.successful(Some(List(testEntity))))
+          .returns(Some(List(testEntity)))
 
         val query = ApiQuery(
           fields = None,
@@ -214,7 +214,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
         (ms
           .getEntities(_: NetworkPath))
           .when(*)
-          .returns(Future.successful(Some(List(testEntity))))
+          .returns(Some(List(testEntity)))
 
         val query = ApiQuery(
           fields = Some(List("valid")),
@@ -251,7 +251,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
         (ms
           .getEntities(_: NetworkPath))
           .when(*)
-          .returns(Future.successful(Some(List(testEntity))))
+          .returns(Some(List(testEntity)))
 
         val query = ApiQuery(
           fields = Some(List("invalid")),
@@ -285,7 +285,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
         (ms
           .getEntities(_: NetworkPath))
           .when(*)
-          .returns(Future.successful(Some(List(testEntity))))
+          .returns(Some(List(testEntity)))
 
         val query = ApiQuery(
           fields = Some(List("valid")),
@@ -322,7 +322,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
         (ms
           .getEntities(_: NetworkPath))
           .when(*)
-          .returns(Future.successful(Some(List(testEntity.copy(limitedQuery = Some(true))))))
+          .returns(Some(List(testEntity.copy(limitedQuery = Some(true)))))
 
         val query = ApiQuery(
           fields = None,
@@ -357,7 +357,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
         (ms
           .getEntities(_: NetworkPath))
           .when(*)
-          .returns(Future.successful(Some(List(testEntity))))
+          .returns(Some(List(testEntity)))
 
         val query = ApiQuery(
           fields = Some(List("valid")),
@@ -395,7 +395,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
         (ms
           .getEntities(_: NetworkPath))
           .when(*)
-          .returns(Future.successful(Some(List(testEntity))))
+          .returns(Some(List(testEntity)))
 
         val query = ApiQuery(
           fields = None,
@@ -433,7 +433,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
         (ms
           .getEntities(_: NetworkPath))
           .when(*)
-          .returns(Future.successful(Some(List(testEntity))))
+          .returns(Some(List(testEntity)))
 
         val query = ApiQuery(
           fields = Some(List("validAttribute")),
@@ -470,7 +470,7 @@ class DataTypesTest extends WordSpec with Matchers with ScalaFutures with MockFa
         (ms
           .getEntities(_: NetworkPath))
           .when(*)
-          .returns(Future.successful(Some(List(testEntity))))
+          .returns(Some(List(testEntity)))
 
         val query = ApiQuery(
           fields = Some(List("validAttribute")),

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
@@ -386,15 +386,6 @@ class TezosPlatformDiscoveryOperationsTest
         sut.listAttributeValues("fees", "kind", Some("1")).futureValue.right.get shouldBe List("example1")
 
       }
-
-      "should validate correctly fields" in {
-        sut.isAttributeValid("fees", "low").futureValue shouldBe true
-      }
-
-      "should return false when there will be field not existing in the DB" in {
-        sut.isAttributeValid("fees", "WRONG").futureValue shouldBe false
-      }
-
     }
 
 }


### PR DESCRIPTION
closes #388
* metadata are precached on Conseil startup
* log if there is no overwritten metadata or there is an override which overrides nothing
* added check if network or platform are not hidden in places where that check was missing
* rewrite tests (avoid stubbing in exchange for real implementation)