### PR TITLE
509 - fixing missing cardinality issue

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/metadata/MetadataService.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/metadata/MetadataService.scala
@@ -61,8 +61,30 @@ class MetadataService(
   // fetches entities
   def getEntities(path: NetworkPath): Option[List[Entity]] = entities.get(path)
 
+  // gets current entities
+  def getCurrentEntities(path: NetworkPath): Future[Option[List[Entity]]] = {
+    platformDiscoveryOperations.getEntities.map { allEntities =>
+      if(exists(path))
+        Some(transformation.overrideEntities(path, allEntities, shouldLog = false))
+      else
+        None
+    }
+  }
+
   // fetches table attributes
   def getTableAttributes(path: EntityPath): Option[List[Attribute]] = attributes.get(path)
+
+  // fetches current attributes
+  def getCurrentTableAttributes(path: EntityPath): Future[Option[List[Attribute]]] = {
+    platformDiscoveryOperations.getTableAttributes(path.entity).map { maybeAttributes =>
+      maybeAttributes.flatMap { attributes =>
+        if(exists(path))
+          Some(transformation.overrideAttributes(path, attributes, shouldLog = false))
+        else
+          None
+      }
+    }
+  }
 
   // fetches table attributes without updating cache
   def getTableAttributesWithoutUpdatingCache(path: EntityPath): Future[Option[List[Attribute]]] =

--- a/src/main/scala/tech/cryptonomic/conseil/metadata/UnitTransformation.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/metadata/UnitTransformation.scala
@@ -22,14 +22,14 @@ class UnitTransformation(overrides: MetadataConfiguration) extends LazyLogging {
   }
 
   // overrides entities
-  def overrideEntities(networkPath: NetworkPath, entities: List[Entity]): List[Entity] = {
-    logDifferences(entities.map(entity => networkPath.addLevel(entity.name)), overrides.entities(networkPath).keys.toList)
+  def overrideEntities(networkPath: NetworkPath, entities: List[Entity], shouldLog: Boolean = true): List[Entity] = {
+    if(shouldLog) logDifferences(entities.map(entity => networkPath.addLevel(entity.name)), overrides.entities(networkPath).keys.toList)
     entities.flatMap(entity => overrideEntity(entity, networkPath.addLevel(entity.name)))
   }
 
   // overrides attributes
-  def overrideAttributes(path: EntityPath, attributes: List[Attribute]): List[Attribute] = {
-    logDifferences(attributes.map(attribute => path.addLevel(attribute.name)), overrides.attributes(path).keys.toList)
+  def overrideAttributes(path: EntityPath, attributes: List[Attribute], shouldLog: Boolean = true): List[Attribute] = {
+    if(shouldLog) logDifferences(attributes.map(attribute => path.addLevel(attribute.name)), overrides.attributes(path).keys.toList)
     attributes.flatMap(attribute => overrideAttribute(attribute, path.addLevel(attribute.name)))
   }
 

--- a/src/main/scala/tech/cryptonomic/conseil/routes/PlatformDiscovery.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/PlatformDiscovery.scala
@@ -39,14 +39,14 @@ class PlatformDiscovery(metadataService: MetadataService)(implicit apiExecutionC
   }
 
   /** Metadata route implementation for entities endpoint */
-  private lazy val entitiesRoute = entitiesEndpoint.implementedBy {
-    case (platform, network, _) => metadataService.getEntities(NetworkPath(network, PlatformPath(platform)))
+  private lazy val entitiesRoute = entitiesEndpoint.implementedByAsync {
+    case (platform, network, _) => metadataService.getCurrentEntities(NetworkPath(network, PlatformPath(platform)))
   }
 
   /** Metadata route implementation for attributes endpoint */
-  private lazy val attributesRoute = attributesEndpoint.implementedBy {
+  private lazy val attributesRoute = attributesEndpoint.implementedByAsync {
     case ((platform, network, entity), _) =>
-      metadataService.getTableAttributes(EntityPath(entity, NetworkPath(network, PlatformPath(platform))))
+      metadataService.getCurrentTableAttributes(EntityPath(entity, NetworkPath(network, PlatformPath(platform))))
   }
 
   /** Metadata route implementation for attributes values endpoint */

--- a/src/test/scala/tech/cryptonomic/conseil/metadata/MetadataServiceTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/metadata/MetadataServiceTest.scala
@@ -215,6 +215,39 @@ class MetadataServiceTest
         result shouldBe Some(List(Entity("entity", "entity-name", 0)))
       }
 
+    "fetch the list of supported entities with updated values" in {
+      // given
+      platformDiscoveryOperations.addEntity(Entity("entity", "entity-name", 0))
+
+      val overwrittenConfiguration = Map(
+        "tezos" ->
+          PlatformConfiguration(
+            None,
+            Some(true),
+            None,
+            Map(
+              "mainnet" ->
+                NetworkConfiguration(
+                  None,
+                  Some(true),
+                  None,
+                  Map(
+                    "entity" ->
+                      EntityConfiguration(None, None, Some(true))
+                  )
+                )
+            )
+          )
+      )
+
+      // when
+      val result =
+        sut(overwrittenConfiguration).getCurrentEntities(NetworkPath("mainnet", PlatformPath("tezos"))).futureValue
+
+      // then
+      result shouldBe Some(List(Entity("entity", "entity-name", 0)))
+    }
+
       "override the display name for an entity" in {
         // given
         platformDiscoveryOperations.addEntity(Entity("entity", "entity-name", 0))
@@ -380,6 +413,39 @@ class MetadataServiceTest
         result shouldBe Some(List.empty)
       }
 
+    "filter out a hidden entity (by default) with updated entities" in {
+      // given
+      platformDiscoveryOperations.addEntity(Entity("entity", "entity-name", 0))
+
+      val overwrittenConfiguration = Map(
+        "tezos" ->
+          PlatformConfiguration(
+            None,
+            Some(true),
+            None,
+            Map(
+              "mainnet" ->
+                NetworkConfiguration(
+                  None,
+                  Some(true),
+                  None,
+                  Map(
+                    "entity" ->
+                      EntityConfiguration(None, None, None)
+                  )
+                )
+            )
+          )
+      )
+
+      // when
+      val result =
+        sut(overwrittenConfiguration).getCurrentEntities(NetworkPath("mainnet", PlatformPath("tezos"))).futureValue
+
+      // then
+      result shouldBe Some(List.empty)
+    }
+
       "return None when fetching entities for a non existing platform" in {
         // when
         val result =
@@ -472,6 +538,49 @@ class MetadataServiceTest
         // then
         result shouldBe Some(List(Attribute("attribute", "attribute-name", Int, None, NonKey, "entity")))
       }
+
+    "fetch the list of supported attributes with updated values" in {
+      // given
+      platformDiscoveryOperations.addEntity(Entity("entity", "entity-name", 0))
+      platformDiscoveryOperations.addAttribute(Attribute("attribute", "attribute-name", Int, None, NonKey, "entity"))
+
+      val overwrittenConfiguration = Map(
+        "tezos" ->
+          PlatformConfiguration(
+            None,
+            Some(true),
+            None,
+            Map(
+              "mainnet" ->
+                NetworkConfiguration(
+                  None,
+                  Some(true),
+                  None,
+                  Map(
+                    "entity" ->
+                      EntityConfiguration(
+                        None,
+                        None,
+                        Some(true),
+                        None,
+                        Map(
+                          "attribute" ->
+                            AttributeConfiguration(None, Some(true))
+                        )
+                      )
+                  )
+                )
+            )
+          )
+      )
+
+      // when
+      val result = sut(overwrittenConfiguration)
+        .getCurrentTableAttributes(EntityPath("entity", NetworkPath("mainnet", PlatformPath("tezos")))).futureValue
+
+      // then
+      result shouldBe Some(List(Attribute("attribute", "attribute-name", Int, None, NonKey, "entity")))
+    }
 
       "override additional fields for an attribute" in {
         // given

--- a/src/test/scala/tech/cryptonomic/conseil/metadata/TransparentUnitTransformation.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/metadata/TransparentUnitTransformation.scala
@@ -16,11 +16,13 @@ object TransparentUnitTransformation extends UnitTransformation(MetadataConfigur
 
   override def overrideEntities(
       networkPath: NetworkPath,
-      entities: List[PlatformDiscoveryTypes.Entity]
+      entities: List[PlatformDiscoveryTypes.Entity],
+      shouldLog: Boolean
   ): List[PlatformDiscoveryTypes.Entity] = entities
 
   override def overrideAttributes(
       path: EntityPath,
-      attributes: List[PlatformDiscoveryTypes.Attribute]
+      attributes: List[PlatformDiscoveryTypes.Attribute],
+      shouldLog: Boolean
   ): List[PlatformDiscoveryTypes.Attribute] = attributes
 }


### PR DESCRIPTION
resolves #509 

The issue was that metadata was stored in the values in MetadataService and they were never updated - update of the values in the cache is being done in background and but because of that it was omitted.