### PR TITLE
576 - Improved version information

### DIFF
--- a/publishing.sbt
+++ b/publishing.sbt
@@ -1,6 +1,6 @@
 //add build information as an object in code
 enablePlugins(BuildInfoPlugin)
-buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion, git.gitHeadCommit)
+buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion, git.gitHeadCommit, git.gitCurrentTags)
 buildInfoPackage := "tech.cryptonomic.conseil"
 
 //uses git tags to generate the project version

--- a/src/main/scala/tech/cryptonomic/conseil/routes/AppInfo.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/AppInfo.scala
@@ -9,8 +9,17 @@ import tech.cryptonomic.conseil.routes.openapi.AppInfoEndpoint
 object AppInfo extends AppInfoEndpoint with akkahttp.server.Endpoints with akkahttp.server.JsonSchemaEntities {
 
   /** data type collecting relevant information to expose */
-  case class Info(application: String, version: String)
+  case class Info(application: String, version: String, gitInfo: GitInfo)
+
+  case class GitInfo(commitHash: Option[String], tags: List[String])
 
   /** the endpoints to expose application information through http */
-  val route: Route = appInfoEndpoint.implementedBy(_ => Info(application = BuildInfo.name, version = BuildInfo.version))
+  val route: Route = appInfoEndpoint.implementedBy(
+    _ =>
+      Info(
+        application = BuildInfo.name,
+        version = BuildInfo.version,
+        gitInfo = GitInfo(commitHash = BuildInfo.gitHeadCommit, tags = BuildInfo.gitCurrentTags.toList)
+      )
+  )
 }

--- a/src/main/scala/tech/cryptonomic/conseil/routes/AppInfo.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/AppInfo.scala
@@ -9,7 +9,7 @@ import tech.cryptonomic.conseil.routes.openapi.AppInfoEndpoint
 object AppInfo extends AppInfoEndpoint with akkahttp.server.Endpoints with akkahttp.server.JsonSchemaEntities {
 
   /** data type collecting relevant information to expose */
-  case class Info(application: String, version: String, gitInfo: GitInfo)
+  case class Info(application: String, version: String, git: GitInfo)
 
   case class GitInfo(commitHash: Option[String], tags: List[String])
 
@@ -19,7 +19,7 @@ object AppInfo extends AppInfoEndpoint with akkahttp.server.Endpoints with akkah
       Info(
         application = BuildInfo.name,
         version = BuildInfo.version,
-        gitInfo = GitInfo(commitHash = BuildInfo.gitHeadCommit, tags = BuildInfo.gitCurrentTags.toList)
+        git = GitInfo(commitHash = BuildInfo.gitHeadCommit, tags = BuildInfo.gitCurrentTags.toList)
       )
   )
 }

--- a/src/main/scala/tech/cryptonomic/conseil/routes/openapi/AppInfoJsonSchemas.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/openapi/AppInfoJsonSchemas.scala
@@ -1,7 +1,7 @@
 package tech.cryptonomic.conseil.routes.openapi
 
 import endpoints.generic
-import tech.cryptonomic.conseil.routes.AppInfo.Info
+import tech.cryptonomic.conseil.routes.AppInfo.{GitInfo, Info}
 
 /** Trait containing AppInfo schema */
 trait AppInfoJsonSchemas extends generic.JsonSchemas {
@@ -9,4 +9,8 @@ trait AppInfoJsonSchemas extends generic.JsonSchemas {
   /** AppInfo JSON schema */
   implicit lazy val appInfoSchema: JsonSchema[Info] =
     genericJsonSchema[Info]
+
+  /** GitInfo JSON schema */
+  implicit lazy val gitInfoSchema: JsonSchema[GitInfo] =
+    genericJsonSchema[GitInfo]
 }

--- a/src/test/scala/tech/cryptonomic/conseil/routes/AppInfoRouteTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/routes/AppInfoRouteTest.scala
@@ -24,9 +24,6 @@ class AppInfoRouteTest extends WordSpec with Matchers with ScalatestRouteTest {
           info("application") shouldBe "Conseil"
           info("version").toString should fullyMatch regex """^0\.\d{4}\.\d{4}(-SNAPSHOT)?"""
           info("git").asInstanceOf[Map[String, String]]("commitHash") should fullyMatch regex """^[0-9a-f]+$"""
-          info("git")
-            .asInstanceOf[Map[String, List[String]]]("tags")
-            .head should not be empty
         }
       }
 

--- a/src/test/scala/tech/cryptonomic/conseil/routes/AppInfoRouteTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/routes/AppInfoRouteTest.scala
@@ -20,9 +20,13 @@ class AppInfoRouteTest extends WordSpec with Matchers with ScalatestRouteTest {
         Get("/info") ~> addHeader("apiKey", "hooman") ~> sut ~> check {
           status shouldEqual StatusCodes.OK
           contentType shouldBe ContentTypes.`application/json`
-          val info: Map[String, String] = toMap[String](responseAs[String])
+          val info: Map[String, Any] = toMap[Any](responseAs[String])
           info("application") shouldBe "Conseil"
-          info("version") should fullyMatch regex """^0\.\d{4}\.\d{4}(-SNAPSHOT)?"""
+          info("version").toString should fullyMatch regex """^0\.\d{4}\.\d{4}(-SNAPSHOT)?"""
+          info("git").asInstanceOf[Map[String, String]]("commitHash") should fullyMatch regex """^[0-9a-f]+$"""
+          info("git")
+            .asInstanceOf[Map[String, List[String]]]("tags")
+            .head should not be empty
         }
       }
 


### PR DESCRIPTION
closes #576 

Added git info to `/info` endpoint:
```
{
  "application": "Conseil",
  "version": "0.1941.0012-SNAPSHOT",
  "git": {
    "commitHash": "c1be007dfc84cbd89b1fd6ef81db805eb2c447c8",
    "tags": [
      "2019-october-release-11-SNAPSHOT"
    ]
  }
}
```