### PR TITLE
Docker build fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM openjdk:8-stretch
-RUN apt-get update && apt-get install -y apt-transport-https && echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
+RUN apt-get update && apt-get install -y apt-transport-https libpq5 && echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823 && \
     apt-get update && \
     apt-get install -y sbt
-ADD . /src
-WORKDIR /src
 RUN adduser --disabled-password --gecos '' builduser && su builduser
+USER builduser
+COPY --chown=builduser:builduser . /src
+WORKDIR /src
+RUN rm -rf test-postgres-path
 RUN sbt clean assembly -J-Xss32m
 
 FROM openjdk:13-alpine


### PR DESCRIPTION
closes #534

The reasons that build failed are as follows:
* missing `libpq5` package 
* wrong permissions for files
* common cache `test-postgres-path` between docker image and real filesystem