### PR TITLE
480 - missing storage information

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/dto/MichelsonExpression.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/dto/MichelsonExpression.scala
@@ -34,7 +34,7 @@ sealed trait MichelsonExpression extends MichelsonElement
  * */
 case class MichelsonType(
     prim: String,
-    args: List[MichelsonExpression] = List.empty,
+    args: List[MichelsonElement] = List.empty,
     annotations: List[String] = List.empty
 ) extends MichelsonExpression
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/dto/MichelsonInstruction.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/dto/MichelsonInstruction.scala
@@ -31,7 +31,9 @@ case class MichelsonSingleInstruction(
 
 /* Class representing a sequence of Michelson instructions */
 case class MichelsonInstructionSequence(instructions: List[MichelsonInstruction] = List.empty)
-    extends MichelsonInstruction
+    extends MichelsonInstruction {
+  lazy val normalized: MichelsonInstruction = if (instructions.isEmpty) MichelsonEmptyInstruction else this
+}
 
 /* Class representing an empty Michelson instruction */
 case object MichelsonEmptyInstruction extends MichelsonInstruction

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/dto/MichelsonSchema.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/dto/MichelsonSchema.scala
@@ -5,5 +5,5 @@ case class MichelsonSchema(parameter: MichelsonExpression, storage: MichelsonExp
     extends MichelsonElement
 
 object MichelsonSchema {
-  def empty = MichelsonSchema(MichelsonEmptyExpression, MichelsonEmptyExpression, MichelsonCode(List.empty))
+  lazy val empty = MichelsonSchema(MichelsonEmptyExpression, MichelsonEmptyExpression, MichelsonCode(List.empty))
 }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParser.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParser.scala
@@ -58,7 +58,7 @@ object JsonParser {
    * */
   case class JsonType(
       prim: String,
-      args: Option[List[Either[JsonExpression, Nil.type]]],
+      args: Option[List[Either[JsonExpression, List[JsonInstruction]]]],
       annots: Option[List[String]] = None
   ) extends JsonExpression {
     override def toMichelsonExpression =
@@ -66,7 +66,8 @@ object JsonParser {
         prim,
         args.getOrElse(List.empty).map {
           case Left(jsonExpression) => jsonExpression.toMichelsonExpression
-          case Right(_) => MichelsonEmptyExpression
+          case Right(jsonInstructions) =>
+            MichelsonInstructionSequence(jsonInstructions.map(_.toMichelsonInstruction)).normalized
         },
         annots.getOrElse(List.empty)
       )

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParserSpec.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParserSpec.scala
@@ -310,7 +310,7 @@ class JsonParserSpec extends FlatSpec with Matchers {
         |}""".stripMargin
 
       parse[MichelsonExpression](json) should equal(
-        Right(MichelsonType("Pair", List(MichelsonIntConstant(0), MichelsonEmptyExpression)))
+        Right(MichelsonType("Pair", List(MichelsonIntConstant(0), MichelsonEmptyInstruction)))
       )
     }
 
@@ -347,6 +347,42 @@ class JsonParserSpec extends FlatSpec with Matchers {
               MichelsonType("contract", List(MichelsonType("unit"))),
               MichelsonInstructionSequence(List(MichelsonSingleInstruction("DUP")))
             )
+          )
+        )
+      )
+    }
+
+    it should "parse MichelsonExpression with both MichelsonExpression and MichelsonInstruction as arguments" in {
+      val json =
+        """{
+          |  "prim": "Pair",
+          |  "args": [
+          |    [
+          |      {
+          |        "prim": "Elt",
+          |        "args": [
+          |          {
+          |            "int": "0"
+          |          }
+          |        ]
+          |      }
+          |    ],
+          |    {
+          |      "string": "Author: Teckhua Chiang, Company: Cryptonomic"
+          |    }
+          |  ]
+          |}
+          |""".stripMargin
+
+      parse[MichelsonExpression](json) should equal(
+        Right(
+          MichelsonType(
+            "Pair",
+            List(
+              MichelsonInstructionSequence(List(MichelsonSingleInstruction("Elt", List(MichelsonIntConstant(0))))),
+              MichelsonStringConstant("Author: Teckhua Chiang, Company: Cryptonomic")
+            ),
+            List()
           )
         )
       )


### PR DESCRIPTION
closes #480 

Fix for parsing of `MichelsonExpression`. `MichelsonExpression` and `MichelsonInstruction` can be now provided as arguments.