### PR TITLE
Add the ability to configure an API key when launching in docker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Conseil Config:
 
 
 * API_PORT - Conseil API port, default: 80
+* API_KEY - Conseil API key, default: conseil
 
 Or, you can use your own config file, in which case specify the environment variable `CONFIG` with the path to your file
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -13,6 +13,7 @@ XTZPREFIX=${XTZ_Prefix:=}
 XTZPORT=${XTZ_Port:=8732}
 XTZNET=${XTZ_Network:=mainnet}
 APIPORT=${API_PORT:=80}
+APIKEY=${API_KEY:=conseil}
 
 CONFIG=${CONFIG:-none}
 
@@ -34,6 +35,7 @@ if [ $CONFIG = "none" ]; then
     sed -i "s/{{XTZPORT}}/$XTZPORT/g" conseil.conf
     sed -i "s/{{XTZNET}}/$XTZNET/g" conseil.conf
     sed -i "s/{{APIPORT}}/$APIPORT/g" conseil.conf
+    sed -i "s/{{APIKEY}}/$APIKEY/g" conseil.conf
 
 else
     echo "Using config file: $CONFIG"

--- a/docker/template.conf
+++ b/docker/template.conf
@@ -35,7 +35,7 @@ conseil {
   # Security settings
   security.apiKeys {
     # List of authorized API keys needed to query Conseil
-    keys: []
+    keys: ["{{APIKEY}}"]
   }
 }
 


### PR DESCRIPTION
- Add the ability to configure an API key when running the conseil API in docker.
- Update the Readme regarding this feature