### PR TITLE
538: Test/create regression basic suite

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,6 @@ lazy val conseil = (project in file("."))
   .configs(IntegrationTest)
   .settings(
     Defaults.itSettings
-    // other settings here
   )
 
 val akkaVersion = "2.5.21"

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,13 @@
 name := "Conseil"
 scalaVersion := "2.12.8"
 
+lazy val conseil = (project in file("."))
+  .configs(IntegrationTest)
+  .settings(
+    Defaults.itSettings
+    // other settings here
+  )
+
 val akkaVersion = "2.5.21"
 val akkaHttpVersion = "10.1.8"
 val akkaHttpJsonVersion = "1.25.2"
@@ -9,6 +16,7 @@ val catsVersion = "1.6.0"
 val monocleVersion = "1.5.1-cats"
 val endpointsVersion = "0.9.0"
 val circeVersion = "0.11.1"
+val http4sVersion = "0.20.10"
 
 scapegoatVersion in ThisBuild := "1.3.8"
 parallelExecution in Test := false
@@ -64,10 +72,13 @@ libraryDependencies ++= Seq(
   "com.rklaehn"                  %% "radixtree"                     % "0.5.1",
   "com.typesafe.akka"            %% "akka-testkit"                  % akkaVersion % Test exclude ("com.typesafe", "config"),
   "com.typesafe.akka"            %% "akka-http-testkit"             % akkaHttpVersion % Test exclude ("com.typesafe", "config"),
-  "org.scalatest"                %% "scalatest"                     % "3.0.5" % Test,
-  "com.stephenn"                 %% "scalatest-json-jsonassert"     % "0.0.3" % Test,
-  "org.scalamock"                %% "scalamock"                     % "4.1.0" % Test,
-  "ru.yandex.qatools.embed"      % "postgresql-embedded"            % "2.10" % Test
+  "org.scalatest"                %% "scalatest"                     % "3.0.5" % "it, test",
+  "com.stephenn"                 %% "scalatest-json-jsonassert"     % "0.0.3" % "it, test",
+  "org.scalamock"                %% "scalamock"                     % "4.1.0" % "it, test",
+  "ru.yandex.qatools.embed"      % "postgresql-embedded"            % "2.10" % "it, test",
+  "org.http4s"                   %% "http4s-blaze-client"           % http4sVersion % IntegrationTest,
+  "org.http4s"                   %% "http4s-dsl"                    % http4sVersion % IntegrationTest,
+  "org.http4s"                   %% "http4s-circe"                  % http4sVersion % IntegrationTest
 )
 
 excludeDependencies ++= Seq(

--- a/src/it/scala/tech/cryptonomic/conseil/client/EndpointClient.scala
+++ b/src/it/scala/tech/cryptonomic/conseil/client/EndpointClient.scala
@@ -1,10 +1,12 @@
 package tech.cryptonomic.conseil.client
 
-import org.http4s.client.blaze._
-import scala.concurrent.ExecutionContext
 import java.util.concurrent.Executors
-import cats.effect.IO
-import io.circe
+import scala.language.postfixOps
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.sys.process._
+import scala.Console.{GREEN, RED, RESET}
+import org.http4s.client.blaze._
 import org.http4s.Header
 import org.http4s.headers._
 import org.http4s.MediaType
@@ -12,24 +14,69 @@ import org.http4s.circe._
 import org.http4s.dsl.io._
 import org.http4s.client.dsl.io._
 import org.http4s.Uri
-import io.circe.Json
+import io.circe.{Json, ParsingFailure, parser}
+import cats.effect.IO
+import cats.syntax.apply._
+import cats.syntax.flatMap._
 
 /** Currently can be used to test any conseil instance that loaded blocks levels 1 to 1000
   * against predefined expectations on the responses
   */
 object DataEndpointsClientProbe {
 
-  /*
-   * We might wanna start with
-   * runLorre -v -d 1000 -h BMbVtqhnzWcXVCLEZvcVVVPYdLLBrFcd2j3bufVY67WWRY8FVuN prodnet
-   */
+  object Setup {
+    implicit val ioShift = IO.contextShift(scala.concurrent.ExecutionContext.global)
+    val timer = IO.timer(scala.concurrent.ExecutionContext.global)
 
-  val pool = Executors.newCachedThreadPool()
-  val clientExecution: ExecutionContext = ExecutionContext.fromExecutor(pool)
-  implicit val shift = IO.contextShift(clientExecution)
+    /* We might wanna start with only 10k blocks */
+    private val runLorre =
+      Process(Seq("sbt", "runLorre -d 10000 -h BLc7tKfzia9hnaY1YTMS6RkDniQBoApM4EjKFRLucsuHbiy3eqt prodnet"))
+    private val runConseil = Process(Seq("sbt", "runConseil -v"))
+    private def grepConseilPID(): String = (Seq("jps", "-m") #| Seq("grep", "runConseil")).!!.split(" ").head
+    private def stopPid(pid: String) = Seq("kill", "-2", pid).!
 
-  val clientBuild = BlazeClientBuilder[IO](clientExecution)
+    private def syncData = IO((runLorre !).ensuring(_ == 0, "lorre failed to load correctly"))
 
+    private def startConseil(shouldSync: Boolean): IO[Process] =
+      for {
+        _ <- if (shouldSync) syncData else IO(0)
+        proc <- IO(runConseil.run())
+        _ <- IO(println("waiting for conseil to start"))
+        _ <- timer.sleep(30.seconds)
+      } yield proc
+
+    def usingConseil[A](shouldSync: Boolean = false)(testBlock: => IO[A]) =
+      startConseil(shouldSync).bracket(
+        use = _ => testBlock
+      )(
+        release = _ =>
+          for {
+            pid <- IO(grepConseilPID())
+            _ <- IO(println(s"Stopping conseil at PID $pid"))
+            _ <- IO(stopPid(pid))
+          } yield ()
+      )
+
+  }
+
+  private val pool = Executors.newCachedThreadPool()
+  private val clientExecution: ExecutionContext = ExecutionContext.fromExecutor(pool)
+  implicit private val shift = IO.contextShift(clientExecution)
+
+  private val clientBuild = BlazeClientBuilder[IO](clientExecution)
+
+  def runRegressionSuite(shouldSync: Boolean = true): IO[Unit] =
+    Setup
+      .usingConseil(shouldSync) {
+        infoEndpoint *>
+        blockHeadEndpoint
+      }
+      .flatMap {
+        case Left(error) => IO(println(s"$RED Regression test failed: ${error.getMessage()}$RESET"))
+        case Right(value) => IO(println(s"$GREEN Regression test passed: OK$RESET"))
+      }
+
+  /** info */
   def infoEndpoint: IO[Either[Throwable, Json]] = {
 
     val expected =
@@ -40,25 +87,80 @@ object DataEndpointsClientProbe {
 
     val endpoint = Uri.uri("http://localhost:1337/info")
 
-    clientBuild.resource.use {
-      client =>
-        val req = GET(
-          endpoint,
-          `Content-Type`(MediaType.application.json),
-          Accept(MediaType.application.json),
-          Header("apiKey", "hooman")
-        )
-        client.expect[Json](req)
-          .attempt
-          .map {
-            case Right(json) =>
-              Either.cond(
-                json \\ "application" == expected \\ "application" && (json \\ "version").nonEmpty,
-                right = json,
-                left = new Exception(s"Failed to match on $endpoint: expected \n${expected.spaces2} \n but found \n ${json.spaces2}")
-              )
-            case left => left
-          }
+    clientBuild.resource.use { client =>
+      val req = GET(
+        endpoint,
+        `Content-Type`(MediaType.application.json),
+        Accept(MediaType.application.json),
+        Header("apiKey", "hooman")
+      )
+      client.expect[Json](req).attempt.map {
+        case Right(json) =>
+          Either.cond(
+            json \\ "application" == expected \\ "application" && (json \\ "version").nonEmpty,
+            right = json,
+            left = new Exception(
+              s"Failed to match on $endpoint: expected \n${expected.spaces2} \n but found \n ${json.spaces2}"
+            )
+          )
+        case left => left
+      }
+    }
+  }
+
+  /** block head */
+  def blockHeadEndpoint: IO[Either[Throwable, Json]] = {
+
+    val expected: Json = parser.parse(
+     """{
+    |  "baker": "tz3RDC3Jdn4j15J7bBHZd29EUee9gVB1CxD9",
+    |  "chainId": "NetXdQprcVkpaWU",
+    |  "consumedGas": 0,
+    |  "context": "CoUnq1qGxUtidFCdcaCWXEQdefFDSdBTpjnYVcrHJ1cKYqL6HLiA",
+    |  "expectedCommitment": false,
+    |  "fitness": "00,000000000004fff6",
+    |  "hash": "BLc7tKfzia9hnaY1YTMS6RkDniQBoApM4EjKFRLucsuHbiy3eqt",
+    |  "level": 10000,
+    |  "metaCycle": 2,
+    |  "metaCyclePosition": 1807,
+    |  "metaLevel": 10000,
+    |  "metaLevelPosition": 9999,
+    |  "metaVotingPeriod": 0,
+    |  "metaVotingPeriodPosition": 9999,
+    |  "operationsHash": "LLob71uMBRtLaKGj3sDJmAT7VEdGTtEoogrbFFnPjxXiYfDmUQrgr",
+    |  "periodKind": "proposal",
+    |  "predecessor": "BMG7bSzAh1is2896bUkK7RnUREqqN4BjcH4J7YgkFKcNHWNe4cM",
+    |  "priority": 0,
+    |  "proto": 1,
+    |  "protocol": "PtCJ7pwoxe8JasnHY8YonnLYjcVHmhiARPJvqcC6VfHT5s8k8sY",
+    |  "signature": "sigRg6mM8oEt5y7nzSwi34P3UEoNDYjHF2Nik9s2f7xFGzMbbgmVYrc3uXdAKPF3ayDLv7vaEN4U2ZeDC69EJp4keYphw9WQ",
+    |  "timestamp": 1530983187000,
+    |  "validationPass": 4
+    |}""".stripMargin
+  ).ensuring(_.isRight)
+    .right
+    .get
+
+    val endpoint = Uri.uri("http://localhost:1337/v2/data/tezos/mainnet/blocks/head")
+
+    clientBuild.resource.use { client =>
+      val req = GET(
+        endpoint,
+        `Content-Type`(MediaType.application.json),
+        Accept(MediaType.application.json),
+        Header("apiKey", "hooman")
+      )
+      client.expect[Json](req).attempt.map {
+        case Right(json) =>
+          Either.cond(
+            json == expected,
+            right = json,
+            left = new Exception(
+              s"Failed to match on $endpoint: expected \n${expected.spaces2} \n but found \n ${json.spaces2}"
+            )
+          )
+        case left => left
+      }
     }
   }
 

--- a/src/it/scala/tech/cryptonomic/conseil/client/EndpointClient.scala
+++ b/src/it/scala/tech/cryptonomic/conseil/client/EndpointClient.scala
@@ -1,0 +1,65 @@
+package tech.cryptonomic.conseil.client
+
+import org.http4s.client.blaze._
+import scala.concurrent.ExecutionContext
+import java.util.concurrent.Executors
+import cats.effect.IO
+import io.circe
+import org.http4s.Header
+import org.http4s.headers._
+import org.http4s.MediaType
+import org.http4s.circe._
+import org.http4s.dsl.io._
+import org.http4s.client.dsl.io._
+import org.http4s.Uri
+import io.circe.Json
+
+/** Currently can be used to test any conseil instance that loaded blocks levels 1 to 1000
+  * against predefined expectations on the responses
+  */
+object DataEndpointsClientProbe {
+
+  /*
+   * We might wanna start with
+   * runLorre -v -d 1000 -h BMbVtqhnzWcXVCLEZvcVVVPYdLLBrFcd2j3bufVY67WWRY8FVuN prodnet
+   */
+
+  val pool = Executors.newCachedThreadPool()
+  val clientExecution: ExecutionContext = ExecutionContext.fromExecutor(pool)
+  implicit val shift = IO.contextShift(clientExecution)
+
+  val clientBuild = BlazeClientBuilder[IO](clientExecution)
+
+  def infoEndpoint: IO[Either[Throwable, Json]] = {
+
+    val expected =
+      Json.obj(
+        "application" -> Json.fromString("Conseil"),
+        "version" -> Json.fromString("A non empty version string")
+      )
+
+    val endpoint = Uri.uri("http://localhost:1337/info")
+
+    clientBuild.resource.use {
+      client =>
+        val req = GET(
+          endpoint,
+          `Content-Type`(MediaType.application.json),
+          Accept(MediaType.application.json),
+          Header("apiKey", "hooman")
+        )
+        client.expect[Json](req)
+          .attempt
+          .map {
+            case Right(json) =>
+              Either.cond(
+                json \\ "application" == expected \\ "application" && (json \\ "version").nonEmpty,
+                right = json,
+                left = new Exception(s"Failed to match on $endpoint: expected \n${expected.spaces2} \n but found \n ${json.spaces2}")
+              )
+            case left => left
+          }
+    }
+  }
+
+}

--- a/src/it/scala/tech/cryptonomic/conseil/client/EndpointClient.scala
+++ b/src/it/scala/tech/cryptonomic/conseil/client/EndpointClient.scala
@@ -14,10 +14,9 @@ import org.http4s.circe._
 import org.http4s.dsl.io._
 import org.http4s.client.dsl.io._
 import org.http4s.Uri
-import io.circe.{Json, ParsingFailure, parser}
+import io.circe.{Json, parser}
 import cats.effect.IO
 import cats.syntax.apply._
-import cats.syntax.flatMap._
 
 /** Currently can be used to test any conseil instance that loaded blocks levels 1 to 1000
   * against predefined expectations on the responses

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/ApiFilterFromQueryString.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/ApiFilterFromQueryString.scala
@@ -6,7 +6,7 @@ import endpoints.algebra
 import tech.cryptonomic.conseil.tezos.ApiOperations.Filter
 
 /** Trait containing helper functions which are necessary for parsing query parameter strings as Filter  */
-trait ApiFilterFromQueryString { self: algebra.JsonSchemaEntities =>
+trait ApiFilterFromQueryString { self: algebra.JsonEntities =>
   import tech.cryptonomic.conseil.routes.openapi.TupleFlattenHelper._
   import FlattenHigh._
 

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataEndpoints.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataEndpoints.scala
@@ -8,10 +8,9 @@ import tech.cryptonomic.conseil.tezos.Tables.BlocksRow
 
 /** Trait containing endpoints definition */
 trait DataEndpoints
-    extends algebra.Endpoints
+    extends algebra.JsonSchemaEntities
     with DataJsonSchemas
     with ApiFilterFromQueryString
-    with algebra.JsonSchemaEntities
     with Validation {
 
   /** Common path among endpoints */

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataJsonSchemas.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/DataJsonSchemas.scala
@@ -10,7 +10,7 @@ import tech.cryptonomic.conseil.tezos.Tables.{AccountsRow, BlocksRow, OperationG
 trait DataJsonSchemas extends generic.JsonSchemas {
 
   /** API field schema */
-  implicit val fieldSchema: JsonSchema[Field] //=
+  implicit val fieldSchema: JsonSchema[Field]
 
   implicit lazy val formattedFieldSchema: JsonSchema[FormattedField] =
     genericJsonSchema[FormattedField]


### PR DESCRIPTION
Closes #538 

This PR builds a basic tool for testing the results of running Lorre and then Conseil against a fixed range of blocks, to verify no regression is introduced by updates in the code.

The implementation adds a new `it` (integration tests) module (in addition to main and test) where this code can be eventually converted into a full integration-test suite to automate in the CI environment.

The current implementation only tests the current endpoints
- info
- head block data

### Usage
The tests need be run manually in this version.
- You have to setup a running postgres database instance with the _correct schema_ and _no data_ in it
- You have to launch the sbt console with the command: `sbt it:console`
- Then you have to import and run the endpoint checking class with the following commands
```bash
> import tech.cryptonomic.conseil.client.DataEndpointsClientProbe
> DataEndpointsClientProbe.runRegressionSuite(Some("prodnet")).unsafeRunSync
# Don't pass any parameter if you already loaded the data with Lorre on a previous check run
```

This will load the first 10k blocks in Lorre based on "prodnet" data (this step will be skipped if you call `runRegressionSuite()` with no arguments.
When the blocks are loaded a conseil instance will be run, and the test will check the endpoints, taking care to clean up the process after that.
A basic report will be printed to the console with the result of the regression test.

