### PR TITLE
584 - fixing bugs in metadata configuration for baking/endorsing rights

### DIFF
--- a/src/main/resources/metadata/tezos.alphanet.conf
+++ b/src/main/resources/metadata/tezos.alphanet.conf
@@ -771,7 +771,7 @@
         delegate {
           visible: true
         }
-        slots {
+        priority {
           visible: true
         }
         estimated_time {
@@ -791,7 +791,7 @@
         delegate {
           visible: true
         }
-        priority {
+        slot {
           visible: true
         }
         estimated_time {

--- a/src/main/resources/metadata/tezos.mainnet.conf
+++ b/src/main/resources/metadata/tezos.mainnet.conf
@@ -771,7 +771,7 @@
         delegate {
           visible: true
         }
-        slots {
+        priority {
           visible: true
         }
         estimated_time {
@@ -791,7 +791,7 @@
         delegate {
           visible: true
         }
-        priority {
+        slot {
           visible: true
         }
         estimated_time {


### PR DESCRIPTION
resolves #584 

The problem was that fields slot/priority were placed in the wrong places in configuration. Changed it in this PR.