### PR TITLE
Travis JDK fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: scala
+jdk:
+  - oraclejdk8
 scala:
    - 2.12.4
 after_success: "sbt coverage test coverageReport coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 jdk:
-  - oraclejdk8
+  - openjdk8
 scala:
    - 2.12.4
 after_success: "sbt coverage test coverageReport coveralls"

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/renderer/MichelsonRenderer.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/renderer/MichelsonRenderer.scala
@@ -52,7 +52,7 @@ object MichelsonRenderer {
       self
         .map(_.render())
         .mkString(" ;\n")
-        .linesIterator
+        .lines
         .mkString("\n" + indent)
   }
 }


### PR DESCRIPTION
Created quick fix for the used JDK version in travis. It did not work with oraclejdk8 - it looks like travis failed to install it: https://travis-ci.org/Cryptonomic/Conseil/builds/569726767