### PR TITLE
449 - make constants instructions rather that expressions

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -166,11 +166,11 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
     val fetchedAccounts: Future[List[(AccountId, Option[Account])]] =
       fetch[AccountId, Option[Account], Future, List, Throwable].run(accountIds)
 
-    def parseMichelsonScripts(account: Account): Account = {
+    def parseMichelsonScripts: Account => Account = {
       val scriptAlter = scriptLens.modify(toMichelsonScript[MichelsonSchema])
       val storageAlter = storageLens.modify(toMichelsonScript[MichelsonInstruction])
 
-      (scriptAlter compose storageAlter)(account)
+      scriptAlter compose storageAlter
     }
 
     fetchedAccounts.map(
@@ -545,12 +545,12 @@ class TezosNodeOperator(val node: TezosRPCInterface, val network: String, batchC
     val proposalsStateFetch =
       fetchMerge(currentQuorumFetcher, currentProposalFetcher)(CurrentVotes.apply)
 
-    def parseMichelsonScripts(block: Block): Block = {
+    def parseMichelsonScripts: Block => Block = {
       val codeAlter = codeLens.modify(toMichelsonScript[MichelsonSchema])
       val storageAlter = storageLens.modify(toMichelsonScript[MichelsonInstruction])
       val parametersAlter = parametersLens.modify(toMichelsonScript[MichelsonInstruction])
 
-      (codeAlter compose storageAlter compose parametersAlter)(block)
+      codeAlter compose storageAlter compose parametersAlter
     }
 
     //Gets blocks data for the requested offsets and associates the operations and account hashes available involved in said operations

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/dto/MichelsonExpression.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/dto/MichelsonExpression.scala
@@ -38,14 +38,5 @@ case class MichelsonType(
     annotations: List[String] = List.empty
 ) extends MichelsonExpression
 
-/* Class representing an int constant */
-case class MichelsonIntConstant(int: Long) extends MichelsonExpression
-
-/* Class representing a string constant */
-case class MichelsonStringConstant(string: String) extends MichelsonExpression
-
-/* Class representing a bytes constant */
-case class MichelsonBytesConstant(bytes: String) extends MichelsonExpression
-
 /* Class representing an empty expression */
 case object MichelsonEmptyExpression extends MichelsonExpression

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/dto/MichelsonInstruction.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/dto/MichelsonInstruction.scala
@@ -20,7 +20,9 @@ package tech.cryptonomic.conseil.tezos.michelson.dto
  *   | MichelsonSingleInstruction (with embedded MichelsonInstructionSequence as above)
  *   MichelsonInstructionSequence (with three instructions separated with ";": "DIP { ... }", "SWAP" and empty instruction)
  * */
-sealed trait MichelsonInstruction extends MichelsonElement
+sealed trait MichelsonInstruction extends MichelsonElement {
+  lazy val normalized: MichelsonInstruction = this
+}
 
 /* Class representing a simple Michelson instruction which can contains following expressions */
 case class MichelsonSingleInstruction(
@@ -32,8 +34,17 @@ case class MichelsonSingleInstruction(
 /* Class representing a sequence of Michelson instructions */
 case class MichelsonInstructionSequence(instructions: List[MichelsonInstruction] = List.empty)
     extends MichelsonInstruction {
-  lazy val normalized: MichelsonInstruction = if (instructions.isEmpty) MichelsonEmptyInstruction else this
+  override lazy val normalized: MichelsonInstruction = if (instructions.isEmpty) MichelsonEmptyInstruction else this
 }
+
+/* Class representing an int constant */
+case class MichelsonIntConstant(int: Long) extends MichelsonInstruction
+
+/* Class representing a string constant */
+case class MichelsonStringConstant(string: String) extends MichelsonInstruction
+
+/* Class representing a bytes constant */
+case class MichelsonBytesConstant(bytes: String) extends MichelsonInstruction
 
 /* Class representing an empty Michelson instruction */
 case object MichelsonEmptyInstruction extends MichelsonInstruction

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParserSpec.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParserSpec.scala
@@ -352,7 +352,7 @@ class JsonParserSpec extends FlatSpec with Matchers {
       )
     }
 
-    it should "parse MichelsonExpression with both MichelsonExpression and MichelsonInstruction as arguments" in {
+  it should "parse MichelsonExpression with both MichelsonExpression and MichelsonInstruction as arguments" in {
       val json =
         """{
           |  "prim": "Pair",
@@ -384,6 +384,16 @@ class JsonParserSpec extends FlatSpec with Matchers {
             ),
             List()
           )
+        )
+      )
+    }
+
+  it should "parse MichelsonInstruction represented as simple string" in {
+      val json = """{"string":"hello"}"""
+
+      parse[MichelsonInstruction](json) should equal(
+        Right(
+          MichelsonStringConstant("hello")
         )
       )
     }


### PR DESCRIPTION
closes #449 

This PR changes the way constant types are parsed (as an instruction, not type). 