### PR TITLE
563-1 - Reduce the max number of connections hitting the database

### DIFF
--- a/docker/template.conf
+++ b/docker/template.conf
@@ -28,8 +28,8 @@ conseil {
       password: "{{DBPW}}"
       url: "jdbc:postgresql://{{DBHOST}}:{{DBPORT}}/{{DBDB}}"
     }
-    numThreads: 64
-    maxConnections: 64
+    numThreads: 20
+    maxConnections: 20
   }
 
   # Security settings
@@ -61,8 +61,8 @@ lorre {
       password: "{{DBPW}}"
       url: "jdbc:postgresql://{{DBHOST}}:{{DBPORT}}/{{DBDB}}"
     }
-    numThreads: 64
-    maxConnections: 64
+    numThreads: 20
+    maxConnections: 20
   }
 
   batchedFetches {


### PR DESCRIPTION
Support to #563

The number of connections configured for a docker-run instance of lorre/conseil was oversized and would generally trip a standard postgres installation (sized to max 100 connections AFAIK).

This PR reduces the default template to a more reasonable size, which can anyway be overridden with a custom configuration file.