### PR TITLE
456 - capture internal transactions

### DIFF
--- a/doc/conseil.sql
+++ b/doc/conseil.sql
@@ -266,7 +266,8 @@ CREATE TABLE public.operations (
     paid_storage_size_diff numeric,
     block_hash character varying NOT NULL,
     block_level integer NOT NULL,
-    "timestamp" timestamp without time zone NOT NULL
+    "timestamp" timestamp without time zone NOT NULL,
+    internal boolean NOT NULL
 );
 
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
@@ -135,7 +135,7 @@ object DatabaseConversions {
   }
 
   private val convertEndorsement: PartialFunction[(Block, OperationHash, Operation), Tables.OperationsRow] = {
-    case (block, groupHash, e @ Endorsement(level, metadata)) =>
+    case (block, groupHash, Endorsement(level, metadata)) =>
       Tables.OperationsRow(
         operationId = 0,
         operationGroupHash = groupHash.value,
@@ -146,7 +146,7 @@ object DatabaseConversions {
         blockHash = block.data.hash.value,
         blockLevel = block.data.header.level,
         timestamp = toSql(block.data.header.timestamp),
-        internal = e.internal
+        internal = false
       )
   }
 
@@ -166,7 +166,7 @@ object DatabaseConversions {
   }
 
   private val convertActivateAccount: PartialFunction[(Block, OperationHash, Operation), Tables.OperationsRow] = {
-    case (block, groupHash, a @ ActivateAccount(pkh, secret, metadata)) =>
+    case (block, groupHash, ActivateAccount(pkh, secret, metadata)) =>
       Tables.OperationsRow(
         operationId = 0,
         operationGroupHash = groupHash.value,
@@ -176,12 +176,12 @@ object DatabaseConversions {
         blockHash = block.data.hash.value,
         blockLevel = block.data.header.level,
         timestamp = toSql(block.data.header.timestamp),
-        internal = a.internal
+        internal = false
       )
   }
 
   private val convertReveal: PartialFunction[(Block, OperationHash, Operation), Tables.OperationsRow] = {
-    case (block, groupHash, r @ Reveal(counter, fee, gas_limit, storage_limit, pk, source, metadata)) =>
+    case (block, groupHash, Reveal(counter, fee, gas_limit, storage_limit, pk, source, metadata)) =>
       Tables.OperationsRow(
         operationId = 0,
         operationGroupHash = groupHash.value,
@@ -197,7 +197,7 @@ object DatabaseConversions {
         blockHash = block.data.hash.value,
         blockLevel = block.data.header.level,
         timestamp = toSql(block.data.header.timestamp),
-        internal = r.internal
+        internal = false
       )
   }
 
@@ -205,7 +205,7 @@ object DatabaseConversions {
     case (
         block,
         groupHash,
-        t @ Transaction(counter, amount, fee, gas_limit, storage_limit, source, destination, parameters, metadata)
+        Transaction(counter, amount, fee, gas_limit, storage_limit, source, destination, parameters, metadata)
         ) =>
       Tables.OperationsRow(
         operationId = 0,
@@ -226,7 +226,7 @@ object DatabaseConversions {
         blockHash = block.data.hash.value,
         blockLevel = block.data.header.level,
         timestamp = toSql(block.data.header.timestamp),
-        internal = t.internal
+        internal = false
       )
   }
 
@@ -234,7 +234,7 @@ object DatabaseConversions {
     case (
         block,
         groupHash,
-        o @ Origination(
+        Origination(
           counter,
           fee,
           source,
@@ -273,12 +273,12 @@ object DatabaseConversions {
         blockHash = block.data.hash.value,
         blockLevel = block.data.header.level,
         timestamp = toSql(block.data.header.timestamp),
-        internal = o.internal
+        internal = false
       )
   }
 
   private val convertDelegation: PartialFunction[(Block, OperationHash, Operation), Tables.OperationsRow] = {
-    case (block, groupHash, d @ Delegation(counter, source, fee, gas_limit, storage_limit, delegate, metadata)) =>
+    case (block, groupHash, Delegation(counter, source, fee, gas_limit, storage_limit, delegate, metadata)) =>
       Tables.OperationsRow(
         operationId = 0,
         operationGroupHash = groupHash.value,
@@ -294,7 +294,7 @@ object DatabaseConversions {
         blockHash = block.data.hash.value,
         blockLevel = block.data.header.level,
         timestamp = toSql(block.data.header.timestamp),
-        internal = d.internal
+        internal = false
       )
   }
 
@@ -314,7 +314,7 @@ object DatabaseConversions {
         blockHash = block.data.hash.value,
         blockLevel = block.data.header.level,
         timestamp = toSql(block.data.header.timestamp),
-        internal = op.internal
+        internal = false
       )
   }
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
@@ -433,9 +433,6 @@ object DatabaseConversions {
         }
     }
 
-  def appendToFile(str: String) =
-    scala.tools.nsc.io.Path("/tmp/my.log").createFile().appendAll("\n" + str)
-
   /** Will convert to paired list of operations with related balance updates
     * with one HUGE CAVEAT: both have only temporary, meaningless, `sourceId`s
     *

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
@@ -375,7 +375,7 @@ object DatabaseConversions {
         // counter/fee/gas_limit/storage_limit are not in internal operations results,
         // so values below are going to be discarded during transformation Operation -> OperationRow
         from match {
-          case reveal: InternalOperationResults.InternalRevealResult =>
+          case reveal: InternalOperationResults.Reveal =>
             reveal
               .into[Reveal]
               .withFieldConst(_.counter, InvalidPositiveDecimal("Discarded"))
@@ -384,7 +384,7 @@ object DatabaseConversions {
               .withFieldConst(_.storage_limit, InvalidPositiveDecimal("Discarded"))
               .withFieldConst(_.metadata, ResultMetadata[OperationResult.Reveal](reveal.result, List.empty, None))
               .transform
-          case transaction: InternalOperationResults.InternalTransactionResult =>
+          case transaction: InternalOperationResults.Transaction =>
             transaction
               .into[Transaction]
               .withFieldConst(_.counter, InvalidPositiveDecimal("Discarded"))
@@ -401,7 +401,7 @@ object DatabaseConversions {
               )
               .transform
 
-          case origination: InternalOperationResults.InternalOriginationResult =>
+          case origination: InternalOperationResults.Origination =>
             origination
               .into[Origination]
               .withFieldConst(_.counter, InvalidPositiveDecimal("Discarded"))
@@ -418,7 +418,7 @@ object DatabaseConversions {
               )
               .transform
 
-          case delegation: InternalOperationResults.InternalDelegationResult =>
+          case delegation: InternalOperationResults.Delegation =>
             delegation
               .into[Delegation]
               .withFieldConst(_.counter, InvalidPositiveDecimal("Discarded"))

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/JsonDecoders.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/JsonDecoders.scala
@@ -106,9 +106,9 @@ object JsonDecoders {
 
     /* Collects definitions to decode delegates and their contracts */
     object Delegates {
+      //reusing much of the values used in operations
       import Numbers._
       import Scripts._
-      //reusing much of the values used in operations
       implicit private val conf = Derivation.tezosDerivationConfig
 
       implicit val contractDelegateDecoder: Decoder[ContractDelegate] = deriveDecoder

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/JsonDecoders.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/JsonDecoders.scala
@@ -227,25 +227,14 @@ object JsonDecoders {
       implicit val transactionMetadataDecoder: Decoder[ResultMetadata[OperationResult.Transaction]] = deriveDecoder
       implicit val originationMetadataDecoder: Decoder[ResultMetadata[OperationResult.Origination]] = deriveDecoder
       implicit val delegationMetadataDecoder: Decoder[ResultMetadata[OperationResult.Delegation]] = deriveDecoder
-      implicit val internalOpResultsDecoder: Decoder[InternalOperationResults.InternalOperationResult] =
-        (c: HCursor) => {
-          c.downField("kind").as[String].flatMap {
-            case "reveal" =>
-              c.as[InternalOperationResults.InternalRevealResult]
-            case "transaction" =>
-              c.as[InternalOperationResults.InternalTransactionResult]
-            case "delegation" =>
-              c.as[InternalOperationResults.InternalDelegationResult]
-            case "origination" =>
-              c.as[InternalOperationResults.InternalOriginationResult]
-          }
-        }
-      implicit val internalRevealResultDecoder: Decoder[InternalOperationResults.InternalRevealResult] = deriveDecoder
-      implicit val internalTransactionResultDecoder: Decoder[InternalOperationResults.InternalTransactionResult] =
+      implicit val internalOperationResultDecoder: Decoder[InternalOperationResults.InternalOperationResult] =
         deriveDecoder
-      implicit val internalOriginationResultDecoder: Decoder[InternalOperationResults.InternalOriginationResult] =
+      implicit val internalRevealResultDecoder: Decoder[InternalOperationResults.Reveal] = deriveDecoder
+      implicit val internalTransactionResultDecoder: Decoder[InternalOperationResults.Transaction] =
         deriveDecoder
-      implicit val internalDelegationResultDecoder: Decoder[InternalOperationResults.InternalDelegationResult] =
+      implicit val internalOriginationResultDecoder: Decoder[InternalOperationResults.Origination] =
+        deriveDecoder
+      implicit val internalDelegationResultDecoder: Decoder[InternalOperationResults.Delegation] =
         deriveDecoder
       implicit val operationDecoder: Decoder[Operation] = deriveDecoder
       implicit val operationGroupDecoder: Decoder[OperationsGroup] = deriveDecoder

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/JsonDecoders.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/JsonDecoders.scala
@@ -106,6 +106,8 @@ object JsonDecoders {
 
     /* Collects definitions to decode delegates and their contracts */
     object Delegates {
+      import Numbers._
+      import Scripts._
       //reusing much of the values used in operations
       implicit private val conf = Derivation.tezosDerivationConfig
 
@@ -144,6 +146,8 @@ object JsonDecoders {
     /* Collects definitions to decode blocks and their components */
     object Blocks {
       // we need to decode BalanceUpdates
+      import Numbers._
+      import Operations._
       implicit private val conf = Derivation.tezosDerivationConfig
 
       val genesisMetadataDecoder: Decoder[GenesisMetadata.type] = deriveDecoder
@@ -200,6 +204,8 @@ object JsonDecoders {
      * Import this in scope to be able to call `io.circe.parser.decode[T](json)` for a valid type of operation
      */
     object Operations {
+      import Scripts._
+      import Numbers._
 
       /* decode any json value to its string representation wrapped in a Error*/
       implicit val errorDecoder: Decoder[OperationResult.Error] =
@@ -248,6 +254,7 @@ object JsonDecoders {
 
     /* Collects definitions to decode accounts and their components */
     object Accounts {
+      import Scripts._
       implicit private val conf = Derivation.tezosDerivationConfig
 
       implicit val delegateDecoder: Decoder[AccountDelegate] = deriveDecoder

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/JsonDecoders.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/JsonDecoders.scala
@@ -1,6 +1,5 @@
 package tech.cryptonomic.conseil.tezos
 
-import io.circe.HCursor
 import tech.cryptonomic.conseil.tezos.TezosTypes._
 
 import scala.util.Try

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
@@ -16,21 +16,7 @@ trait Tables {
   import slick.jdbc.{GetResult => GR}
 
   /** DDL for all tables. Call .create to execute. */
-  lazy val schema: profile.SchemaDescription = Array(
-    Accounts.schema,
-    AccountsCheckpoint.schema,
-    BalanceUpdates.schema,
-    Ballots.schema,
-    Blocks.schema,
-    DelegatedContracts.schema,
-    Delegates.schema,
-    DelegatesCheckpoint.schema,
-    Fees.schema,
-    OperationGroups.schema,
-    Operations.schema,
-    Proposals.schema,
-    Rolls.schema
-  ).reduceLeft(_ ++ _)
+  lazy val schema: profile.SchemaDescription = Array(Accounts.schema, AccountsCheckpoint.schema, BalanceUpdates.schema, Ballots.schema, Blocks.schema, DelegatedContracts.schema, Delegates.schema, DelegatesCheckpoint.schema, Fees.schema, OperationGroups.schema, Operations.schema, Proposals.schema, Rolls.schema).reduceLeft(_ ++ _)
   @deprecated("Use .schema instead of .ddl", "3.0")
   def ddl = schema
 
@@ -46,137 +32,49 @@ trait Tables {
     *  @param storage Database column storage SqlType(varchar), Default(None)
     *  @param balance Database column balance SqlType(numeric)
     *  @param blockLevel Database column block_level SqlType(numeric), Default(-1) */
-  case class AccountsRow(
-      accountId: String,
-      blockId: String,
-      manager: String,
-      spendable: Boolean,
-      delegateSetable: Boolean,
-      delegateValue: Option[String] = None,
-      counter: Int,
-      script: Option[String] = None,
-      storage: Option[String] = None,
-      balance: scala.math.BigDecimal,
-      blockLevel: scala.math.BigDecimal = scala.math.BigDecimal("-1")
-  )
-
+  case class AccountsRow(accountId: String, blockId: String, manager: String, spendable: Boolean, delegateSetable: Boolean, delegateValue: Option[String] = None, counter: Int, script: Option[String] = None, storage: Option[String] = None, balance: scala.math.BigDecimal, blockLevel: scala.math.BigDecimal = scala.math.BigDecimal("-1"))
   /** GetResult implicit for fetching AccountsRow objects using plain SQL queries */
-  implicit def GetResultAccountsRow(
-      implicit e0: GR[String],
-      e1: GR[Boolean],
-      e2: GR[Option[String]],
-      e3: GR[Int],
-      e4: GR[scala.math.BigDecimal]
-  ): GR[AccountsRow] = GR { prs =>
-    import prs._
-    AccountsRow.tupled(
-      (
-        <<[String],
-        <<[String],
-        <<[String],
-        <<[Boolean],
-        <<[Boolean],
-        <<?[String],
-        <<[Int],
-        <<?[String],
-        <<?[String],
-        <<[scala.math.BigDecimal],
-        <<[scala.math.BigDecimal]
-      )
-    )
+  implicit def GetResultAccountsRow(implicit e0: GR[String], e1: GR[Boolean], e2: GR[Option[String]], e3: GR[Int], e4: GR[scala.math.BigDecimal]): GR[AccountsRow] = GR{
+    prs => import prs._
+      AccountsRow.tupled((<<[String], <<[String], <<[String], <<[Boolean], <<[Boolean], <<?[String], <<[Int], <<?[String], <<?[String], <<[scala.math.BigDecimal], <<[scala.math.BigDecimal]))
   }
-
   /** Table description of table accounts. Objects of this class serve as prototypes for rows in queries. */
   class Accounts(_tableTag: Tag) extends profile.api.Table[AccountsRow](_tableTag, "accounts") {
-    def * =
-      (
-        accountId,
-        blockId,
-        manager,
-        spendable,
-        delegateSetable,
-        delegateValue,
-        counter,
-        script,
-        storage,
-        balance,
-        blockLevel
-      ) <> (AccountsRow.tupled, AccountsRow.unapply)
-
+    def * = (accountId, blockId, manager, spendable, delegateSetable, delegateValue, counter, script, storage, balance, blockLevel) <> (AccountsRow.tupled, AccountsRow.unapply)
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? =
-      (
-        (
-          Rep.Some(accountId),
-          Rep.Some(blockId),
-          Rep.Some(manager),
-          Rep.Some(spendable),
-          Rep.Some(delegateSetable),
-          delegateValue,
-          Rep.Some(counter),
-          script,
-          storage,
-          Rep.Some(balance),
-          Rep.Some(blockLevel)
-        )
-      ).shaped.<>(
-        { r =>
-          import r._;
-          _1.map(
-            _ => AccountsRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get, _6, _7.get, _8, _9, _10.get, _11.get))
-          )
-        },
-        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
-      )
+    def ? = ((Rep.Some(accountId), Rep.Some(blockId), Rep.Some(manager), Rep.Some(spendable), Rep.Some(delegateSetable), delegateValue, Rep.Some(counter), script, storage, Rep.Some(balance), Rep.Some(blockLevel))).shaped.<>({r=>import r._; _1.map(_=> AccountsRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get, _6, _7.get, _8, _9, _10.get, _11.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
 
     /** Database column account_id SqlType(varchar), PrimaryKey */
     val accountId: Rep[String] = column[String]("account_id", O.PrimaryKey)
-
     /** Database column block_id SqlType(varchar) */
     val blockId: Rep[String] = column[String]("block_id")
-
     /** Database column manager SqlType(varchar) */
     val manager: Rep[String] = column[String]("manager")
-
     /** Database column spendable SqlType(bool) */
     val spendable: Rep[Boolean] = column[Boolean]("spendable")
-
     /** Database column delegate_setable SqlType(bool) */
     val delegateSetable: Rep[Boolean] = column[Boolean]("delegate_setable")
-
     /** Database column delegate_value SqlType(varchar), Default(None) */
     val delegateValue: Rep[Option[String]] = column[Option[String]]("delegate_value", O.Default(None))
-
     /** Database column counter SqlType(int4) */
     val counter: Rep[Int] = column[Int]("counter")
-
     /** Database column script SqlType(varchar), Default(None) */
     val script: Rep[Option[String]] = column[Option[String]]("script", O.Default(None))
-
     /** Database column storage SqlType(varchar), Default(None) */
     val storage: Rep[Option[String]] = column[Option[String]]("storage", O.Default(None))
-
     /** Database column balance SqlType(numeric) */
     val balance: Rep[scala.math.BigDecimal] = column[scala.math.BigDecimal]("balance")
-
     /** Database column block_level SqlType(numeric), Default(-1) */
-    val blockLevel: Rep[scala.math.BigDecimal] =
-      column[scala.math.BigDecimal]("block_level", O.Default(scala.math.BigDecimal("-1")))
+    val blockLevel: Rep[scala.math.BigDecimal] = column[scala.math.BigDecimal]("block_level", O.Default(scala.math.BigDecimal("-1")))
 
     /** Foreign key referencing Blocks (database name accounts_block_id_fkey) */
-    lazy val blocksFk = foreignKey("accounts_block_id_fkey", blockId, Blocks)(
-      r => r.hash,
-      onUpdate = ForeignKeyAction.NoAction,
-      onDelete = ForeignKeyAction.NoAction
-    )
+    lazy val blocksFk = foreignKey("accounts_block_id_fkey", blockId, Blocks)(r => r.hash, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
 
     /** Index over (blockLevel) (database name ix_accounts_block_level) */
     val index1 = index("ix_accounts_block_level", blockLevel)
-
     /** Index over (manager) (database name ix_accounts_manager) */
     val index2 = index("ix_accounts_manager", manager)
   }
-
   /** Collection-like TableQuery object for table Accounts */
   lazy val Accounts = new TableQuery(tag => new Accounts(tag))
 
@@ -185,51 +83,32 @@ trait Tables {
     *  @param blockId Database column block_id SqlType(varchar)
     *  @param blockLevel Database column block_level SqlType(int4), Default(-1) */
   case class AccountsCheckpointRow(accountId: String, blockId: String, blockLevel: Int = -1)
-
   /** GetResult implicit for fetching AccountsCheckpointRow objects using plain SQL queries */
-  implicit def GetResultAccountsCheckpointRow(implicit e0: GR[String], e1: GR[Int]): GR[AccountsCheckpointRow] = GR {
-    prs =>
-      import prs._
+  implicit def GetResultAccountsCheckpointRow(implicit e0: GR[String], e1: GR[Int]): GR[AccountsCheckpointRow] = GR{
+    prs => import prs._
       AccountsCheckpointRow.tupled((<<[String], <<[String], <<[Int]))
   }
-
   /** Table description of table accounts_checkpoint. Objects of this class serve as prototypes for rows in queries. */
-  class AccountsCheckpoint(_tableTag: Tag)
-      extends profile.api.Table[AccountsCheckpointRow](_tableTag, "accounts_checkpoint") {
+  class AccountsCheckpoint(_tableTag: Tag) extends profile.api.Table[AccountsCheckpointRow](_tableTag, "accounts_checkpoint") {
     def * = (accountId, blockId, blockLevel) <> (AccountsCheckpointRow.tupled, AccountsCheckpointRow.unapply)
-
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? =
-      ((Rep.Some(accountId), Rep.Some(blockId), Rep.Some(blockLevel))).shaped.<>(
-        { r =>
-          import r._; _1.map(_ => AccountsCheckpointRow.tupled((_1.get, _2.get, _3.get)))
-        },
-        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
-      )
+    def ? = ((Rep.Some(accountId), Rep.Some(blockId), Rep.Some(blockLevel))).shaped.<>({r=>import r._; _1.map(_=> AccountsCheckpointRow.tupled((_1.get, _2.get, _3.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
 
     /** Database column account_id SqlType(varchar) */
     val accountId: Rep[String] = column[String]("account_id")
-
     /** Database column block_id SqlType(varchar) */
     val blockId: Rep[String] = column[String]("block_id")
-
     /** Database column block_level SqlType(int4), Default(-1) */
     val blockLevel: Rep[Int] = column[Int]("block_level", O.Default(-1))
 
     /** Foreign key referencing Blocks (database name checkpoint_block_id_fkey) */
-    lazy val blocksFk = foreignKey("checkpoint_block_id_fkey", blockId, Blocks)(
-      r => r.hash,
-      onUpdate = ForeignKeyAction.NoAction,
-      onDelete = ForeignKeyAction.NoAction
-    )
+    lazy val blocksFk = foreignKey("checkpoint_block_id_fkey", blockId, Blocks)(r => r.hash, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
 
     /** Index over (accountId) (database name ix_accounts_checkpoint_account_id) */
     val index1 = index("ix_accounts_checkpoint_account_id", accountId)
-
     /** Index over (blockLevel) (database name ix_accounts_checkpoint_block_level) */
     val index2 = index("ix_accounts_checkpoint_block_level", blockLevel)
   }
-
   /** Collection-like TableQuery object for table AccountsCheckpoint */
   lazy val AccountsCheckpoint = new TableQuery(tag => new AccountsCheckpoint(tag))
 
@@ -244,103 +123,39 @@ trait Tables {
     *  @param level Database column level SqlType(numeric), Default(None)
     *  @param delegate Database column delegate SqlType(varchar), Default(None)
     *  @param category Database column category SqlType(varchar), Default(None) */
-  case class BalanceUpdatesRow(
-      id: Int,
-      source: String,
-      sourceId: Option[Int] = None,
-      sourceHash: Option[String] = None,
-      kind: String,
-      contract: Option[String] = None,
-      change: scala.math.BigDecimal,
-      level: Option[scala.math.BigDecimal] = None,
-      delegate: Option[String] = None,
-      category: Option[String] = None
-  )
-
+  case class BalanceUpdatesRow(id: Int, source: String, sourceId: Option[Int] = None, sourceHash: Option[String] = None, kind: String, contract: Option[String] = None, change: scala.math.BigDecimal, level: Option[scala.math.BigDecimal] = None, delegate: Option[String] = None, category: Option[String] = None)
   /** GetResult implicit for fetching BalanceUpdatesRow objects using plain SQL queries */
-  implicit def GetResultBalanceUpdatesRow(
-      implicit e0: GR[Int],
-      e1: GR[String],
-      e2: GR[Option[Int]],
-      e3: GR[Option[String]],
-      e4: GR[scala.math.BigDecimal],
-      e5: GR[Option[scala.math.BigDecimal]]
-  ): GR[BalanceUpdatesRow] = GR { prs =>
-    import prs._
-    BalanceUpdatesRow.tupled(
-      (
-        <<[Int],
-        <<[String],
-        <<?[Int],
-        <<?[String],
-        <<[String],
-        <<?[String],
-        <<[scala.math.BigDecimal],
-        <<?[scala.math.BigDecimal],
-        <<?[String],
-        <<?[String]
-      )
-    )
+  implicit def GetResultBalanceUpdatesRow(implicit e0: GR[Int], e1: GR[String], e2: GR[Option[Int]], e3: GR[Option[String]], e4: GR[scala.math.BigDecimal], e5: GR[Option[scala.math.BigDecimal]]): GR[BalanceUpdatesRow] = GR{
+    prs => import prs._
+      BalanceUpdatesRow.tupled((<<[Int], <<[String], <<?[Int], <<?[String], <<[String], <<?[String], <<[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<?[String], <<?[String]))
   }
-
   /** Table description of table balance_updates. Objects of this class serve as prototypes for rows in queries. */
   class BalanceUpdates(_tableTag: Tag) extends profile.api.Table[BalanceUpdatesRow](_tableTag, "balance_updates") {
-    def * =
-      (id, source, sourceId, sourceHash, kind, contract, change, level, delegate, category) <> (BalanceUpdatesRow.tupled, BalanceUpdatesRow.unapply)
-
+    def * = (id, source, sourceId, sourceHash, kind, contract, change, level, delegate, category) <> (BalanceUpdatesRow.tupled, BalanceUpdatesRow.unapply)
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? =
-      (
-        (
-          Rep.Some(id),
-          Rep.Some(source),
-          sourceId,
-          sourceHash,
-          Rep.Some(kind),
-          contract,
-          Rep.Some(change),
-          level,
-          delegate,
-          category
-        )
-      ).shaped.<>(
-        { r =>
-          import r._; _1.map(_ => BalanceUpdatesRow.tupled((_1.get, _2.get, _3, _4, _5.get, _6, _7.get, _8, _9, _10)))
-        },
-        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
-      )
+    def ? = ((Rep.Some(id), Rep.Some(source), sourceId, sourceHash, Rep.Some(kind), contract, Rep.Some(change), level, delegate, category)).shaped.<>({r=>import r._; _1.map(_=> BalanceUpdatesRow.tupled((_1.get, _2.get, _3, _4, _5.get, _6, _7.get, _8, _9, _10)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
 
     /** Database column id SqlType(serial), AutoInc, PrimaryKey */
     val id: Rep[Int] = column[Int]("id", O.AutoInc, O.PrimaryKey)
-
     /** Database column source SqlType(varchar) */
     val source: Rep[String] = column[String]("source")
-
     /** Database column source_id SqlType(int4), Default(None) */
     val sourceId: Rep[Option[Int]] = column[Option[Int]]("source_id", O.Default(None))
-
     /** Database column source_hash SqlType(varchar), Default(None) */
     val sourceHash: Rep[Option[String]] = column[Option[String]]("source_hash", O.Default(None))
-
     /** Database column kind SqlType(varchar) */
     val kind: Rep[String] = column[String]("kind")
-
     /** Database column contract SqlType(varchar), Default(None) */
     val contract: Rep[Option[String]] = column[Option[String]]("contract", O.Default(None))
-
     /** Database column change SqlType(numeric) */
     val change: Rep[scala.math.BigDecimal] = column[scala.math.BigDecimal]("change")
-
     /** Database column level SqlType(numeric), Default(None) */
     val level: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("level", O.Default(None))
-
     /** Database column delegate SqlType(varchar), Default(None) */
     val delegate: Rep[Option[String]] = column[Option[String]]("delegate", O.Default(None))
-
     /** Database column category SqlType(varchar), Default(None) */
     val category: Rep[Option[String]] = column[Option[String]]("category", O.Default(None))
   }
-
   /** Collection-like TableQuery object for table BalanceUpdates */
   lazy val BalanceUpdates = new TableQuery(tag => new BalanceUpdates(tag))
 
@@ -350,43 +165,29 @@ trait Tables {
     *  @param blockId Database column block_id SqlType(varchar)
     *  @param blockLevel Database column block_level SqlType(int4) */
   case class BallotsRow(pkh: String, ballot: String, blockId: String, blockLevel: Int)
-
   /** GetResult implicit for fetching BallotsRow objects using plain SQL queries */
-  implicit def GetResultBallotsRow(implicit e0: GR[String], e1: GR[Int]): GR[BallotsRow] = GR { prs =>
-    import prs._
-    BallotsRow.tupled((<<[String], <<[String], <<[String], <<[Int]))
+  implicit def GetResultBallotsRow(implicit e0: GR[String], e1: GR[Int]): GR[BallotsRow] = GR{
+    prs => import prs._
+      BallotsRow.tupled((<<[String], <<[String], <<[String], <<[Int]))
   }
-
   /** Table description of table ballots. Objects of this class serve as prototypes for rows in queries. */
   class Ballots(_tableTag: Tag) extends profile.api.Table[BallotsRow](_tableTag, "ballots") {
     def * = (pkh, ballot, blockId, blockLevel) <> (BallotsRow.tupled, BallotsRow.unapply)
-
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? =
-      ((Rep.Some(pkh), Rep.Some(ballot), Rep.Some(blockId), Rep.Some(blockLevel))).shaped.<>({ r =>
-        import r._; _1.map(_ => BallotsRow.tupled((_1.get, _2.get, _3.get, _4.get)))
-      }, (_: Any) => throw new Exception("Inserting into ? projection not supported."))
+    def ? = ((Rep.Some(pkh), Rep.Some(ballot), Rep.Some(blockId), Rep.Some(blockLevel))).shaped.<>({r=>import r._; _1.map(_=> BallotsRow.tupled((_1.get, _2.get, _3.get, _4.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
 
     /** Database column pkh SqlType(varchar) */
     val pkh: Rep[String] = column[String]("pkh")
-
     /** Database column ballot SqlType(varchar) */
     val ballot: Rep[String] = column[String]("ballot")
-
     /** Database column block_id SqlType(varchar) */
     val blockId: Rep[String] = column[String]("block_id")
-
     /** Database column block_level SqlType(int4) */
     val blockLevel: Rep[Int] = column[Int]("block_level")
 
     /** Foreign key referencing Blocks (database name ballot_block_id_fkey) */
-    lazy val blocksFk = foreignKey("ballot_block_id_fkey", blockId, Blocks)(
-      r => r.hash,
-      onUpdate = ForeignKeyAction.NoAction,
-      onDelete = ForeignKeyAction.NoAction
-    )
+    lazy val blocksFk = foreignKey("ballot_block_id_fkey", blockId, Blocks)(r => r.hash, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
   }
-
   /** Collection-like TableQuery object for table Ballots */
   lazy val Ballots = new TableQuery(tag => new Ballots(tag))
 
@@ -417,205 +218,76 @@ trait Tables {
     *  @param metaVotingPeriodPosition Database column meta_voting_period_position SqlType(int4), Default(None)
     *  @param expectedCommitment Database column expected_commitment SqlType(bool), Default(None)
     *  @param priority Database column priority SqlType(int4), Default(None) */
-  case class BlocksRow(
-      level: Int,
-      proto: Int,
-      predecessor: String,
-      timestamp: java.sql.Timestamp,
-      validationPass: Int,
-      fitness: String,
-      context: Option[String] = None,
-      signature: Option[String] = None,
-      protocol: String,
-      chainId: Option[String] = None,
-      hash: String,
-      operationsHash: Option[String] = None,
-      periodKind: Option[String] = None,
-      currentExpectedQuorum: Option[Int] = None,
-      activeProposal: Option[String] = None,
-      baker: Option[String] = None,
-      nonceHash: Option[String] = None,
-      consumedGas: Option[scala.math.BigDecimal] = None,
-      metaLevel: Option[Int] = None,
-      metaLevelPosition: Option[Int] = None,
-      metaCycle: Option[Int] = None,
-      metaCyclePosition: Option[Int] = None,
-      metaVotingPeriod: Option[Int] = None,
-      metaVotingPeriodPosition: Option[Int] = None,
-      expectedCommitment: Option[Boolean] = None,
-      priority: Option[Int] = None
-  )
-
+  case class BlocksRow(level: Int, proto: Int, predecessor: String, timestamp: java.sql.Timestamp, validationPass: Int, fitness: String, context: Option[String] = None, signature: Option[String] = None, protocol: String, chainId: Option[String] = None, hash: String, operationsHash: Option[String] = None, periodKind: Option[String] = None, currentExpectedQuorum: Option[Int] = None, activeProposal: Option[String] = None, baker: Option[String] = None, nonceHash: Option[String] = None, consumedGas: Option[scala.math.BigDecimal] = None, metaLevel: Option[Int] = None, metaLevelPosition: Option[Int] = None, metaCycle: Option[Int] = None, metaCyclePosition: Option[Int] = None, metaVotingPeriod: Option[Int] = None, metaVotingPeriodPosition: Option[Int] = None, expectedCommitment: Option[Boolean] = None, priority: Option[Int] = None)
   /** GetResult implicit for fetching BlocksRow objects using plain SQL queries */
-  implicit def GetResultBlocksRow(
-      implicit e0: GR[Int],
-      e1: GR[String],
-      e2: GR[java.sql.Timestamp],
-      e3: GR[Option[String]],
-      e4: GR[Option[Int]],
-      e5: GR[Option[scala.math.BigDecimal]],
-      e6: GR[Option[Boolean]]
-  ): GR[BlocksRow] = GR { prs =>
-    import prs._
-    BlocksRow(
-      <<[Int],
-      <<[Int],
-      <<[String],
-      <<[java.sql.Timestamp],
-      <<[Int],
-      <<[String],
-      <<?[String],
-      <<?[String],
-      <<[String],
-      <<?[String],
-      <<[String],
-      <<?[String],
-      <<?[String],
-      <<?[Int],
-      <<?[String],
-      <<?[String],
-      <<?[String],
-      <<?[scala.math.BigDecimal],
-      <<?[Int],
-      <<?[Int],
-      <<?[Int],
-      <<?[Int],
-      <<?[Int],
-      <<?[Int],
-      <<?[Boolean],
-      <<?[Int]
-    )
+  implicit def GetResultBlocksRow(implicit e0: GR[Int], e1: GR[String], e2: GR[java.sql.Timestamp], e3: GR[Option[String]], e4: GR[Option[Int]], e5: GR[Option[scala.math.BigDecimal]], e6: GR[Option[Boolean]]): GR[BlocksRow] = GR{
+    prs => import prs._
+      BlocksRow(<<[Int], <<[Int], <<[String], <<[java.sql.Timestamp], <<[Int], <<[String], <<?[String], <<?[String], <<[String], <<?[String], <<[String], <<?[String], <<?[String], <<?[Int], <<?[String], <<?[String], <<?[String], <<?[scala.math.BigDecimal], <<?[Int], <<?[Int], <<?[Int], <<?[Int], <<?[Int], <<?[Int], <<?[Boolean], <<?[Int])
   }
-
   /** Table description of table blocks. Objects of this class serve as prototypes for rows in queries. */
   class Blocks(_tableTag: Tag) extends profile.api.Table[BlocksRow](_tableTag, "blocks") {
-    def * =
-      (level :: proto :: predecessor :: timestamp :: validationPass :: fitness :: context :: signature :: protocol :: chainId :: hash :: operationsHash :: periodKind :: currentExpectedQuorum :: activeProposal :: baker :: nonceHash :: consumedGas :: metaLevel :: metaLevelPosition :: metaCycle :: metaCyclePosition :: metaVotingPeriod :: metaVotingPeriodPosition :: expectedCommitment :: priority :: HNil)
-        .mapTo[BlocksRow]
-
+    def * = (level :: proto :: predecessor :: timestamp :: validationPass :: fitness :: context :: signature :: protocol :: chainId :: hash :: operationsHash :: periodKind :: currentExpectedQuorum :: activeProposal :: baker :: nonceHash :: consumedGas :: metaLevel :: metaLevelPosition :: metaCycle :: metaCyclePosition :: metaVotingPeriod :: metaVotingPeriodPosition :: expectedCommitment :: priority :: HNil).mapTo[BlocksRow]
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? =
-      (Rep.Some(level) :: Rep.Some(proto) :: Rep.Some(predecessor) :: Rep.Some(timestamp) :: Rep.Some(validationPass) :: Rep
-            .Some(fitness) :: context :: signature :: Rep.Some(protocol) :: chainId :: Rep.Some(hash) :: operationsHash :: periodKind :: currentExpectedQuorum :: activeProposal :: baker :: nonceHash :: consumedGas :: metaLevel :: metaLevelPosition :: metaCycle :: metaCyclePosition :: metaVotingPeriod :: metaVotingPeriodPosition :: expectedCommitment :: priority :: HNil).shaped
-        .<>(
-          r =>
-            BlocksRow(
-              r(0).asInstanceOf[Option[Int]].get,
-              r(1).asInstanceOf[Option[Int]].get,
-              r(2).asInstanceOf[Option[String]].get,
-              r(3).asInstanceOf[Option[java.sql.Timestamp]].get,
-              r(4).asInstanceOf[Option[Int]].get,
-              r(5).asInstanceOf[Option[String]].get,
-              r(6).asInstanceOf[Option[String]],
-              r(7).asInstanceOf[Option[String]],
-              r(8).asInstanceOf[Option[String]].get,
-              r(9).asInstanceOf[Option[String]],
-              r(10).asInstanceOf[Option[String]].get,
-              r(11).asInstanceOf[Option[String]],
-              r(12).asInstanceOf[Option[String]],
-              r(13).asInstanceOf[Option[Int]],
-              r(14).asInstanceOf[Option[String]],
-              r(15).asInstanceOf[Option[String]],
-              r(16).asInstanceOf[Option[String]],
-              r(17).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(18).asInstanceOf[Option[Int]],
-              r(19).asInstanceOf[Option[Int]],
-              r(20).asInstanceOf[Option[Int]],
-              r(21).asInstanceOf[Option[Int]],
-              r(22).asInstanceOf[Option[Int]],
-              r(23).asInstanceOf[Option[Int]],
-              r(24).asInstanceOf[Option[Boolean]],
-              r(25).asInstanceOf[Option[Int]]
-            ),
-          (_: Any) => throw new Exception("Inserting into ? projection not supported.")
-        )
+    def ? = (Rep.Some(level) :: Rep.Some(proto) :: Rep.Some(predecessor) :: Rep.Some(timestamp) :: Rep.Some(validationPass) :: Rep.Some(fitness) :: context :: signature :: Rep.Some(protocol) :: chainId :: Rep.Some(hash) :: operationsHash :: periodKind :: currentExpectedQuorum :: activeProposal :: baker :: nonceHash :: consumedGas :: metaLevel :: metaLevelPosition :: metaCycle :: metaCyclePosition :: metaVotingPeriod :: metaVotingPeriodPosition :: expectedCommitment :: priority :: HNil).shaped.<>(r => BlocksRow(r(0).asInstanceOf[Option[Int]].get, r(1).asInstanceOf[Option[Int]].get, r(2).asInstanceOf[Option[String]].get, r(3).asInstanceOf[Option[java.sql.Timestamp]].get, r(4).asInstanceOf[Option[Int]].get, r(5).asInstanceOf[Option[String]].get, r(6).asInstanceOf[Option[String]], r(7).asInstanceOf[Option[String]], r(8).asInstanceOf[Option[String]].get, r(9).asInstanceOf[Option[String]], r(10).asInstanceOf[Option[String]].get, r(11).asInstanceOf[Option[String]], r(12).asInstanceOf[Option[String]], r(13).asInstanceOf[Option[Int]], r(14).asInstanceOf[Option[String]], r(15).asInstanceOf[Option[String]], r(16).asInstanceOf[Option[String]], r(17).asInstanceOf[Option[scala.math.BigDecimal]], r(18).asInstanceOf[Option[Int]], r(19).asInstanceOf[Option[Int]], r(20).asInstanceOf[Option[Int]], r(21).asInstanceOf[Option[Int]], r(22).asInstanceOf[Option[Int]], r(23).asInstanceOf[Option[Int]], r(24).asInstanceOf[Option[Boolean]], r(25).asInstanceOf[Option[Int]]), (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
 
     /** Database column level SqlType(int4) */
     val level: Rep[Int] = column[Int]("level")
-
     /** Database column proto SqlType(int4) */
     val proto: Rep[Int] = column[Int]("proto")
-
     /** Database column predecessor SqlType(varchar) */
     val predecessor: Rep[String] = column[String]("predecessor")
-
     /** Database column timestamp SqlType(timestamp) */
     val timestamp: Rep[java.sql.Timestamp] = column[java.sql.Timestamp]("timestamp")
-
     /** Database column validation_pass SqlType(int4) */
     val validationPass: Rep[Int] = column[Int]("validation_pass")
-
     /** Database column fitness SqlType(varchar) */
     val fitness: Rep[String] = column[String]("fitness")
-
     /** Database column context SqlType(varchar), Default(None) */
     val context: Rep[Option[String]] = column[Option[String]]("context", O.Default(None))
-
     /** Database column signature SqlType(varchar), Default(None) */
     val signature: Rep[Option[String]] = column[Option[String]]("signature", O.Default(None))
-
     /** Database column protocol SqlType(varchar) */
     val protocol: Rep[String] = column[String]("protocol")
-
     /** Database column chain_id SqlType(varchar), Default(None) */
     val chainId: Rep[Option[String]] = column[Option[String]]("chain_id", O.Default(None))
-
     /** Database column hash SqlType(varchar) */
     val hash: Rep[String] = column[String]("hash")
-
     /** Database column operations_hash SqlType(varchar), Default(None) */
     val operationsHash: Rep[Option[String]] = column[Option[String]]("operations_hash", O.Default(None))
-
     /** Database column period_kind SqlType(varchar), Default(None) */
     val periodKind: Rep[Option[String]] = column[Option[String]]("period_kind", O.Default(None))
-
     /** Database column current_expected_quorum SqlType(int4), Default(None) */
     val currentExpectedQuorum: Rep[Option[Int]] = column[Option[Int]]("current_expected_quorum", O.Default(None))
-
     /** Database column active_proposal SqlType(varchar), Default(None) */
     val activeProposal: Rep[Option[String]] = column[Option[String]]("active_proposal", O.Default(None))
-
     /** Database column baker SqlType(varchar), Default(None) */
     val baker: Rep[Option[String]] = column[Option[String]]("baker", O.Default(None))
-
     /** Database column nonce_hash SqlType(varchar), Default(None) */
     val nonceHash: Rep[Option[String]] = column[Option[String]]("nonce_hash", O.Default(None))
-
     /** Database column consumed_gas SqlType(numeric), Default(None) */
-    val consumedGas: Rep[Option[scala.math.BigDecimal]] =
-      column[Option[scala.math.BigDecimal]]("consumed_gas", O.Default(None))
-
+    val consumedGas: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("consumed_gas", O.Default(None))
     /** Database column meta_level SqlType(int4), Default(None) */
     val metaLevel: Rep[Option[Int]] = column[Option[Int]]("meta_level", O.Default(None))
-
     /** Database column meta_level_position SqlType(int4), Default(None) */
     val metaLevelPosition: Rep[Option[Int]] = column[Option[Int]]("meta_level_position", O.Default(None))
-
     /** Database column meta_cycle SqlType(int4), Default(None) */
     val metaCycle: Rep[Option[Int]] = column[Option[Int]]("meta_cycle", O.Default(None))
-
     /** Database column meta_cycle_position SqlType(int4), Default(None) */
     val metaCyclePosition: Rep[Option[Int]] = column[Option[Int]]("meta_cycle_position", O.Default(None))
-
     /** Database column meta_voting_period SqlType(int4), Default(None) */
     val metaVotingPeriod: Rep[Option[Int]] = column[Option[Int]]("meta_voting_period", O.Default(None))
-
     /** Database column meta_voting_period_position SqlType(int4), Default(None) */
     val metaVotingPeriodPosition: Rep[Option[Int]] = column[Option[Int]]("meta_voting_period_position", O.Default(None))
-
     /** Database column expected_commitment SqlType(bool), Default(None) */
     val expectedCommitment: Rep[Option[Boolean]] = column[Option[Boolean]]("expected_commitment", O.Default(None))
-
     /** Database column priority SqlType(int4), Default(None) */
     val priority: Rep[Option[Int]] = column[Option[Int]]("priority", O.Default(None))
 
     /** Uniqueness Index over (hash) (database name blocks_hash_key) */
-    val index1 = index("blocks_hash_key", hash :: HNil, unique = true)
-
+    val index1 = index("blocks_hash_key", hash :: HNil, unique=true)
     /** Index over (level) (database name ix_blocks_level) */
     val index2 = index("ix_blocks_level", level :: HNil)
   }
-
   /** Collection-like TableQuery object for table Blocks */
   lazy val Blocks = new TableQuery(tag => new Blocks(tag))
 
@@ -623,48 +295,27 @@ trait Tables {
     *  @param accountId Database column account_id SqlType(varchar)
     *  @param delegateValue Database column delegate_value SqlType(varchar), Default(None) */
   case class DelegatedContractsRow(accountId: String, delegateValue: Option[String] = None)
-
   /** GetResult implicit for fetching DelegatedContractsRow objects using plain SQL queries */
-  implicit def GetResultDelegatedContractsRow(
-      implicit e0: GR[String],
-      e1: GR[Option[String]]
-  ): GR[DelegatedContractsRow] = GR { prs =>
-    import prs._
-    DelegatedContractsRow.tupled((<<[String], <<?[String]))
+  implicit def GetResultDelegatedContractsRow(implicit e0: GR[String], e1: GR[Option[String]]): GR[DelegatedContractsRow] = GR{
+    prs => import prs._
+      DelegatedContractsRow.tupled((<<[String], <<?[String]))
   }
-
   /** Table description of table delegated_contracts. Objects of this class serve as prototypes for rows in queries. */
-  class DelegatedContracts(_tableTag: Tag)
-      extends profile.api.Table[DelegatedContractsRow](_tableTag, "delegated_contracts") {
+  class DelegatedContracts(_tableTag: Tag) extends profile.api.Table[DelegatedContractsRow](_tableTag, "delegated_contracts") {
     def * = (accountId, delegateValue) <> (DelegatedContractsRow.tupled, DelegatedContractsRow.unapply)
-
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? =
-      ((Rep.Some(accountId), delegateValue)).shaped.<>({ r =>
-        import r._; _1.map(_ => DelegatedContractsRow.tupled((_1.get, _2)))
-      }, (_: Any) => throw new Exception("Inserting into ? projection not supported."))
+    def ? = ((Rep.Some(accountId), delegateValue)).shaped.<>({r=>import r._; _1.map(_=> DelegatedContractsRow.tupled((_1.get, _2)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
 
     /** Database column account_id SqlType(varchar) */
     val accountId: Rep[String] = column[String]("account_id")
-
     /** Database column delegate_value SqlType(varchar), Default(None) */
     val delegateValue: Rep[Option[String]] = column[Option[String]]("delegate_value", O.Default(None))
 
     /** Foreign key referencing Accounts (database name contracts_account_id_fkey) */
-    lazy val accountsFk = foreignKey("contracts_account_id_fkey", accountId, Accounts)(
-      r => r.accountId,
-      onUpdate = ForeignKeyAction.NoAction,
-      onDelete = ForeignKeyAction.NoAction
-    )
-
+    lazy val accountsFk = foreignKey("contracts_account_id_fkey", accountId, Accounts)(r => r.accountId, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
     /** Foreign key referencing Delegates (database name contracts_delegate_pkh_fkey) */
-    lazy val delegatesFk = foreignKey("contracts_delegate_pkh_fkey", delegateValue, Delegates)(
-      r => Rep.Some(r.pkh),
-      onUpdate = ForeignKeyAction.NoAction,
-      onDelete = ForeignKeyAction.NoAction
-    )
+    lazy val delegatesFk = foreignKey("contracts_delegate_pkh_fkey", delegateValue, Delegates)(r => Rep.Some(r.pkh), onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
   }
-
   /** Collection-like TableQuery object for table DelegatedContracts */
   lazy val DelegatedContracts = new TableQuery(tag => new DelegatedContracts(tag))
 
@@ -678,105 +329,40 @@ trait Tables {
     *  @param deactivated Database column deactivated SqlType(bool)
     *  @param gracePeriod Database column grace_period SqlType(int4)
     *  @param blockLevel Database column block_level SqlType(int4), Default(-1) */
-  case class DelegatesRow(
-      pkh: String,
-      blockId: String,
-      balance: Option[scala.math.BigDecimal] = None,
-      frozenBalance: Option[scala.math.BigDecimal] = None,
-      stakingBalance: Option[scala.math.BigDecimal] = None,
-      delegatedBalance: Option[scala.math.BigDecimal] = None,
-      deactivated: Boolean,
-      gracePeriod: Int,
-      blockLevel: Int = -1
-  )
-
+  case class DelegatesRow(pkh: String, blockId: String, balance: Option[scala.math.BigDecimal] = None, frozenBalance: Option[scala.math.BigDecimal] = None, stakingBalance: Option[scala.math.BigDecimal] = None, delegatedBalance: Option[scala.math.BigDecimal] = None, deactivated: Boolean, gracePeriod: Int, blockLevel: Int = -1)
   /** GetResult implicit for fetching DelegatesRow objects using plain SQL queries */
-  implicit def GetResultDelegatesRow(
-      implicit e0: GR[String],
-      e1: GR[Option[scala.math.BigDecimal]],
-      e2: GR[Boolean],
-      e3: GR[Int]
-  ): GR[DelegatesRow] = GR { prs =>
-    import prs._
-    DelegatesRow.tupled(
-      (
-        <<[String],
-        <<[String],
-        <<?[scala.math.BigDecimal],
-        <<?[scala.math.BigDecimal],
-        <<?[scala.math.BigDecimal],
-        <<?[scala.math.BigDecimal],
-        <<[Boolean],
-        <<[Int],
-        <<[Int]
-      )
-    )
+  implicit def GetResultDelegatesRow(implicit e0: GR[String], e1: GR[Option[scala.math.BigDecimal]], e2: GR[Boolean], e3: GR[Int]): GR[DelegatesRow] = GR{
+    prs => import prs._
+      DelegatesRow.tupled((<<[String], <<[String], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<[Boolean], <<[Int], <<[Int]))
   }
-
   /** Table description of table delegates. Objects of this class serve as prototypes for rows in queries. */
   class Delegates(_tableTag: Tag) extends profile.api.Table[DelegatesRow](_tableTag, "delegates") {
-    def * =
-      (pkh, blockId, balance, frozenBalance, stakingBalance, delegatedBalance, deactivated, gracePeriod, blockLevel) <> (DelegatesRow.tupled, DelegatesRow.unapply)
-
+    def * = (pkh, blockId, balance, frozenBalance, stakingBalance, delegatedBalance, deactivated, gracePeriod, blockLevel) <> (DelegatesRow.tupled, DelegatesRow.unapply)
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? =
-      (
-        (
-          Rep.Some(pkh),
-          Rep.Some(blockId),
-          balance,
-          frozenBalance,
-          stakingBalance,
-          delegatedBalance,
-          Rep.Some(deactivated),
-          Rep.Some(gracePeriod),
-          Rep.Some(blockLevel)
-        )
-      ).shaped.<>(
-        { r =>
-          import r._; _1.map(_ => DelegatesRow.tupled((_1.get, _2.get, _3, _4, _5, _6, _7.get, _8.get, _9.get)))
-        },
-        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
-      )
+    def ? = ((Rep.Some(pkh), Rep.Some(blockId), balance, frozenBalance, stakingBalance, delegatedBalance, Rep.Some(deactivated), Rep.Some(gracePeriod), Rep.Some(blockLevel))).shaped.<>({r=>import r._; _1.map(_=> DelegatesRow.tupled((_1.get, _2.get, _3, _4, _5, _6, _7.get, _8.get, _9.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
 
     /** Database column pkh SqlType(varchar), PrimaryKey */
     val pkh: Rep[String] = column[String]("pkh", O.PrimaryKey)
-
     /** Database column block_id SqlType(varchar) */
     val blockId: Rep[String] = column[String]("block_id")
-
     /** Database column balance SqlType(numeric), Default(None) */
     val balance: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("balance", O.Default(None))
-
     /** Database column frozen_balance SqlType(numeric), Default(None) */
-    val frozenBalance: Rep[Option[scala.math.BigDecimal]] =
-      column[Option[scala.math.BigDecimal]]("frozen_balance", O.Default(None))
-
+    val frozenBalance: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("frozen_balance", O.Default(None))
     /** Database column staking_balance SqlType(numeric), Default(None) */
-    val stakingBalance: Rep[Option[scala.math.BigDecimal]] =
-      column[Option[scala.math.BigDecimal]]("staking_balance", O.Default(None))
-
+    val stakingBalance: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("staking_balance", O.Default(None))
     /** Database column delegated_balance SqlType(numeric), Default(None) */
-    val delegatedBalance: Rep[Option[scala.math.BigDecimal]] =
-      column[Option[scala.math.BigDecimal]]("delegated_balance", O.Default(None))
-
+    val delegatedBalance: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("delegated_balance", O.Default(None))
     /** Database column deactivated SqlType(bool) */
     val deactivated: Rep[Boolean] = column[Boolean]("deactivated")
-
     /** Database column grace_period SqlType(int4) */
     val gracePeriod: Rep[Int] = column[Int]("grace_period")
-
     /** Database column block_level SqlType(int4), Default(-1) */
     val blockLevel: Rep[Int] = column[Int]("block_level", O.Default(-1))
 
     /** Foreign key referencing Blocks (database name delegates_block_id_fkey) */
-    lazy val blocksFk = foreignKey("delegates_block_id_fkey", blockId, Blocks)(
-      r => r.hash,
-      onUpdate = ForeignKeyAction.NoAction,
-      onDelete = ForeignKeyAction.NoAction
-    )
+    lazy val blocksFk = foreignKey("delegates_block_id_fkey", blockId, Blocks)(r => r.hash, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
   }
-
   /** Collection-like TableQuery object for table Delegates */
   lazy val Delegates = new TableQuery(tag => new Delegates(tag))
 
@@ -785,48 +371,30 @@ trait Tables {
     *  @param blockId Database column block_id SqlType(varchar)
     *  @param blockLevel Database column block_level SqlType(int4), Default(-1) */
   case class DelegatesCheckpointRow(delegatePkh: String, blockId: String, blockLevel: Int = -1)
-
   /** GetResult implicit for fetching DelegatesCheckpointRow objects using plain SQL queries */
-  implicit def GetResultDelegatesCheckpointRow(implicit e0: GR[String], e1: GR[Int]): GR[DelegatesCheckpointRow] = GR {
-    prs =>
-      import prs._
+  implicit def GetResultDelegatesCheckpointRow(implicit e0: GR[String], e1: GR[Int]): GR[DelegatesCheckpointRow] = GR{
+    prs => import prs._
       DelegatesCheckpointRow.tupled((<<[String], <<[String], <<[Int]))
   }
-
   /** Table description of table delegates_checkpoint. Objects of this class serve as prototypes for rows in queries. */
-  class DelegatesCheckpoint(_tableTag: Tag)
-      extends profile.api.Table[DelegatesCheckpointRow](_tableTag, "delegates_checkpoint") {
+  class DelegatesCheckpoint(_tableTag: Tag) extends profile.api.Table[DelegatesCheckpointRow](_tableTag, "delegates_checkpoint") {
     def * = (delegatePkh, blockId, blockLevel) <> (DelegatesCheckpointRow.tupled, DelegatesCheckpointRow.unapply)
-
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? =
-      ((Rep.Some(delegatePkh), Rep.Some(blockId), Rep.Some(blockLevel))).shaped.<>(
-        { r =>
-          import r._; _1.map(_ => DelegatesCheckpointRow.tupled((_1.get, _2.get, _3.get)))
-        },
-        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
-      )
+    def ? = ((Rep.Some(delegatePkh), Rep.Some(blockId), Rep.Some(blockLevel))).shaped.<>({r=>import r._; _1.map(_=> DelegatesCheckpointRow.tupled((_1.get, _2.get, _3.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
 
     /** Database column delegate_pkh SqlType(varchar) */
     val delegatePkh: Rep[String] = column[String]("delegate_pkh")
-
     /** Database column block_id SqlType(varchar) */
     val blockId: Rep[String] = column[String]("block_id")
-
     /** Database column block_level SqlType(int4), Default(-1) */
     val blockLevel: Rep[Int] = column[Int]("block_level", O.Default(-1))
 
     /** Foreign key referencing Blocks (database name delegate_checkpoint_block_id_fkey) */
-    lazy val blocksFk = foreignKey("delegate_checkpoint_block_id_fkey", blockId, Blocks)(
-      r => r.hash,
-      onUpdate = ForeignKeyAction.NoAction,
-      onDelete = ForeignKeyAction.NoAction
-    )
+    lazy val blocksFk = foreignKey("delegate_checkpoint_block_id_fkey", blockId, Blocks)(r => r.hash, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
 
     /** Index over (blockLevel) (database name ix_delegates_checkpoint_block_level) */
     val index1 = index("ix_delegates_checkpoint_block_level", blockLevel)
   }
-
   /** Collection-like TableQuery object for table DelegatesCheckpoint */
   lazy val DelegatesCheckpoint = new TableQuery(tag => new DelegatesCheckpoint(tag))
 
@@ -837,43 +405,28 @@ trait Tables {
     *  @param timestamp Database column timestamp SqlType(timestamp)
     *  @param kind Database column kind SqlType(varchar) */
   case class FeesRow(low: Int, medium: Int, high: Int, timestamp: java.sql.Timestamp, kind: String)
-
   /** GetResult implicit for fetching FeesRow objects using plain SQL queries */
-  implicit def GetResultFeesRow(implicit e0: GR[Int], e1: GR[java.sql.Timestamp], e2: GR[String]): GR[FeesRow] = GR {
-    prs =>
-      import prs._
+  implicit def GetResultFeesRow(implicit e0: GR[Int], e1: GR[java.sql.Timestamp], e2: GR[String]): GR[FeesRow] = GR{
+    prs => import prs._
       FeesRow.tupled((<<[Int], <<[Int], <<[Int], <<[java.sql.Timestamp], <<[String]))
   }
-
   /** Table description of table fees. Objects of this class serve as prototypes for rows in queries. */
   class Fees(_tableTag: Tag) extends profile.api.Table[FeesRow](_tableTag, "fees") {
     def * = (low, medium, high, timestamp, kind) <> (FeesRow.tupled, FeesRow.unapply)
-
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? =
-      ((Rep.Some(low), Rep.Some(medium), Rep.Some(high), Rep.Some(timestamp), Rep.Some(kind))).shaped.<>(
-        { r =>
-          import r._; _1.map(_ => FeesRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get)))
-        },
-        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
-      )
+    def ? = ((Rep.Some(low), Rep.Some(medium), Rep.Some(high), Rep.Some(timestamp), Rep.Some(kind))).shaped.<>({r=>import r._; _1.map(_=> FeesRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
 
     /** Database column low SqlType(int4) */
     val low: Rep[Int] = column[Int]("low")
-
     /** Database column medium SqlType(int4) */
     val medium: Rep[Int] = column[Int]("medium")
-
     /** Database column high SqlType(int4) */
     val high: Rep[Int] = column[Int]("high")
-
     /** Database column timestamp SqlType(timestamp) */
     val timestamp: Rep[java.sql.Timestamp] = column[java.sql.Timestamp]("timestamp")
-
     /** Database column kind SqlType(varchar) */
     val kind: Rep[String] = column[String]("kind")
   }
-
   /** Collection-like TableQuery object for table Fees */
   lazy val Fees = new TableQuery(tag => new Fees(tag))
 
@@ -885,82 +438,39 @@ trait Tables {
     *  @param signature Database column signature SqlType(varchar), Default(None)
     *  @param blockId Database column block_id SqlType(varchar)
     *  @param blockLevel Database column block_level SqlType(int4) */
-  case class OperationGroupsRow(
-      protocol: String,
-      chainId: Option[String] = None,
-      hash: String,
-      branch: String,
-      signature: Option[String] = None,
-      blockId: String,
-      blockLevel: Int
-  )
-
+  case class OperationGroupsRow(protocol: String, chainId: Option[String] = None, hash: String, branch: String, signature: Option[String] = None, blockId: String, blockLevel: Int)
   /** GetResult implicit for fetching OperationGroupsRow objects using plain SQL queries */
-  implicit def GetResultOperationGroupsRow(
-      implicit e0: GR[String],
-      e1: GR[Option[String]],
-      e2: GR[Int]
-  ): GR[OperationGroupsRow] = GR { prs =>
-    import prs._
-    OperationGroupsRow.tupled((<<[String], <<?[String], <<[String], <<[String], <<?[String], <<[String], <<[Int]))
+  implicit def GetResultOperationGroupsRow(implicit e0: GR[String], e1: GR[Option[String]], e2: GR[Int]): GR[OperationGroupsRow] = GR{
+    prs => import prs._
+      OperationGroupsRow.tupled((<<[String], <<?[String], <<[String], <<[String], <<?[String], <<[String], <<[Int]))
   }
-
   /** Table description of table operation_groups. Objects of this class serve as prototypes for rows in queries. */
   class OperationGroups(_tableTag: Tag) extends profile.api.Table[OperationGroupsRow](_tableTag, "operation_groups") {
-    def * =
-      (protocol, chainId, hash, branch, signature, blockId, blockLevel) <> (OperationGroupsRow.tupled, OperationGroupsRow.unapply)
-
+    def * = (protocol, chainId, hash, branch, signature, blockId, blockLevel) <> (OperationGroupsRow.tupled, OperationGroupsRow.unapply)
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? =
-      (
-        (
-          Rep.Some(protocol),
-          chainId,
-          Rep.Some(hash),
-          Rep.Some(branch),
-          signature,
-          Rep.Some(blockId),
-          Rep.Some(blockLevel)
-        )
-      ).shaped.<>(
-        { r =>
-          import r._; _1.map(_ => OperationGroupsRow.tupled((_1.get, _2, _3.get, _4.get, _5, _6.get, _7.get)))
-        },
-        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
-      )
+    def ? = ((Rep.Some(protocol), chainId, Rep.Some(hash), Rep.Some(branch), signature, Rep.Some(blockId), Rep.Some(blockLevel))).shaped.<>({r=>import r._; _1.map(_=> OperationGroupsRow.tupled((_1.get, _2, _3.get, _4.get, _5, _6.get, _7.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
 
     /** Database column protocol SqlType(varchar) */
     val protocol: Rep[String] = column[String]("protocol")
-
     /** Database column chain_id SqlType(varchar), Default(None) */
     val chainId: Rep[Option[String]] = column[Option[String]]("chain_id", O.Default(None))
-
     /** Database column hash SqlType(varchar), PrimaryKey */
     val hash: Rep[String] = column[String]("hash", O.PrimaryKey)
-
     /** Database column branch SqlType(varchar) */
     val branch: Rep[String] = column[String]("branch")
-
     /** Database column signature SqlType(varchar), Default(None) */
     val signature: Rep[Option[String]] = column[Option[String]]("signature", O.Default(None))
-
     /** Database column block_id SqlType(varchar) */
     val blockId: Rep[String] = column[String]("block_id")
-
     /** Database column block_level SqlType(int4) */
     val blockLevel: Rep[Int] = column[Int]("block_level")
 
     /** Foreign key referencing Blocks (database name block) */
-    lazy val blocksFk = foreignKey("block", blockId, Blocks)(
-      r => r.hash,
-      onUpdate = ForeignKeyAction.NoAction,
-      onDelete = ForeignKeyAction.NoAction
-    )
+    lazy val blocksFk = foreignKey("block", blockId, Blocks)(r => r.hash, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
 
     /** Index over (blockLevel) (database name ix_operation_groups_block_level) */
     val index1 = index("ix_operation_groups_block_level", blockLevel)
   }
-
   /** Collection-like TableQuery object for table OperationGroups */
   lazy val OperationGroups = new TableQuery(tag => new OperationGroups(tag))
 
@@ -996,265 +506,101 @@ trait Tables {
     *  @param originatedContracts Database column originated_contracts SqlType(varchar), Default(None)
     *  @param blockHash Database column block_hash SqlType(varchar)
     *  @param blockLevel Database column block_level SqlType(int4)
-    *  @param timestamp Database column timestamp SqlType(timestamp) */
-  case class OperationsRow(
-      operationId: Int,
-      operationGroupHash: String,
-      kind: String,
-      level: Option[Int] = None,
-      delegate: Option[String] = None,
-      slots: Option[String] = None,
-      nonce: Option[String] = None,
-      pkh: Option[String] = None,
-      secret: Option[String] = None,
-      source: Option[String] = None,
-      fee: Option[scala.math.BigDecimal] = None,
-      counter: Option[scala.math.BigDecimal] = None,
-      gasLimit: Option[scala.math.BigDecimal] = None,
-      storageLimit: Option[scala.math.BigDecimal] = None,
-      publicKey: Option[String] = None,
-      amount: Option[scala.math.BigDecimal] = None,
-      destination: Option[String] = None,
-      parameters: Option[String] = None,
-      managerPubkey: Option[String] = None,
-      balance: Option[scala.math.BigDecimal] = None,
-      spendable: Option[Boolean] = None,
-      delegatable: Option[Boolean] = None,
-      script: Option[String] = None,
-      storage: Option[String] = None,
-      status: Option[String] = None,
-      consumedGas: Option[scala.math.BigDecimal] = None,
-      storageSize: Option[scala.math.BigDecimal] = None,
-      paidStorageSizeDiff: Option[scala.math.BigDecimal] = None,
-      originatedContracts: Option[String] = None,
-      blockHash: String,
-      blockLevel: Int,
-      timestamp: java.sql.Timestamp
-  )
-
+    *  @param timestamp Database column timestamp SqlType(timestamp)
+    *  @param internal Database column internal SqlType(bool) */
+  case class OperationsRow(operationId: Int, operationGroupHash: String, kind: String, level: Option[Int] = None, delegate: Option[String] = None, slots: Option[String] = None, nonce: Option[String] = None, pkh: Option[String] = None, secret: Option[String] = None, source: Option[String] = None, fee: Option[scala.math.BigDecimal] = None, counter: Option[scala.math.BigDecimal] = None, gasLimit: Option[scala.math.BigDecimal] = None, storageLimit: Option[scala.math.BigDecimal] = None, publicKey: Option[String] = None, amount: Option[scala.math.BigDecimal] = None, destination: Option[String] = None, parameters: Option[String] = None, managerPubkey: Option[String] = None, balance: Option[scala.math.BigDecimal] = None, spendable: Option[Boolean] = None, delegatable: Option[Boolean] = None, script: Option[String] = None, storage: Option[String] = None, status: Option[String] = None, consumedGas: Option[scala.math.BigDecimal] = None, storageSize: Option[scala.math.BigDecimal] = None, paidStorageSizeDiff: Option[scala.math.BigDecimal] = None, originatedContracts: Option[String] = None, blockHash: String, blockLevel: Int, timestamp: java.sql.Timestamp, internal: Boolean)
   /** GetResult implicit for fetching OperationsRow objects using plain SQL queries */
-  implicit def GetResultOperationsRow(
-      implicit e0: GR[Int],
-      e1: GR[String],
-      e2: GR[Option[Int]],
-      e3: GR[Option[String]],
-      e4: GR[Option[scala.math.BigDecimal]],
-      e5: GR[Option[Boolean]],
-      e6: GR[java.sql.Timestamp]
-  ): GR[OperationsRow] = GR { prs =>
-    import prs._
-    OperationsRow(
-      <<[Int],
-      <<[String],
-      <<[String],
-      <<?[Int],
-      <<?[String],
-      <<?[String],
-      <<?[String],
-      <<?[String],
-      <<?[String],
-      <<?[String],
-      <<?[scala.math.BigDecimal],
-      <<?[scala.math.BigDecimal],
-      <<?[scala.math.BigDecimal],
-      <<?[scala.math.BigDecimal],
-      <<?[String],
-      <<?[scala.math.BigDecimal],
-      <<?[String],
-      <<?[String],
-      <<?[String],
-      <<?[scala.math.BigDecimal],
-      <<?[Boolean],
-      <<?[Boolean],
-      <<?[String],
-      <<?[String],
-      <<?[String],
-      <<?[scala.math.BigDecimal],
-      <<?[scala.math.BigDecimal],
-      <<?[scala.math.BigDecimal],
-      <<?[String],
-      <<[String],
-      <<[Int],
-      <<[java.sql.Timestamp]
-    )
+  implicit def GetResultOperationsRow(implicit e0: GR[Int], e1: GR[String], e2: GR[Option[Int]], e3: GR[Option[String]], e4: GR[Option[scala.math.BigDecimal]], e5: GR[Option[Boolean]], e6: GR[java.sql.Timestamp], e7: GR[Boolean]): GR[OperationsRow] = GR{
+    prs => import prs._
+      OperationsRow(<<[Int], <<[String], <<[String], <<?[Int], <<?[String], <<?[String], <<?[String], <<?[String], <<?[String], <<?[String], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<?[String], <<?[scala.math.BigDecimal], <<?[String], <<?[String], <<?[String], <<?[scala.math.BigDecimal], <<?[Boolean], <<?[Boolean], <<?[String], <<?[String], <<?[String], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<?[String], <<[String], <<[Int], <<[java.sql.Timestamp], <<[Boolean])
   }
-
   /** Table description of table operations. Objects of this class serve as prototypes for rows in queries. */
   class Operations(_tableTag: Tag) extends profile.api.Table[OperationsRow](_tableTag, "operations") {
-    def * =
-      (operationId :: operationGroupHash :: kind :: level :: delegate :: slots :: nonce :: pkh :: secret :: source :: fee :: counter :: gasLimit :: storageLimit :: publicKey :: amount :: destination :: parameters :: managerPubkey :: balance :: spendable :: delegatable :: script :: storage :: status :: consumedGas :: storageSize :: paidStorageSizeDiff :: originatedContracts :: blockHash :: blockLevel :: timestamp :: HNil)
-        .mapTo[OperationsRow]
-
+    def * = (operationId :: operationGroupHash :: kind :: level :: delegate :: slots :: nonce :: pkh :: secret :: source :: fee :: counter :: gasLimit :: storageLimit :: publicKey :: amount :: destination :: parameters :: managerPubkey :: balance :: spendable :: delegatable :: script :: storage :: status :: consumedGas :: storageSize :: paidStorageSizeDiff :: originatedContracts :: blockHash :: blockLevel :: timestamp :: internal :: HNil).mapTo[OperationsRow]
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? =
-      (Rep.Some(operationId) :: Rep.Some(operationGroupHash) :: Rep.Some(kind) :: level :: delegate :: slots :: nonce :: pkh :: secret :: source :: fee :: counter :: gasLimit :: storageLimit :: publicKey :: amount :: destination :: parameters :: managerPubkey :: balance :: spendable :: delegatable :: script :: storage :: status :: consumedGas :: storageSize :: paidStorageSizeDiff :: originatedContracts :: Rep
-            .Some(blockHash) :: Rep.Some(blockLevel) :: Rep.Some(timestamp) :: HNil).shaped.<>(
-        r =>
-          OperationsRow(
-            r(0).asInstanceOf[Option[Int]].get,
-            r(1).asInstanceOf[Option[String]].get,
-            r(2).asInstanceOf[Option[String]].get,
-            r(3).asInstanceOf[Option[Int]],
-            r(4).asInstanceOf[Option[String]],
-            r(5).asInstanceOf[Option[String]],
-            r(6).asInstanceOf[Option[String]],
-            r(7).asInstanceOf[Option[String]],
-            r(8).asInstanceOf[Option[String]],
-            r(9).asInstanceOf[Option[String]],
-            r(10).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(11).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(12).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(13).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(14).asInstanceOf[Option[String]],
-            r(15).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(16).asInstanceOf[Option[String]],
-            r(17).asInstanceOf[Option[String]],
-            r(18).asInstanceOf[Option[String]],
-            r(19).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(20).asInstanceOf[Option[Boolean]],
-            r(21).asInstanceOf[Option[Boolean]],
-            r(22).asInstanceOf[Option[String]],
-            r(23).asInstanceOf[Option[String]],
-            r(24).asInstanceOf[Option[String]],
-            r(25).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(26).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(27).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(28).asInstanceOf[Option[String]],
-            r(29).asInstanceOf[Option[String]].get,
-            r(30).asInstanceOf[Option[Int]].get,
-            r(31).asInstanceOf[Option[java.sql.Timestamp]].get
-          ),
-        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
-      )
+    def ? = (Rep.Some(operationId) :: Rep.Some(operationGroupHash) :: Rep.Some(kind) :: level :: delegate :: slots :: nonce :: pkh :: secret :: source :: fee :: counter :: gasLimit :: storageLimit :: publicKey :: amount :: destination :: parameters :: managerPubkey :: balance :: spendable :: delegatable :: script :: storage :: status :: consumedGas :: storageSize :: paidStorageSizeDiff :: originatedContracts :: Rep.Some(blockHash) :: Rep.Some(blockLevel) :: Rep.Some(timestamp) :: Rep.Some(internal) :: HNil).shaped.<>(r => OperationsRow(r(0).asInstanceOf[Option[Int]].get, r(1).asInstanceOf[Option[String]].get, r(2).asInstanceOf[Option[String]].get, r(3).asInstanceOf[Option[Int]], r(4).asInstanceOf[Option[String]], r(5).asInstanceOf[Option[String]], r(6).asInstanceOf[Option[String]], r(7).asInstanceOf[Option[String]], r(8).asInstanceOf[Option[String]], r(9).asInstanceOf[Option[String]], r(10).asInstanceOf[Option[scala.math.BigDecimal]], r(11).asInstanceOf[Option[scala.math.BigDecimal]], r(12).asInstanceOf[Option[scala.math.BigDecimal]], r(13).asInstanceOf[Option[scala.math.BigDecimal]], r(14).asInstanceOf[Option[String]], r(15).asInstanceOf[Option[scala.math.BigDecimal]], r(16).asInstanceOf[Option[String]], r(17).asInstanceOf[Option[String]], r(18).asInstanceOf[Option[String]], r(19).asInstanceOf[Option[scala.math.BigDecimal]], r(20).asInstanceOf[Option[Boolean]], r(21).asInstanceOf[Option[Boolean]], r(22).asInstanceOf[Option[String]], r(23).asInstanceOf[Option[String]], r(24).asInstanceOf[Option[String]], r(25).asInstanceOf[Option[scala.math.BigDecimal]], r(26).asInstanceOf[Option[scala.math.BigDecimal]], r(27).asInstanceOf[Option[scala.math.BigDecimal]], r(28).asInstanceOf[Option[String]], r(29).asInstanceOf[Option[String]].get, r(30).asInstanceOf[Option[Int]].get, r(31).asInstanceOf[Option[java.sql.Timestamp]].get, r(32).asInstanceOf[Option[Boolean]].get), (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
 
     /** Database column operation_id SqlType(serial), AutoInc, PrimaryKey */
     val operationId: Rep[Int] = column[Int]("operation_id", O.AutoInc, O.PrimaryKey)
-
     /** Database column operation_group_hash SqlType(varchar) */
     val operationGroupHash: Rep[String] = column[String]("operation_group_hash")
-
     /** Database column kind SqlType(varchar) */
     val kind: Rep[String] = column[String]("kind")
-
     /** Database column level SqlType(int4), Default(None) */
     val level: Rep[Option[Int]] = column[Option[Int]]("level", O.Default(None))
-
     /** Database column delegate SqlType(varchar), Default(None) */
     val delegate: Rep[Option[String]] = column[Option[String]]("delegate", O.Default(None))
-
     /** Database column slots SqlType(varchar), Default(None) */
     val slots: Rep[Option[String]] = column[Option[String]]("slots", O.Default(None))
-
     /** Database column nonce SqlType(varchar), Default(None) */
     val nonce: Rep[Option[String]] = column[Option[String]]("nonce", O.Default(None))
-
     /** Database column pkh SqlType(varchar), Default(None) */
     val pkh: Rep[Option[String]] = column[Option[String]]("pkh", O.Default(None))
-
     /** Database column secret SqlType(varchar), Default(None) */
     val secret: Rep[Option[String]] = column[Option[String]]("secret", O.Default(None))
-
     /** Database column source SqlType(varchar), Default(None) */
     val source: Rep[Option[String]] = column[Option[String]]("source", O.Default(None))
-
     /** Database column fee SqlType(numeric), Default(None) */
     val fee: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("fee", O.Default(None))
-
     /** Database column counter SqlType(numeric), Default(None) */
     val counter: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("counter", O.Default(None))
-
     /** Database column gas_limit SqlType(numeric), Default(None) */
-    val gasLimit: Rep[Option[scala.math.BigDecimal]] =
-      column[Option[scala.math.BigDecimal]]("gas_limit", O.Default(None))
-
+    val gasLimit: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("gas_limit", O.Default(None))
     /** Database column storage_limit SqlType(numeric), Default(None) */
-    val storageLimit: Rep[Option[scala.math.BigDecimal]] =
-      column[Option[scala.math.BigDecimal]]("storage_limit", O.Default(None))
-
+    val storageLimit: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("storage_limit", O.Default(None))
     /** Database column public_key SqlType(varchar), Default(None) */
     val publicKey: Rep[Option[String]] = column[Option[String]]("public_key", O.Default(None))
-
     /** Database column amount SqlType(numeric), Default(None) */
     val amount: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("amount", O.Default(None))
-
     /** Database column destination SqlType(varchar), Default(None) */
     val destination: Rep[Option[String]] = column[Option[String]]("destination", O.Default(None))
-
     /** Database column parameters SqlType(varchar), Default(None) */
     val parameters: Rep[Option[String]] = column[Option[String]]("parameters", O.Default(None))
-
     /** Database column manager_pubkey SqlType(varchar), Default(None) */
     val managerPubkey: Rep[Option[String]] = column[Option[String]]("manager_pubkey", O.Default(None))
-
     /** Database column balance SqlType(numeric), Default(None) */
     val balance: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("balance", O.Default(None))
-
     /** Database column spendable SqlType(bool), Default(None) */
     val spendable: Rep[Option[Boolean]] = column[Option[Boolean]]("spendable", O.Default(None))
-
     /** Database column delegatable SqlType(bool), Default(None) */
     val delegatable: Rep[Option[Boolean]] = column[Option[Boolean]]("delegatable", O.Default(None))
-
     /** Database column script SqlType(varchar), Default(None) */
     val script: Rep[Option[String]] = column[Option[String]]("script", O.Default(None))
-
     /** Database column storage SqlType(varchar), Default(None) */
     val storage: Rep[Option[String]] = column[Option[String]]("storage", O.Default(None))
-
     /** Database column status SqlType(varchar), Default(None) */
     val status: Rep[Option[String]] = column[Option[String]]("status", O.Default(None))
-
     /** Database column consumed_gas SqlType(numeric), Default(None) */
-    val consumedGas: Rep[Option[scala.math.BigDecimal]] =
-      column[Option[scala.math.BigDecimal]]("consumed_gas", O.Default(None))
-
+    val consumedGas: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("consumed_gas", O.Default(None))
     /** Database column storage_size SqlType(numeric), Default(None) */
-    val storageSize: Rep[Option[scala.math.BigDecimal]] =
-      column[Option[scala.math.BigDecimal]]("storage_size", O.Default(None))
-
+    val storageSize: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("storage_size", O.Default(None))
     /** Database column paid_storage_size_diff SqlType(numeric), Default(None) */
-    val paidStorageSizeDiff: Rep[Option[scala.math.BigDecimal]] =
-      column[Option[scala.math.BigDecimal]]("paid_storage_size_diff", O.Default(None))
-
+    val paidStorageSizeDiff: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("paid_storage_size_diff", O.Default(None))
     /** Database column originated_contracts SqlType(varchar), Default(None) */
     val originatedContracts: Rep[Option[String]] = column[Option[String]]("originated_contracts", O.Default(None))
-
     /** Database column block_hash SqlType(varchar) */
     val blockHash: Rep[String] = column[String]("block_hash")
-
     /** Database column block_level SqlType(int4) */
     val blockLevel: Rep[Int] = column[Int]("block_level")
-
     /** Database column timestamp SqlType(timestamp) */
     val timestamp: Rep[java.sql.Timestamp] = column[java.sql.Timestamp]("timestamp")
+    /** Database column internal SqlType(bool) */
+    val internal: Rep[Boolean] = column[Boolean]("internal")
 
     /** Foreign key referencing Blocks (database name fk_blockhashes) */
-    lazy val blocksFk = foreignKey("fk_blockhashes", blockHash :: HNil, Blocks)(
-      r => r.hash :: HNil,
-      onUpdate = ForeignKeyAction.NoAction,
-      onDelete = ForeignKeyAction.NoAction
-    )
-
+    lazy val blocksFk = foreignKey("fk_blockhashes", blockHash :: HNil, Blocks)(r => r.hash :: HNil, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
     /** Foreign key referencing OperationGroups (database name fk_opgroups) */
-    lazy val operationGroupsFk = foreignKey("fk_opgroups", operationGroupHash :: HNil, OperationGroups)(
-      r => r.hash :: HNil,
-      onUpdate = ForeignKeyAction.NoAction,
-      onDelete = ForeignKeyAction.NoAction
-    )
+    lazy val operationGroupsFk = foreignKey("fk_opgroups", operationGroupHash :: HNil, OperationGroups)(r => r.hash :: HNil, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
 
     /** Index over (blockLevel) (database name ix_operations_block_level) */
     val index1 = index("ix_operations_block_level", blockLevel :: HNil)
-
     /** Index over (destination) (database name ix_operations_destination) */
     val index2 = index("ix_operations_destination", destination :: HNil)
-
     /** Index over (source) (database name ix_operations_source) */
     val index3 = index("ix_operations_source", source :: HNil)
-
     /** Index over (timestamp) (database name ix_operations_timestamp) */
     val index4 = index("ix_operations_timestamp", timestamp :: HNil)
   }
-
   /** Collection-like TableQuery object for table Operations */
   lazy val Operations = new TableQuery(tag => new Operations(tag))
 
@@ -1264,47 +610,32 @@ trait Tables {
     *  @param blockLevel Database column block_level SqlType(int4)
     *  @param supporters Database column supporters SqlType(int4), Default(None) */
   case class ProposalsRow(protocolHash: String, blockId: String, blockLevel: Int, supporters: Option[Int] = None)
-
   /** GetResult implicit for fetching ProposalsRow objects using plain SQL queries */
-  implicit def GetResultProposalsRow(implicit e0: GR[String], e1: GR[Int], e2: GR[Option[Int]]): GR[ProposalsRow] = GR {
-    prs =>
-      import prs._
+  implicit def GetResultProposalsRow(implicit e0: GR[String], e1: GR[Int], e2: GR[Option[Int]]): GR[ProposalsRow] = GR{
+    prs => import prs._
       ProposalsRow.tupled((<<[String], <<[String], <<[Int], <<?[Int]))
   }
-
   /** Table description of table proposals. Objects of this class serve as prototypes for rows in queries. */
   class Proposals(_tableTag: Tag) extends profile.api.Table[ProposalsRow](_tableTag, "proposals") {
     def * = (protocolHash, blockId, blockLevel, supporters) <> (ProposalsRow.tupled, ProposalsRow.unapply)
-
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? =
-      ((Rep.Some(protocolHash), Rep.Some(blockId), Rep.Some(blockLevel), supporters)).shaped.<>({ r =>
-        import r._; _1.map(_ => ProposalsRow.tupled((_1.get, _2.get, _3.get, _4)))
-      }, (_: Any) => throw new Exception("Inserting into ? projection not supported."))
+    def ? = ((Rep.Some(protocolHash), Rep.Some(blockId), Rep.Some(blockLevel), supporters)).shaped.<>({r=>import r._; _1.map(_=> ProposalsRow.tupled((_1.get, _2.get, _3.get, _4)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
 
     /** Database column protocol_hash SqlType(varchar) */
     val protocolHash: Rep[String] = column[String]("protocol_hash")
-
     /** Database column block_id SqlType(varchar) */
     val blockId: Rep[String] = column[String]("block_id")
-
     /** Database column block_level SqlType(int4) */
     val blockLevel: Rep[Int] = column[Int]("block_level")
-
     /** Database column supporters SqlType(int4), Default(None) */
     val supporters: Rep[Option[Int]] = column[Option[Int]]("supporters", O.Default(None))
 
     /** Foreign key referencing Blocks (database name proposal_block_id_fkey) */
-    lazy val blocksFk = foreignKey("proposal_block_id_fkey", blockId, Blocks)(
-      r => r.hash,
-      onUpdate = ForeignKeyAction.NoAction,
-      onDelete = ForeignKeyAction.NoAction
-    )
+    lazy val blocksFk = foreignKey("proposal_block_id_fkey", blockId, Blocks)(r => r.hash, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
 
     /** Index over (protocolHash) (database name ix_proposals_protocol) */
     val index1 = index("ix_proposals_protocol", protocolHash)
   }
-
   /** Collection-like TableQuery object for table Proposals */
   lazy val Proposals = new TableQuery(tag => new Proposals(tag))
 
@@ -1314,43 +645,29 @@ trait Tables {
     *  @param blockId Database column block_id SqlType(varchar)
     *  @param blockLevel Database column block_level SqlType(int4) */
   case class RollsRow(pkh: String, rolls: Int, blockId: String, blockLevel: Int)
-
   /** GetResult implicit for fetching RollsRow objects using plain SQL queries */
-  implicit def GetResultRollsRow(implicit e0: GR[String], e1: GR[Int]): GR[RollsRow] = GR { prs =>
-    import prs._
-    RollsRow.tupled((<<[String], <<[Int], <<[String], <<[Int]))
+  implicit def GetResultRollsRow(implicit e0: GR[String], e1: GR[Int]): GR[RollsRow] = GR{
+    prs => import prs._
+      RollsRow.tupled((<<[String], <<[Int], <<[String], <<[Int]))
   }
-
   /** Table description of table rolls. Objects of this class serve as prototypes for rows in queries. */
   class Rolls(_tableTag: Tag) extends profile.api.Table[RollsRow](_tableTag, "rolls") {
     def * = (pkh, rolls, blockId, blockLevel) <> (RollsRow.tupled, RollsRow.unapply)
-
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? =
-      ((Rep.Some(pkh), Rep.Some(rolls), Rep.Some(blockId), Rep.Some(blockLevel))).shaped.<>({ r =>
-        import r._; _1.map(_ => RollsRow.tupled((_1.get, _2.get, _3.get, _4.get)))
-      }, (_: Any) => throw new Exception("Inserting into ? projection not supported."))
+    def ? = ((Rep.Some(pkh), Rep.Some(rolls), Rep.Some(blockId), Rep.Some(blockLevel))).shaped.<>({r=>import r._; _1.map(_=> RollsRow.tupled((_1.get, _2.get, _3.get, _4.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
 
     /** Database column pkh SqlType(varchar) */
     val pkh: Rep[String] = column[String]("pkh")
-
     /** Database column rolls SqlType(int4) */
     val rolls: Rep[Int] = column[Int]("rolls")
-
     /** Database column block_id SqlType(varchar) */
     val blockId: Rep[String] = column[String]("block_id")
-
     /** Database column block_level SqlType(int4) */
     val blockLevel: Rep[Int] = column[Int]("block_level")
 
     /** Foreign key referencing Blocks (database name rolls_block_id_fkey) */
-    lazy val blocksFk = foreignKey("rolls_block_id_fkey", blockId, Blocks)(
-      r => r.hash,
-      onUpdate = ForeignKeyAction.NoAction,
-      onDelete = ForeignKeyAction.NoAction
-    )
+    lazy val blocksFk = foreignKey("rolls_block_id_fkey", blockId, Blocks)(r => r.hash, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
   }
-
   /** Collection-like TableQuery object for table Rolls */
   lazy val Rolls = new TableQuery(tag => new Rolls(tag))
 }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -258,7 +258,7 @@ object TezosTypes {
       def nonce: Int
     }
 
-    case class InternalRevealResult(
+    case class Reveal(
         kind: String,
         source: ContractId,
         nonce: Int,
@@ -266,7 +266,7 @@ object TezosTypes {
         result: OperationResult.Reveal
     ) extends InternalOperationResult
 
-    case class InternalTransactionResult(
+    case class Transaction(
         kind: String,
         source: ContractId,
         nonce: Int,
@@ -276,7 +276,7 @@ object TezosTypes {
         result: OperationResult.Transaction
     ) extends InternalOperationResult
 
-    case class InternalOriginationResult(
+    case class Origination(
         kind: String,
         source: ContractId,
         nonce: Int,
@@ -289,7 +289,7 @@ object TezosTypes {
         result: OperationResult.Origination
     ) extends InternalOperationResult
 
-    case class InternalDelegationResult(
+    case class Delegation(
         kind: String,
         source: ContractId,
         nonce: Int,

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -254,10 +254,8 @@ object TezosTypes {
 // Internal operations result definitions
   object InternalOperationResults {
 
-    sealed trait InternalOperationResult {
-      val source: ContractId
-      val kind: String
-      val nonce: Int
+    sealed trait InternalOperationResult extends Product with Serializable {
+      def nonce: Int
     }
 
     case class InternalRevealResult(

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -162,10 +162,7 @@ object TezosTypes {
   }
 
   /** root of the operation hiearchy */
-  sealed trait Operation extends Product with Serializable {
-    val internal: Boolean = false
-  }
-
+  sealed trait Operation extends Product with Serializable
   //operations definition
 
   final case class Endorsement(

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -158,7 +158,9 @@ object TezosTypes {
   }
 
   /** root of the operation hiearchy */
-  sealed trait Operation extends Product with Serializable
+  sealed trait Operation extends Product with Serializable {
+    val internal: Boolean = false
+  }
 
   //operations definition
 
@@ -232,7 +234,6 @@ object TezosTypes {
   final case object Ballot extends Operation
 
   //metadata definitions, both shared or specific to operation kind
-
   final case class EndorsementMetadata(
       slots: List[Int],
       delegate: PublicKeyHash,
@@ -242,8 +243,59 @@ object TezosTypes {
   //for now we ignore internal results, as it gets funny as sitting naked on a wasps' nest
   final case class ResultMetadata[RESULT](
       operation_result: RESULT,
-      balance_updates: List[OperationMetadata.BalanceUpdate]
+      balance_updates: List[OperationMetadata.BalanceUpdate],
+      internal_operation_results: Option[List[InternalOperationResults.InternalOperationResult]] = None
   )
+
+// Internal operations result definitions
+  object InternalOperationResults {
+
+    sealed trait InternalOperationResult {
+      val source: ContractId
+      val kind: String
+      val nonce: Int
+    }
+
+    case class InternalRevealResult(
+        kind: String,
+        source: ContractId,
+        nonce: Int,
+        public_key: PublicKey,
+        result: OperationResult.Reveal
+    ) extends InternalOperationResult
+
+    case class InternalTransactionResult(
+        kind: String,
+        source: ContractId,
+        nonce: Int,
+        amount: PositiveBigNumber,
+        destination: ContractId,
+        parameters: Option[Micheline],
+        result: OperationResult.Transaction
+    ) extends InternalOperationResult
+
+    case class InternalOriginationResult(
+        kind: String,
+        source: ContractId,
+        nonce: Int,
+        manager_pubkey: PublicKeyHash,
+        balance: PositiveBigNumber,
+        spendable: Option[Boolean],
+        delegatable: Option[Boolean],
+        delegate: Option[PublicKeyHash],
+        script: Option[Scripted.Contracts],
+        result: OperationResult.Origination
+    ) extends InternalOperationResult
+
+    case class InternalDelegationResult(
+        kind: String,
+        source: ContractId,
+        nonce: Int,
+        delegate: Option[PublicKeyHash],
+        result: OperationResult.Delegation
+    ) extends InternalOperationResult
+
+  }
 
   //generic metadata, used whenever balance updates are the only thing inside
   final case class BalanceUpdatesMetadata(

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTest.scala
@@ -1,345 +1,345 @@
 package tech.cryptonomic.conseil.tezos
 
 import org.scalatest.{EitherValues, Matchers, OptionValues, WordSpec}
-import TezosTypes._
+import tech.cryptonomic.conseil.tezos.TezosTypes._
 import tech.cryptonomic.conseil.util.JsonUtil.adaptManagerPubkeyField
 
 class JsonDecodersTest extends WordSpec with Matchers with EitherValues with OptionValues {
 
-  import JsonDecoders.Circe._
   import JsonDecoders.Circe.Accounts._
-  import JsonDecoders.Circe.Scripts._
   import JsonDecoders.Circe.Numbers._
   import JsonDecoders.Circe.Operations._
+  import JsonDecoders.Circe.Scripts._
   import JsonDecoders.Circe.Votes._
+  import JsonDecoders.Circe._
   import io.circe.parser.decode
 
   "the json decoders" should {
 
-      val validB58Hash =
-        "signiRfcqmbGc6UtW1WzuJNGzRRsWDLpafxZZPwwTMntFwup8rTxXEgcLD5UBWkYmMqZECVEr33Xw5sh9NVi45c4FVAXvQSf"
-      val invalidB58Hash =
-        "signiRfcqmbGc6UtW1WzuJNGzRRsWDLpafxZZPwwTMntFwup8rTxXEgcLD5UBWkYmMqZECVEr33Xw5sh9NVi45c4FVAXvQSl"
-      val alphanumneric = "asdopkjfap2398ufa3908wimv3pw98vja3pw98v"
-      val invalidAlphanumeric = "@*;akjfa80330"
-      val invalidJson = """{wrongname: "name"}"""
+    val validB58Hash =
+      "signiRfcqmbGc6UtW1WzuJNGzRRsWDLpafxZZPwwTMntFwup8rTxXEgcLD5UBWkYmMqZECVEr33Xw5sh9NVi45c4FVAXvQSf"
+    val invalidB58Hash =
+      "signiRfcqmbGc6UtW1WzuJNGzRRsWDLpafxZZPwwTMntFwup8rTxXEgcLD5UBWkYmMqZECVEr33Xw5sh9NVi45c4FVAXvQSl"
+    val alphanumneric = "asdopkjfap2398ufa3908wimv3pw98vja3pw98v"
+    val invalidAlphanumeric = "@*;akjfa80330"
+    val invalidJson = """{wrongname: "name"}"""
 
-      /** wrap in quotes to be a valid json string */
-      val jsonStringOf = (content: String) => s""""$content""""
+    /** wrap in quotes to be a valid json string */
+    val jsonStringOf = (content: String) => s""""$content""""
 
-      "allow decoding json with duplicate fields" in {
-        import io.circe.Decoder
-        import io.circe.generic.extras.semiauto._
-        implicit val derivationConf = Derivation.tezosDerivationConfig
+    "allow decoding json with duplicate fields" in {
+      import io.circe.Decoder
+      import io.circe.generic.extras.semiauto._
+      implicit val derivationConf = Derivation.tezosDerivationConfig
 
-        case class JsonTest(field: String)
-
-        implicit val testDecoder: Decoder[JsonTest] = deriveDecoder
+      case class JsonTest(field: String)
+
+      implicit val testDecoder: Decoder[JsonTest] = deriveDecoder
 
-        val duplicateDecoded = decode[JsonTest]("""{"field": "test", "field": "duplicate"}""")
-        duplicateDecoded shouldBe 'right
-
-        val duplicateUndecoded = decode[JsonTest]("""{"field": "test", "inner": {"key": "one", "key": "duplicate"}}""")
-        duplicateUndecoded shouldBe 'right
-
-      }
-
-      "decode null fields as empty Options" in {
-        import io.circe.Decoder
-        import io.circe.generic.extras.semiauto._
-        implicit val derivationConf = Derivation.tezosDerivationConfig
-
-        case class JsonTest(field: Option[String])
-
-        implicit val testDecoder: Decoder[JsonTest] = deriveDecoder
-
-        val valueDecoded = decode[JsonTest]("""{"field": "test"}""")
-        valueDecoded.right.value shouldBe JsonTest(Some("test"))
-
-        val nulllDecoded = decode[JsonTest]("""{"field": null}""")
-        nulllDecoded.right.value shouldBe JsonTest(None)
-
-      }
-
-      "decode a timestamp from ISO-8601 string format" in {
-        import java.time._
-        import format.DateTimeFormatter.ISO_INSTANT
-
-        val time = Instant.now()
-        val timestamp = ISO_INSTANT.format(time)
-
-        val decoded = decode[ZonedDateTime](s""""$timestamp"""") // wrap as a json string
-        decoded shouldBe 'right
-
-        decoded.right.value.toInstant shouldEqual Instant.parse(timestamp)
-      }
-
-      "decode valid json base58check strings into a PublicKey" in {
-        val decoded = decode[PublicKey](jsonStringOf(validB58Hash))
-        decoded.right.value shouldBe PublicKey(validB58Hash)
-      }
-
-      "fail to decode an invalid json base58check strings into a PublicKey" in {
-        val decoded = decode[PublicKey](jsonStringOf(invalidB58Hash))
-        decoded shouldBe 'left
-      }
-
-      "decode valid json base58check strings into a PublicKeyHash" in {
-        val decoded = decode[PublicKeyHash](jsonStringOf(validB58Hash))
-        decoded.right.value shouldBe PublicKeyHash(validB58Hash)
-      }
-
-      "fail to decode an invalid json base58check strings into a PublicKeyHash" in {
-        val decoded = decode[PublicKeyHash](jsonStringOf(invalidB58Hash))
-        decoded shouldBe 'left
-      }
-
-      "decode valid json base58check strings into a Signature" in {
-        val decoded = decode[Signature](jsonStringOf(validB58Hash))
-        decoded.right.value shouldBe Signature(validB58Hash)
-      }
-
-      "fail to decode an invalid json base58check strings into a Signature" in {
-        val decoded = decode[Signature](jsonStringOf(invalidB58Hash))
-        decoded shouldBe 'left
-      }
-
-      "decode valid json base58check strings into a BlockHash" in {
-        val decoded = decode[BlockHash](jsonStringOf(validB58Hash))
-        decoded.right.value shouldBe BlockHash(validB58Hash)
-      }
-
-      "fail to decode an invalid json base58check strings into a BlockHash" in {
-        val decoded = decode[BlockHash](jsonStringOf(invalidB58Hash))
-        decoded shouldBe 'left
-      }
-
-      "decode valid json base58check strings into a OperationHash" in {
-        val decoded = decode[OperationHash](jsonStringOf(validB58Hash))
-        decoded.right.value shouldBe OperationHash(validB58Hash)
-      }
-
-      "fail to decode an invalid json base58check strings into a OperationHash" in {
-        val decoded = decode[OperationHash](jsonStringOf(invalidB58Hash))
-        decoded shouldBe 'left
-      }
-
-      "decode valid json base58check strings into a AccountId" in {
-        val decoded = decode[AccountId](jsonStringOf(validB58Hash))
-        decoded.right.value shouldBe AccountId(validB58Hash)
-      }
-
-      "fail to decode an invalid json base58check strings into a AccountId" in {
-        val decoded = decode[AccountId](jsonStringOf(invalidB58Hash))
-        decoded shouldBe 'left
-      }
-
-      "decode valid json base58check strings into a ContractId" in {
-        val decoded = decode[ContractId](jsonStringOf(validB58Hash))
-        decoded.right.value shouldBe ContractId(validB58Hash)
-      }
-
-      "fail to decode an invalid json base58check strings into a ContractId" in {
-        val decoded = decode[ContractId](jsonStringOf(invalidB58Hash))
-        decoded shouldBe 'left
-      }
-
-      "decode valid json base58check strings into a ChainId" in {
-        val decoded = decode[ChainId](jsonStringOf(validB58Hash))
-        decoded.right.value shouldBe ChainId(validB58Hash)
-      }
-
-      "fail to decode an invalid json base58check strings into a ChainId" in {
-        val decoded = decode[ChainId](jsonStringOf(invalidB58Hash))
-        decoded shouldBe 'left
-      }
-
-      "decode valid json base58check strings into a ProtocolId" in {
-        val decoded = decode[ProtocolId](jsonStringOf(validB58Hash))
-        decoded.right.value shouldBe ProtocolId(validB58Hash)
-      }
-
-      "fail to decode an invalid json base58check strings into a ProtocolId" in {
-        val decoded = decode[ProtocolId](jsonStringOf(invalidB58Hash))
-        decoded shouldBe 'left
-      }
-
-      "decode valid json base58check strings into a ScriptId" in {
-        val decoded = decode[ScriptId](jsonStringOf(validB58Hash))
-        decoded.right.value shouldBe ScriptId(validB58Hash)
-      }
-
-      "fail to decode an invalid json base58check strings into a ScriptId" in {
-        val decoded = decode[ScriptId](jsonStringOf(invalidB58Hash))
-        decoded shouldBe 'left
-      }
-
-      "decode valid json alphanumneric strings into a Nonce" in {
-        val decoded = decode[Nonce](jsonStringOf(alphanumneric))
-        decoded.right.value shouldBe Nonce(alphanumneric)
-      }
-
-      "fail to decode an invalid json alphanumneric strings into a Nonce" in {
-        val decoded = decode[Nonce](jsonStringOf(invalidAlphanumeric))
-        decoded shouldBe 'left
-      }
-
-      "decode valid json base58check strings into a NonceHash" in {
-        val decoded = decode[NonceHash](jsonStringOf(validB58Hash))
-        decoded.right.value shouldBe NonceHash(validB58Hash)
-      }
-
-      "fail to decode an invalid json base58check strings into a NonceHash" in {
-        val decoded = decode[NonceHash](jsonStringOf(invalidB58Hash))
-        decoded shouldBe 'left
-      }
-
-      "decode valid json alphanumneric strings into a Secret" in {
-        val decoded = decode[Secret](jsonStringOf(alphanumneric))
-        decoded.right.value shouldBe Secret(alphanumneric)
-      }
-
-      "fail to decode an invalid json alphanumneric strings into a Secret" in {
-        val decoded = decode[Secret](jsonStringOf(invalidAlphanumeric))
-        decoded shouldBe 'left
-      }
-
-      "decode valid json into Micheline values" in new OperationsJsonData {
-        val decoded = decode[Micheline](michelineJson)
-        decoded.right.value shouldEqual expectedMicheline
-      }
-
-      "fail to decode invalid json into Micheline values" in new OperationsJsonData {
-        val decoded = decode[Micheline](invalidJson)
-        decoded shouldBe 'left
-      }
-
-      "decode valid json strings representing a PositiveBigNumber" in {
-        val decoded = decode[PositiveBigNumber](jsonStringOf("1000000000"))
-        decoded.right.value shouldEqual PositiveDecimal(1000000000)
-      }
-
-      "decode valid json strings representing zero as a PositiveBigNumber" in {
-        val decoded = decode[PositiveBigNumber](jsonStringOf("0"))
-        decoded.right.value shouldEqual PositiveDecimal(0)
-      }
-
-      "decode invalid json for PositiveBigNumber, representing negatives, as the original string" in {
-        val decoded = decode[PositiveBigNumber](jsonStringOf("-1000000000"))
-        decoded.right.value shouldBe InvalidPositiveDecimal("-1000000000")
-      }
-
-      "decode invalid json for PositiveBigNumber, not representing numbers, as the original string" in {
-        val decoded = decode[PositiveBigNumber](jsonStringOf("1AA000000000"))
-        decoded.right.value shouldBe InvalidPositiveDecimal("1AA000000000")
-      }
-
-      "decode valid json strings representing both positive and negative values as BigNumber" in {
-        val decoded = decode[BigNumber](jsonStringOf("1000000000"))
-        decoded.right.value shouldEqual Decimal(1000000000)
-
-        val negDecoded = decode[BigNumber](jsonStringOf("-1000000000"))
-        negDecoded.right.value shouldBe Decimal(-1000000000)
-      }
-
-      "decode invalid json for BigNumber, not representing numbers, as the original string" in {
-        val decoded = decode[BigNumber](jsonStringOf("1AA000000000"))
-        decoded.right.value shouldBe InvalidDecimal("1AA000000000")
-      }
-
-      "decode all valid voting period kinds to an enumerated value" in {
-        val proposal = decode[VotingPeriod.Kind](jsonStringOf("proposal"))
-        proposal shouldBe 'right
-        proposal.right.value shouldBe VotingPeriod.proposal
-        val promotion_vote = decode[VotingPeriod.Kind](jsonStringOf("promotion_vote"))
-        promotion_vote shouldBe 'right
-        promotion_vote.right.value shouldBe VotingPeriod.promotion_vote
-        val testing_vote = decode[VotingPeriod.Kind](jsonStringOf("testing_vote"))
-        testing_vote shouldBe 'right
-        testing_vote.right.value shouldBe VotingPeriod.testing_vote
-        val testing = decode[VotingPeriod.Kind](jsonStringOf("testing"))
-        testing shouldBe 'right
-        testing.right.value shouldBe VotingPeriod.testing
-      }
-
-      "fail to decode an invalid string as a voting period kind" in {
-        val decoded = decode[VotingPeriod.Kind](jsonStringOf("undefined_period"))
-        decoded shouldBe 'left
-      }
-
-      "decode all valid ballot votes to a BallotVote" in {
-        val yay = decode[Voting.Vote](jsonStringOf("yay"))
-        yay shouldBe 'right
-        val nay = decode[Voting.Vote](jsonStringOf("nay"))
-        nay shouldBe 'right
-        val pass = decode[Voting.Vote](jsonStringOf("pass"))
-        pass shouldBe 'right
-      }
-
-      "fail to decode an invalid string to a BallotVote" in {
-        val decoded = decode[Voting.Vote](jsonStringOf("nope"))
-        decoded shouldBe 'left
-      }
-
-      "decode valid json into a BigMapDiff value" in new OperationsJsonData {
-        val decoded = decode[Contract.BigMapDiff](bigmapdiffJson)
-        decoded.right.value shouldEqual expectedBigMapDiff
-      }
-
-      "decode valid json into a Scipted.Contracts value" in new OperationsJsonData {
-        val decoded = decode[Scripted.Contracts](scriptJson)
-        decoded.right.value shouldEqual expectedScript
-      }
-
-      "decode valid json into Error values" in new OperationsJsonData {
-        val decoded = decode[OperationResult.Error](errorJson)
-        decoded.right.value shouldEqual expectedError
-      }
-
-      "fail to decode invalid json into Error values" in new OperationsJsonData {
-        val decoded = decode[OperationResult.Error](invalidJson)
-        decoded shouldBe 'left
-      }
-
-      "decode an endorsement operation from json" in new OperationsJsonData {
-        val decoded = decode[Operation](adaptManagerPubkeyField(endorsementJson))
-        decoded shouldBe 'right
-
-        val operation = decoded.right.value
-        operation shouldBe a[Endorsement]
-        operation shouldEqual expectedEndorsement
-
-      }
-
-      "decode a seed nonce revelation operation from json" in new OperationsJsonData {
-        val decoded = decode[Operation](adaptManagerPubkeyField(nonceRevelationJson))
-        decoded shouldBe 'right
-
-        val operation = decoded.right.value
-        operation shouldBe a[SeedNonceRevelation]
-        operation shouldEqual expectedNonceRevelation
-
-      }
-
-      "decode an account activation operation from json" in new OperationsJsonData {
-        val decoded = decode[Operation](adaptManagerPubkeyField(activationJson))
-        decoded shouldBe 'right
-
-        val operation = decoded.right.value
-        operation shouldBe a[ActivateAccount]
-        operation shouldEqual expectedActivation
-
-      }
-
-      "decode an reveal operation from json" in new OperationsJsonData {
-        val decoded = decode[Operation](adaptManagerPubkeyField(revealJson))
-        decoded shouldBe 'right
-
-        val operation = decoded.right.value
-        operation shouldBe a[Reveal]
-        operation shouldEqual expectedReveal
-
-      }
+      val duplicateDecoded = decode[JsonTest]("""{"field": "test", "field": "duplicate"}""")
+      duplicateDecoded shouldBe 'right
+
+      val duplicateUndecoded = decode[JsonTest]("""{"field": "test", "inner": {"key": "one", "key": "duplicate"}}""")
+      duplicateUndecoded shouldBe 'right
+
+    }
+
+    "decode null fields as empty Options" in {
+      import io.circe.Decoder
+      import io.circe.generic.extras.semiauto._
+      implicit val derivationConf = Derivation.tezosDerivationConfig
+
+      case class JsonTest(field: Option[String])
+
+      implicit val testDecoder: Decoder[JsonTest] = deriveDecoder
+
+      val valueDecoded = decode[JsonTest]("""{"field": "test"}""")
+      valueDecoded.right.value shouldBe JsonTest(Some("test"))
+
+      val nulllDecoded = decode[JsonTest]("""{"field": null}""")
+      nulllDecoded.right.value shouldBe JsonTest(None)
+
+    }
+
+    "decode a timestamp from ISO-8601 string format" in {
+      import java.time._
+      import format.DateTimeFormatter.ISO_INSTANT
+
+      val time = Instant.now()
+      val timestamp = ISO_INSTANT.format(time)
+
+      val decoded = decode[ZonedDateTime](s""""$timestamp"""") // wrap as a json string
+      decoded shouldBe 'right
+
+      decoded.right.value.toInstant shouldEqual Instant.parse(timestamp)
+    }
+
+    "decode valid json base58check strings into a PublicKey" in {
+      val decoded = decode[PublicKey](jsonStringOf(validB58Hash))
+      decoded.right.value shouldBe PublicKey(validB58Hash)
+    }
+
+    "fail to decode an invalid json base58check strings into a PublicKey" in {
+      val decoded = decode[PublicKey](jsonStringOf(invalidB58Hash))
+      decoded shouldBe 'left
+    }
+
+    "decode valid json base58check strings into a PublicKeyHash" in {
+      val decoded = decode[PublicKeyHash](jsonStringOf(validB58Hash))
+      decoded.right.value shouldBe PublicKeyHash(validB58Hash)
+    }
+
+    "fail to decode an invalid json base58check strings into a PublicKeyHash" in {
+      val decoded = decode[PublicKeyHash](jsonStringOf(invalidB58Hash))
+      decoded shouldBe 'left
+    }
+
+    "decode valid json base58check strings into a Signature" in {
+      val decoded = decode[Signature](jsonStringOf(validB58Hash))
+      decoded.right.value shouldBe Signature(validB58Hash)
+    }
+
+    "fail to decode an invalid json base58check strings into a Signature" in {
+      val decoded = decode[Signature](jsonStringOf(invalidB58Hash))
+      decoded shouldBe 'left
+    }
+
+    "decode valid json base58check strings into a BlockHash" in {
+      val decoded = decode[BlockHash](jsonStringOf(validB58Hash))
+      decoded.right.value shouldBe BlockHash(validB58Hash)
+    }
+
+    "fail to decode an invalid json base58check strings into a BlockHash" in {
+      val decoded = decode[BlockHash](jsonStringOf(invalidB58Hash))
+      decoded shouldBe 'left
+    }
+
+    "decode valid json base58check strings into a OperationHash" in {
+      val decoded = decode[OperationHash](jsonStringOf(validB58Hash))
+      decoded.right.value shouldBe OperationHash(validB58Hash)
+    }
+
+    "fail to decode an invalid json base58check strings into a OperationHash" in {
+      val decoded = decode[OperationHash](jsonStringOf(invalidB58Hash))
+      decoded shouldBe 'left
+    }
+
+    "decode valid json base58check strings into a AccountId" in {
+      val decoded = decode[AccountId](jsonStringOf(validB58Hash))
+      decoded.right.value shouldBe AccountId(validB58Hash)
+    }
+
+    "fail to decode an invalid json base58check strings into a AccountId" in {
+      val decoded = decode[AccountId](jsonStringOf(invalidB58Hash))
+      decoded shouldBe 'left
+    }
+
+    "decode valid json base58check strings into a ContractId" in {
+      val decoded = decode[ContractId](jsonStringOf(validB58Hash))
+      decoded.right.value shouldBe ContractId(validB58Hash)
+    }
+
+    "fail to decode an invalid json base58check strings into a ContractId" in {
+      val decoded = decode[ContractId](jsonStringOf(invalidB58Hash))
+      decoded shouldBe 'left
+    }
+
+    "decode valid json base58check strings into a ChainId" in {
+      val decoded = decode[ChainId](jsonStringOf(validB58Hash))
+      decoded.right.value shouldBe ChainId(validB58Hash)
+    }
+
+    "fail to decode an invalid json base58check strings into a ChainId" in {
+      val decoded = decode[ChainId](jsonStringOf(invalidB58Hash))
+      decoded shouldBe 'left
+    }
+
+    "decode valid json base58check strings into a ProtocolId" in {
+      val decoded = decode[ProtocolId](jsonStringOf(validB58Hash))
+      decoded.right.value shouldBe ProtocolId(validB58Hash)
+    }
+
+    "fail to decode an invalid json base58check strings into a ProtocolId" in {
+      val decoded = decode[ProtocolId](jsonStringOf(invalidB58Hash))
+      decoded shouldBe 'left
+    }
+
+    "decode valid json base58check strings into a ScriptId" in {
+      val decoded = decode[ScriptId](jsonStringOf(validB58Hash))
+      decoded.right.value shouldBe ScriptId(validB58Hash)
+    }
+
+    "fail to decode an invalid json base58check strings into a ScriptId" in {
+      val decoded = decode[ScriptId](jsonStringOf(invalidB58Hash))
+      decoded shouldBe 'left
+    }
+
+    "decode valid json alphanumneric strings into a Nonce" in {
+      val decoded = decode[Nonce](jsonStringOf(alphanumneric))
+      decoded.right.value shouldBe Nonce(alphanumneric)
+    }
+
+    "fail to decode an invalid json alphanumneric strings into a Nonce" in {
+      val decoded = decode[Nonce](jsonStringOf(invalidAlphanumeric))
+      decoded shouldBe 'left
+    }
+
+    "decode valid json base58check strings into a NonceHash" in {
+      val decoded = decode[NonceHash](jsonStringOf(validB58Hash))
+      decoded.right.value shouldBe NonceHash(validB58Hash)
+    }
+
+    "fail to decode an invalid json base58check strings into a NonceHash" in {
+      val decoded = decode[NonceHash](jsonStringOf(invalidB58Hash))
+      decoded shouldBe 'left
+    }
+
+    "decode valid json alphanumneric strings into a Secret" in {
+      val decoded = decode[Secret](jsonStringOf(alphanumneric))
+      decoded.right.value shouldBe Secret(alphanumneric)
+    }
+
+    "fail to decode an invalid json alphanumneric strings into a Secret" in {
+      val decoded = decode[Secret](jsonStringOf(invalidAlphanumeric))
+      decoded shouldBe 'left
+    }
+
+    "decode valid json into Micheline values" in new OperationsJsonData {
+      val decoded = decode[Micheline](michelineJson)
+      decoded.right.value shouldEqual expectedMicheline
+    }
+
+    "fail to decode invalid json into Micheline values" in new OperationsJsonData {
+      val decoded = decode[Micheline](invalidJson)
+      decoded shouldBe 'left
+    }
+
+    "decode valid json strings representing a PositiveBigNumber" in {
+      val decoded = decode[PositiveBigNumber](jsonStringOf("1000000000"))
+      decoded.right.value shouldEqual PositiveDecimal(1000000000)
+    }
+
+    "decode valid json strings representing zero as a PositiveBigNumber" in {
+      val decoded = decode[PositiveBigNumber](jsonStringOf("0"))
+      decoded.right.value shouldEqual PositiveDecimal(0)
+    }
+
+    "decode invalid json for PositiveBigNumber, representing negatives, as the original string" in {
+      val decoded = decode[PositiveBigNumber](jsonStringOf("-1000000000"))
+      decoded.right.value shouldBe InvalidPositiveDecimal("-1000000000")
+    }
+
+    "decode invalid json for PositiveBigNumber, not representing numbers, as the original string" in {
+      val decoded = decode[PositiveBigNumber](jsonStringOf("1AA000000000"))
+      decoded.right.value shouldBe InvalidPositiveDecimal("1AA000000000")
+    }
+
+    "decode valid json strings representing both positive and negative values as BigNumber" in {
+      val decoded = decode[BigNumber](jsonStringOf("1000000000"))
+      decoded.right.value shouldEqual Decimal(1000000000)
+
+      val negDecoded = decode[BigNumber](jsonStringOf("-1000000000"))
+      negDecoded.right.value shouldBe Decimal(-1000000000)
+    }
+
+    "decode invalid json for BigNumber, not representing numbers, as the original string" in {
+      val decoded = decode[BigNumber](jsonStringOf("1AA000000000"))
+      decoded.right.value shouldBe InvalidDecimal("1AA000000000")
+    }
+
+    "decode all valid voting period kinds to an enumerated value" in {
+      val proposal = decode[VotingPeriod.Kind](jsonStringOf("proposal"))
+      proposal shouldBe 'right
+      proposal.right.value shouldBe VotingPeriod.proposal
+      val promotion_vote = decode[VotingPeriod.Kind](jsonStringOf("promotion_vote"))
+      promotion_vote shouldBe 'right
+      promotion_vote.right.value shouldBe VotingPeriod.promotion_vote
+      val testing_vote = decode[VotingPeriod.Kind](jsonStringOf("testing_vote"))
+      testing_vote shouldBe 'right
+      testing_vote.right.value shouldBe VotingPeriod.testing_vote
+      val testing = decode[VotingPeriod.Kind](jsonStringOf("testing"))
+      testing shouldBe 'right
+      testing.right.value shouldBe VotingPeriod.testing
+    }
+
+    "fail to decode an invalid string as a voting period kind" in {
+      val decoded = decode[VotingPeriod.Kind](jsonStringOf("undefined_period"))
+      decoded shouldBe 'left
+    }
+
+    "decode all valid ballot votes to a BallotVote" in {
+      val yay = decode[Voting.Vote](jsonStringOf("yay"))
+      yay shouldBe 'right
+      val nay = decode[Voting.Vote](jsonStringOf("nay"))
+      nay shouldBe 'right
+      val pass = decode[Voting.Vote](jsonStringOf("pass"))
+      pass shouldBe 'right
+    }
+
+    "fail to decode an invalid string to a BallotVote" in {
+      val decoded = decode[Voting.Vote](jsonStringOf("nope"))
+      decoded shouldBe 'left
+    }
+
+    "decode valid json into a BigMapDiff value" in new OperationsJsonData {
+      val decoded = decode[Contract.BigMapDiff](bigmapdiffJson)
+      decoded.right.value shouldEqual expectedBigMapDiff
+    }
+
+    "decode valid json into a Scipted.Contracts value" in new OperationsJsonData {
+      val decoded = decode[Scripted.Contracts](scriptJson)
+      decoded.right.value shouldEqual expectedScript
+    }
+
+    "decode valid json into Error values" in new OperationsJsonData {
+      val decoded = decode[OperationResult.Error](errorJson)
+      decoded.right.value shouldEqual expectedError
+    }
+
+    "fail to decode invalid json into Error values" in new OperationsJsonData {
+      val decoded = decode[OperationResult.Error](invalidJson)
+      decoded shouldBe 'left
+    }
+
+    "decode an endorsement operation from json" in new OperationsJsonData {
+      val decoded = decode[Operation](adaptManagerPubkeyField(endorsementJson))
+      decoded shouldBe 'right
+
+      val operation = decoded.right.value
+      operation shouldBe a[Endorsement]
+      operation shouldEqual expectedEndorsement
+
+    }
+
+    "decode a seed nonce revelation operation from json" in new OperationsJsonData {
+      val decoded = decode[Operation](adaptManagerPubkeyField(nonceRevelationJson))
+      decoded shouldBe 'right
+
+      val operation = decoded.right.value
+      operation shouldBe a[SeedNonceRevelation]
+      operation shouldEqual expectedNonceRevelation
+
+    }
+
+    "decode an account activation operation from json" in new OperationsJsonData {
+      val decoded = decode[Operation](adaptManagerPubkeyField(activationJson))
+      decoded shouldBe 'right
+
+      val operation = decoded.right.value
+      operation shouldBe a[ActivateAccount]
+      operation shouldEqual expectedActivation
+
+    }
+
+    "decode an reveal operation from json" in new OperationsJsonData {
+      val decoded = decode[Operation](adaptManagerPubkeyField(revealJson))
+      decoded shouldBe 'right
+
+      val operation = decoded.right.value
+      operation shouldBe a[Reveal]
+      operation shouldEqual expectedReveal
+
+    }
 
     "decode an transaction with internal transaction result operation from json" in new OperationsJsonData {
       val decoded = decode[Operation](adaptManagerPubkeyField(transactionWithInternalTransactionJson))
@@ -352,130 +352,120 @@ class JsonDecodersTest extends WordSpec with Matchers with EitherValues with Opt
     }
 
 
-    "decode an transaction operation from json" in new OperationsJsonData {
-        val decoded = decode[Operation](adaptManagerPubkeyField(transactionJson))
-        decoded shouldBe 'right
+    "decode an origination operation from json" in new OperationsJsonData {
+      val decoded = decode[Operation](adaptManagerPubkeyField(originationJson))
+      decoded shouldBe 'right
 
-        val operation = decoded.right.value
-        operation shouldBe a[Transaction]
-        operation shouldEqual expectedTransaction
+      val operation = decoded.right.value
+      operation shouldBe a[Origination]
+      operation shouldEqual expectedOrigination
 
-      }
-
-      "decode an origination operation from json" in new OperationsJsonData {
-        val decoded = decode[Operation](adaptManagerPubkeyField(originationJson))
-        decoded shouldBe 'right
-
-        val operation = decoded.right.value
-        operation shouldBe a[Origination]
-        operation shouldEqual expectedOrigination
-
-      }
-
-      "decode an origination operation from alphanet schema json" in new OperationsJsonData {
-        val decoded = decode[Operation](adaptManagerPubkeyField(alphanetOriginationJson))
-        decoded shouldBe 'right
-
-        val operation = decoded.right.value
-        operation shouldBe a[Origination]
-        operation shouldEqual expectedOrigination
-
-      }
-
-      "decode a delegation operation from json" in new OperationsJsonData {
-        val decoded = decode[Operation](adaptManagerPubkeyField(delegationJson))
-        decoded shouldBe 'right
-
-        val operation = decoded.right.value
-        operation shouldBe a[Delegation]
-        operation shouldEqual expectedDelegation
-
-      }
-
-      "decode a group of operations from json" in new OperationsJsonData {
-        val decoded = decode[OperationsGroup](operationsGroupJson)
-        decoded shouldBe 'right
-
-        val operations = decoded.right.value
-        operations shouldBe a[OperationsGroup]
-        operations shouldEqual expectedGroup
-
-      }
-
-      "decode proposals elements" in {
-        val decoded =
-          decode[List[(ProtocolId, ProposalSupporters)]](s"""[["$validB58Hash", 1], ["$validB58Hash", 2]]""")
-        decoded shouldBe 'right
-        decoded.right.value should contain theSameElementsAs List(
-          ProtocolId(validB58Hash) -> 1,
-          ProtocolId(validB58Hash) -> 2
-        )
-      }
-
-      "decode bakers rolls" in {
-        val decoded = decode[Voting.BakerRolls](s"""{"pkh":"$validB58Hash", "rolls":150}""")
-        decoded shouldBe 'right
-        decoded.right.value shouldBe Voting.BakerRolls(pkh = PublicKeyHash(validB58Hash), rolls = 150)
-      }
-
-      "decode bakers rolls even if rolls are json encoded as 'stringly' numbers" in {
-        val decoded = decode[Voting.BakerRolls](s"""{"pkh":"$validB58Hash", "rolls":"150"}""")
-        decoded shouldBe 'right
-        decoded.right.value shouldBe Voting.BakerRolls(pkh = PublicKeyHash(validB58Hash), rolls = 150)
-      }
-
-      "fail to decode bakers rolls for invalid fields" in {
-        val failedHash = decode[Voting.BakerRolls](s"""{"pkh":"SinvalidB58Hash", "rolls":150}""")
-        failedHash shouldBe 'left
-        val failedRolls = decode[Voting.BakerRolls](s"""{"pkh":"$validB58Hash", "rolls":true}""")
-        failedRolls shouldBe 'left
-      }
-
-      "decode ballots" in {
-        val decoded = decode[Voting.Ballot](s"""{"pkh":"$validB58Hash", "ballot":"yay"}""")
-        decoded shouldBe 'right
-        decoded.right.value shouldBe Voting.Ballot(pkh = PublicKeyHash(validB58Hash), ballot = Voting.Vote("yay"))
-      }
-
-      "fail to decode ballots with invalid fields" in {
-        val failedHash = decode[Voting.Ballot](s"""{"pkh":"SinvalidB58Hash", "ballot":"yay"}""")
-        failedHash shouldBe 'left
-        val failedBallot = decode[Voting.Ballot](s"""{"pkh":"$validB58Hash", "ballot":"nup"}""")
-        failedBallot shouldBe 'left
-      }
-
-      "decode accounts" in new AccountsJsonData {
-        val decoded = decode[Account](accountJson)
-        decoded shouldBe 'right
-
-        val account = decoded.right.value
-        account shouldEqual expectedAccount
-      }
-
-      "decode account scripts as wrapped and unparsed text, instead of a json object" in new AccountsJsonData {
-        val decoded = decode[Account](accountScriptedJson)
-        decoded shouldBe 'right
-
-        val account = decoded.right.value
-        account.script.value shouldEqual expectedScript
-      }
-
-      import JsonDecoders.Circe.Delegates._
-      "decode a delegate baker" in new DelegatesJsonData {
-        val decoded = decode[Delegate](delegateJson)
-        decoded shouldBe 'right
-
-        val delegate = decoded.right.value
-        delegate shouldEqual expectedDelegate
-      }
-
-      "decode delegate contracts" in new DelegatesJsonData {
-        val decoded = decode[Contract](contractJson)
-        decoded shouldBe 'right
-
-        val contract = decoded.right.value
-        contract shouldEqual expectedContract
-      }
     }
+
+    "decode an origination operation from alphanet schema json" in new OperationsJsonData {
+      val decoded = decode[Operation](adaptManagerPubkeyField(alphanetOriginationJson))
+      decoded shouldBe 'right
+
+      val operation = decoded.right.value
+      operation shouldBe a[Origination]
+      operation shouldEqual expectedOrigination
+
+    }
+
+    "decode a delegation operation from json" in new OperationsJsonData {
+      val decoded = decode[Operation](adaptManagerPubkeyField(delegationJson))
+      decoded shouldBe 'right
+
+      val operation = decoded.right.value
+      operation shouldBe a[Delegation]
+      operation shouldEqual expectedDelegation
+
+    }
+
+    "decode a group of operations from json" in new OperationsJsonData {
+      val decoded = decode[OperationsGroup](operationsGroupJson)
+      decoded shouldBe 'right
+
+      val operations = decoded.right.value
+      operations shouldBe a[OperationsGroup]
+      operations shouldEqual expectedGroup
+
+    }
+
+    "decode proposals elements" in {
+      val decoded =
+        decode[List[(ProtocolId, ProposalSupporters)]](s"""[["$validB58Hash", 1], ["$validB58Hash", 2]]""")
+      decoded shouldBe 'right
+      decoded.right.value should contain theSameElementsAs List(
+        ProtocolId(validB58Hash) -> 1,
+        ProtocolId(validB58Hash) -> 2
+      )
+    }
+
+    "decode bakers rolls" in {
+      val decoded = decode[Voting.BakerRolls](s"""{"pkh":"$validB58Hash", "rolls":150}""")
+      decoded shouldBe 'right
+      decoded.right.value shouldBe Voting.BakerRolls(pkh = PublicKeyHash(validB58Hash), rolls = 150)
+    }
+
+    "decode bakers rolls even if rolls are json encoded as 'stringly' numbers" in {
+      val decoded = decode[Voting.BakerRolls](s"""{"pkh":"$validB58Hash", "rolls":"150"}""")
+      decoded shouldBe 'right
+      decoded.right.value shouldBe Voting.BakerRolls(pkh = PublicKeyHash(validB58Hash), rolls = 150)
+    }
+
+    "fail to decode bakers rolls for invalid fields" in {
+      val failedHash = decode[Voting.BakerRolls](s"""{"pkh":"SinvalidB58Hash", "rolls":150}""")
+      failedHash shouldBe 'left
+      val failedRolls = decode[Voting.BakerRolls](s"""{"pkh":"$validB58Hash", "rolls":true}""")
+      failedRolls shouldBe 'left
+    }
+
+    "decode ballots" in {
+      val decoded = decode[Voting.Ballot](s"""{"pkh":"$validB58Hash", "ballot":"yay"}""")
+      decoded shouldBe 'right
+      decoded.right.value shouldBe Voting.Ballot(pkh = PublicKeyHash(validB58Hash), ballot = Voting.Vote("yay"))
+    }
+
+    "fail to decode ballots with invalid fields" in {
+      val failedHash = decode[Voting.Ballot](s"""{"pkh":"SinvalidB58Hash", "ballot":"yay"}""")
+      failedHash shouldBe 'left
+      val failedBallot = decode[Voting.Ballot](s"""{"pkh":"$validB58Hash", "ballot":"nup"}""")
+      failedBallot shouldBe 'left
+    }
+
+    "decode accounts" in new AccountsJsonData {
+      val decoded = decode[Account](accountJson)
+      decoded shouldBe 'right
+
+      val account = decoded.right.value
+      account shouldEqual expectedAccount
+    }
+
+    "decode account scripts as wrapped and unparsed text, instead of a json object" in new AccountsJsonData {
+      val decoded = decode[Account](accountScriptedJson)
+      decoded shouldBe 'right
+
+      val account = decoded.right.value
+      account.script.value shouldEqual expectedScript
+    }
+
+    import JsonDecoders.Circe.Delegates._
+    "decode a delegate baker" in new DelegatesJsonData {
+      val decoded = decode[Delegate](delegateJson)
+      decoded shouldBe 'right
+
+      val delegate = decoded.right.value
+      delegate shouldEqual expectedDelegate
+    }
+
+    "decode delegate contracts" in new DelegatesJsonData {
+      val decoded = decode[Contract](contractJson)
+      decoded shouldBe 'right
+
+      val contract = decoded.right.value
+      contract shouldEqual expectedContract
+    }
+  }
 
 }

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTest.scala
@@ -341,7 +341,18 @@ class JsonDecodersTest extends WordSpec with Matchers with EitherValues with Opt
 
       }
 
-      "decode an transaction operation from json" in new OperationsJsonData {
+    "decode an transaction with internal transaction result operation from json" in new OperationsJsonData {
+      val decoded = decode[Operation](adaptManagerPubkeyField(transactionWithInternalTransactionJson))
+      decoded shouldBe 'right
+
+      val operation = decoded.right.value
+      operation shouldBe a[Transaction]
+      operation shouldEqual transactionWithInternalTransactionResult
+
+    }
+
+
+    "decode an transaction operation from json" in new OperationsJsonData {
         val decoded = decode[Operation](adaptManagerPubkeyField(transactionJson))
         decoded shouldBe 'right
 

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTestFixtures.scala
@@ -1,6 +1,7 @@
 package tech.cryptonomic.conseil.tezos
 
 import TezosTypes._
+import tech.cryptonomic.conseil.tezos.TezosTypes.InternalOperationResults.InternalTransactionResult
 import tech.cryptonomic.conseil.tezos.TezosTypes.Scripted.Contracts
 
 /* defines example tezos json definitions of delegates and related contracts with the typed counterparts used in the tests */
@@ -577,9 +578,148 @@ trait OperationsJsonData {
           status = "applied",
           consumed_gas = Some(Decimal(10000)),
           errors = None
+        ),
+        internal_operation_results = Some(
+          List(
+            InternalOperationResults.InternalRevealResult(
+              result = OperationResult.Reveal("applied", Some(Decimal(10000)), None),
+              public_key = PublicKey("edpktxRxk9r61tjEZCt5a2hY2MWC3gzECGL7FXS1K6WXGG28hTFdFz"),
+              nonce = 1234,
+              source = ContractId("KT1PPuBrvCGpJt54hVBgXMm2sKa6QpSwKrJq"),
+              kind = "reveal"
+            )
+          )
         )
       )
     )
+
+
+  val transactionWithInternalTransactionResult = Transaction(
+    counter = PositiveDecimal(120917),
+    amount = PositiveDecimal(0),
+    fee = PositiveDecimal(0),
+    gas_limit = PositiveDecimal(2215),
+    storage_limit = PositiveDecimal(0),
+    source = ContractId("tz1MS1g7tETWfiPXtXx6Jx1XUrYJzzFY4QYN"),
+    destination = ContractId("KT1XYHyoewY5CMDdcYB5BjN7dQbWreV5cWgH"),
+    parameters = Some(Micheline("""{"string":"tz1MS1g7tETWfiPXtXx6Jx1XUrYJzzFY4QYN"}""")),
+    metadata = ResultMetadata(
+      operation_result = OperationResult.Transaction(
+        status = "applied",
+        allocated_destination_contract = None,
+        balance_updates = None,
+        big_map_diff = None,
+        consumed_gas = Some(Decimal(2008)),
+        originated_contracts = None,
+        paid_storage_size_diff = None,
+        storage = Some(Micheline("""{"prim":"Unit"}""")),
+        storage_size = Some(Decimal(69)),
+        errors = None
+      ),
+      balance_updates = List(),
+      internal_operation_results = Some(
+        List(
+          InternalTransactionResult(
+            "transaction",
+            ContractId("KT1XYHyoewY5CMDdcYB5BjN7dQbWreV5cWgH"),
+            0,
+            PositiveDecimal(1000),
+            ContractId("tz1MS1g7tETWfiPXtXx6Jx1XUrYJzzFY4QYN"),
+            Some(Micheline("""{"prim":"Unit"}""")),
+            OperationResult.Transaction(
+              status = "applied",
+              allocated_destination_contract = None,
+              balance_updates = Some(
+                List(
+                  BalanceUpdate(
+                    kind = "contract",
+                    change = -1000,
+                    category = None,
+                    contract = Some(ContractId("KT1XYHyoewY5CMDdcYB5BjN7dQbWreV5cWgH")),
+                    delegate = None,
+                    level = None
+                  ),
+                  BalanceUpdate(
+                    kind = "contract",
+                    change = 1000,
+                    category = None,
+                    contract = Some(ContractId("tz1MS1g7tETWfiPXtXx6Jx1XUrYJzzFY4QYN")),
+                    delegate = None,
+                    level = None
+                  )
+                )
+              ),
+              big_map_diff = None,
+              consumed_gas = Some(Decimal(107)),
+              originated_contracts = None,
+              paid_storage_size_diff = None,
+              storage = None,
+              storage_size = None,
+              errors = None
+            )
+          )
+        )
+      )
+    )
+  )
+
+
+  val transactionWithInternalTransactionJson =
+    """
+      |{
+      |    "kind": "transaction",
+      |    "source": "tz1MS1g7tETWfiPXtXx6Jx1XUrYJzzFY4QYN",
+      |    "fee": "0",
+      |    "counter": "120917",
+      |    "gas_limit": "2215",
+      |    "storage_limit": "0",
+      |    "amount": "0",
+      |    "destination": "KT1XYHyoewY5CMDdcYB5BjN7dQbWreV5cWgH",
+      |    "parameters": {
+      |        "string": "tz1MS1g7tETWfiPXtXx6Jx1XUrYJzzFY4QYN"
+      |    },
+      |    "metadata": {
+      |        "balance_updates": [],
+      |        "operation_result": {
+      |            "status": "applied",
+      |            "storage": {
+      |                "prim": "Unit"
+      |            },
+      |            "consumed_gas": "2008",
+      |            "storage_size": "69"
+      |        },
+      |        "internal_operation_results": [
+      |            {
+      |                "kind": "transaction",
+      |                "source": "KT1XYHyoewY5CMDdcYB5BjN7dQbWreV5cWgH",
+      |                "nonce": 0,
+      |                "amount": "1000",
+      |                "destination": "tz1MS1g7tETWfiPXtXx6Jx1XUrYJzzFY4QYN",
+      |                "parameters": {
+      |                    "prim": "Unit"
+      |                },
+      |                "result": {
+      |                    "status": "applied",
+      |                    "balance_updates": [
+      |                        {
+      |                            "kind": "contract",
+      |                            "contract": "KT1XYHyoewY5CMDdcYB5BjN7dQbWreV5cWgH",
+      |                            "change": "-1000"
+      |                        },
+      |                        {
+      |                            "kind": "contract",
+      |                            "contract": "tz1MS1g7tETWfiPXtXx6Jx1XUrYJzzFY4QYN",
+      |                            "change": "1000"
+      |                        }
+      |                    ],
+      |                    "consumed_gas": "107"
+      |                }
+      |            }
+      |        ]
+      |    }
+      |}
+    """.stripMargin
+
 
   //used to check if internal errors are correctly decoded
   val failedRevealJson =

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTestFixtures.scala
@@ -1,7 +1,6 @@
 package tech.cryptonomic.conseil.tezos
 
 import TezosTypes._
-import tech.cryptonomic.conseil.tezos.TezosTypes.InternalOperationResults.InternalTransactionResult
 import tech.cryptonomic.conseil.tezos.TezosTypes.Scripted.Contracts
 
 /* defines example tezos json definitions of delegates and related contracts with the typed counterparts used in the tests */
@@ -546,7 +545,6 @@ trait OperationsJsonData {
     |  }
     |}""".stripMargin
 
-  //ignores the internal_operation_result
   val expectedReveal =
     Reveal(
       source = ContractId("KT1PPuBrvCGpJt54hVBgXMm2sKa6QpSwKrJq"),
@@ -581,7 +579,7 @@ trait OperationsJsonData {
         ),
         internal_operation_results = Some(
           List(
-            InternalOperationResults.InternalRevealResult(
+            InternalOperationResults.Reveal(
               result = OperationResult.Reveal("applied", Some(Decimal(10000)), None),
               public_key = PublicKey("edpktxRxk9r61tjEZCt5a2hY2MWC3gzECGL7FXS1K6WXGG28hTFdFz"),
               nonce = 1234,
@@ -619,7 +617,7 @@ trait OperationsJsonData {
       balance_updates = List(),
       internal_operation_results = Some(
         List(
-          InternalTransactionResult(
+          InternalOperationResults.Transaction(
             "transaction",
             ContractId("KT1XYHyoewY5CMDdcYB5BjN7dQbWreV5cWgH"),
             0,

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
@@ -310,7 +310,8 @@ trait TezosDataGeneration extends RandomGenerationKit {
         blockHash = block.hash,
         blockLevel = block.level,
         timestamp = block.timestamp,
-        level = Some(block.level)
+        level = Some(block.level),
+        internal = false
       )
     }
 
@@ -326,7 +327,8 @@ trait TezosDataGeneration extends RandomGenerationKit {
           blockHash = block.hash,
           blockLevel = block.level,
           timestamp = new Timestamp(block.timestamp.getTime + index),
-          level = Some(block.level)
+          level = Some(block.level),
+          internal = false
         )
     }
 

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
@@ -225,8 +225,9 @@ class TezosPlatformDiscoveryOperationsTest
                 "operations"
               ),
               Attribute("block_hash", "Block hash", DataType.String, None, KeyType.NonKey, "operations"),
-              Attribute("block_level", "Block level", DataType.Int, None, KeyType.NonKey, "operations"),
-              Attribute("timestamp", "Timestamp", DataType.DateTime, None, KeyType.NonKey, "operations")
+              Attribute("block_level", "Block level", DataType.Int, None, KeyType.UniqueKey, "operations"),
+              Attribute("timestamp", "Timestamp", DataType.DateTime, None, KeyType.UniqueKey, "operations"),
+              Attribute("internal", "Internal", DataType.Boolean, None, KeyType.NonKey, "operations")
             )
           )
       }

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
@@ -237,7 +237,7 @@ class TezosPlatformDiscoveryOperationsTest
               ),
               Attribute("block_hash", "Block hash", DataType.String, None, KeyType.NonKey, "operations"),
               Attribute("block_level", "Block level", DataType.Int, None, KeyType.UniqueKey, "operations"),
-              Attribute("timestamp", "Timestamp", DataType.DateTime, None, KeyType.UniqueKey, "operations")
+              Attribute("timestamp", "Timestamp", DataType.DateTime, None, KeyType.UniqueKey, "operations"),
               Attribute("internal", "Internal", DataType.Boolean, None, KeyType.NonKey, "operations")
             )
           )


### PR DESCRIPTION
Resolves #456 
Added capturing internal transactions and other internal transactions and inserting them to the operations table with `internal` flag.
Schema was described here:
https://tezos-prod.cryptonomic-infra.tech/describe/chains/main/blocks/head/operations

### Required database changes:
In `operations` table:
+     internal boolean NOT NULL

