### PR TITLE
587 - Bugfix provide accounts compatibility layer for protocol 005 changes

### DIFF
--- a/doc/conseil.sql
+++ b/doc/conseil.sql
@@ -37,6 +37,7 @@ CREATE TABLE public.accounts (
     balance numeric NOT NULL,
     block_level numeric DEFAULT '-1'::integer NOT NULL,
     manager character varying, -- retro-compat from protocol 5+
+    spendable boolean, -- retro-compat from protocol 5+
     delegate_setable boolean, -- retro-compat from protocol 5+
     delegate_value char varying -- retro-compat from protocol 5+
 );

--- a/doc/conseil.sql
+++ b/doc/conseil.sql
@@ -35,7 +35,10 @@ CREATE TABLE public.accounts (
     script character varying,
     storage character varying,
     balance numeric NOT NULL,
-    block_level numeric DEFAULT '-1'::integer NOT NULL
+    block_level numeric DEFAULT '-1'::integer NOT NULL,
+    manager character varying, -- retro-compat from protocol 5+
+    delegate_setable boolean, -- retro-compat from protocol 5+
+    delegate_value char varying -- retro-compat from protocol 5+
 );
 
 

--- a/src/it/scala/tech/cryptonomic/conseil/client/EndpointClient.scala
+++ b/src/it/scala/tech/cryptonomic/conseil/client/EndpointClient.scala
@@ -1,7 +1,6 @@
 package tech.cryptonomic.conseil.client
 
 import java.util.concurrent.Executors
-import scala.language.postfixOps
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.sys.process._

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
@@ -61,6 +61,7 @@ object DatabaseConversions {
       val toDelegateValue: Option[AccountDelegate] => Option[String] = delegate =>
         PartialFunction.condOpt(delegate) {
           case Some(Left(Protocol4Delegate(_, Some(pkh)))) => pkh.value
+          case Some(Right(pkh)) => pkh.value
         }
 
       override def convert(from: BlockTagged[Map[AccountId, Account]]) = {

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
@@ -77,6 +77,7 @@ object DatabaseConversions {
               balance = balance,
               blockLevel = level,
               manager = manager.map(_.value),
+              spendable = spendable,
               delegateSetable = toDelegateSetable(delegate),
               delegateValue = toDelegateValue(delegate)
             )

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
@@ -48,19 +48,37 @@ object DatabaseConversions {
 
   implicit val blockAccountsToAccountRows =
     new Conversion[List, BlockTagged[Map[AccountId, Account]], Tables.AccountsRow] {
+      val toDelegateKeyHash: Option[AccountDelegate] => Option[String] = delegate =>
+        PartialFunction.condOpt(delegate) {
+          case Some(Right(pkh)) => pkh.value
+        }
+
+      val toDelegateSetable: Option[AccountDelegate] => Option[Boolean] = delegate =>
+        PartialFunction.condOpt(delegate) {
+          case Some(Left(Protocol4Delegate(setable, _))) => setable
+        }
+
+      val toDelegateValue: Option[AccountDelegate] => Option[String] = delegate =>
+        PartialFunction.condOpt(delegate) {
+          case Some(Left(Protocol4Delegate(_, Some(pkh)))) => pkh.value
+        }
+
       override def convert(from: BlockTagged[Map[AccountId, Account]]) = {
         val BlockTagged(hash, level, accounts) = from
         accounts.map {
-          case (id, Account(balance, delegate, script, counter)) =>
+          case (id, Account(balance, delegate, script, counter, manager, spendable)) =>
             Tables.AccountsRow(
               accountId = id.id,
               blockId = hash.value,
-              delegate = delegate.map(_.value),
+              delegate = toDelegateKeyHash(delegate),
               counter = counter,
               script = script.map(_.code.expression),
               storage = script.map(_.storage.expression),
               balance = balance,
-              blockLevel = level
+              blockLevel = level,
+              manager = manager.map(_.value),
+              delegateSetable = toDelegateSetable(delegate),
+              delegateValue = toDelegateValue(delegate)
             )
         }.toList
       }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/JsonDecoders.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/JsonDecoders.scala
@@ -15,6 +15,7 @@ object JsonDecoders {
     import io.circe.Decoder
     import io.circe.generic.extras.Configuration
     import io.circe.generic.extras.semiauto._
+    import tech.cryptonomic.conseil.util.JsonUtil.CirceCommonDecoders
 
     type JsonDecoded[T] = Either[Error, T]
 
@@ -244,8 +245,10 @@ object JsonDecoders {
     /* Collects definitions to decode accounts and their components */
     object Accounts {
       import Scripts._
+      import CirceCommonDecoders._
       implicit private val conf = Derivation.tezosDerivationConfig
 
+      implicit val delegateProtocol4Decoder: Decoder[Protocol4Delegate] = deriveDecoder
       implicit val accountDecoder: Decoder[Account] = deriveDecoder
     }
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
@@ -43,6 +43,7 @@ trait Tables {
     *  @param balance Database column balance SqlType(numeric)
     *  @param blockLevel Database column block_level SqlType(numeric), Default(-1)
     *  @param manager Database column manager SqlType(varchar), Default(None)
+    *  @param spendable Database column spendable SqlType(bool), Default(None)
     *  @param delegateSetable Database column delegate_setable SqlType(bool), Default(None)
     *  @param delegateValue Database column delegate_value SqlType(varchar), Default(None) */
   case class AccountsRow(
@@ -55,6 +56,7 @@ trait Tables {
       balance: scala.math.BigDecimal,
       blockLevel: scala.math.BigDecimal = scala.math.BigDecimal("-1"),
       manager: Option[String] = None,
+      spendable: Option[Boolean] = None,
       delegateSetable: Option[Boolean] = None,
       delegateValue: Option[String] = None
   )
@@ -80,6 +82,7 @@ trait Tables {
         <<[scala.math.BigDecimal],
         <<?[String],
         <<?[Boolean],
+        <<?[Boolean],
         <<?[String]
       )
     )
@@ -98,6 +101,7 @@ trait Tables {
         balance,
         blockLevel,
         manager,
+        spendable,
         delegateSetable,
         delegateValue
       ) <> (AccountsRow.tupled, AccountsRow.unapply)
@@ -115,12 +119,14 @@ trait Tables {
           Rep.Some(balance),
           Rep.Some(blockLevel),
           manager,
+          spendable,
           delegateSetable,
           delegateValue
         )
       ).shaped.<>(
         { r =>
-          import r._; _1.map(_ => AccountsRow.tupled((_1.get, _2.get, _3, _4, _5, _6, _7.get, _8.get, _9, _10, _11)))
+          import r._;
+          _1.map(_ => AccountsRow.tupled((_1.get, _2.get, _3, _4, _5, _6, _7.get, _8.get, _9, _10, _11, _12)))
         },
         (_: Any) => throw new Exception("Inserting into ? projection not supported.")
       )
@@ -152,6 +158,9 @@ trait Tables {
 
     /** Database column manager SqlType(varchar), Default(None) */
     val manager: Rep[Option[String]] = column[Option[String]]("manager", O.Default(None))
+
+    /** Database column spendable SqlType(bool), Default(None) */
+    val spendable: Rep[Option[Boolean]] = column[Option[Boolean]]("spendable", O.Default(None))
 
     /** Database column delegate_setable SqlType(bool), Default(None) */
     val delegateSetable: Rep[Option[Boolean]] = column[Option[Boolean]]("delegate_setable", O.Default(None))

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
@@ -16,7 +16,20 @@ trait Tables {
   import slick.jdbc.{GetResult => GR}
 
   /** DDL for all tables. Call .create to execute. */
-  lazy val schema: profile.SchemaDescription = Array(Accounts.schema, AccountsCheckpoint.schema, BakingRights.schema, BalanceUpdates.schema, Blocks.schema, Delegates.schema, DelegatesCheckpoint.schema, EndorsingRights.schema, Fees.schema, OperationGroups.schema, Operations.schema, Rolls.schema).reduceLeft(_ ++ _)
+  lazy val schema: profile.SchemaDescription = Array(
+    Accounts.schema,
+    AccountsCheckpoint.schema,
+    BakingRights.schema,
+    BalanceUpdates.schema,
+    Blocks.schema,
+    Delegates.schema,
+    DelegatesCheckpoint.schema,
+    EndorsingRights.schema,
+    Fees.schema,
+    OperationGroups.schema,
+    Operations.schema,
+    Rolls.schema
+  ).reduceLeft(_ ++ _)
   @deprecated("Use .schema instead of .ddl", "3.0")
   def ddl = schema
 
@@ -28,42 +41,135 @@ trait Tables {
     *  @param script Database column script SqlType(varchar), Default(None)
     *  @param storage Database column storage SqlType(varchar), Default(None)
     *  @param balance Database column balance SqlType(numeric)
-    *  @param blockLevel Database column block_level SqlType(numeric), Default(-1) */
-  case class AccountsRow(accountId: String, blockId: String, delegate: Option[String] = None, counter: Option[Int] = None, script: Option[String] = None, storage: Option[String] = None, balance: scala.math.BigDecimal, blockLevel: scala.math.BigDecimal = scala.math.BigDecimal("-1"))
+    *  @param blockLevel Database column block_level SqlType(numeric), Default(-1)
+    *  @param manager Database column manager SqlType(varchar), Default(None)
+    *  @param delegateSetable Database column delegate_setable SqlType(bool), Default(None)
+    *  @param delegateValue Database column delegate_value SqlType(varchar), Default(None) */
+  case class AccountsRow(
+      accountId: String,
+      blockId: String,
+      delegate: Option[String] = None,
+      counter: Option[Int] = None,
+      script: Option[String] = None,
+      storage: Option[String] = None,
+      balance: scala.math.BigDecimal,
+      blockLevel: scala.math.BigDecimal = scala.math.BigDecimal("-1"),
+      manager: Option[String] = None,
+      delegateSetable: Option[Boolean] = None,
+      delegateValue: Option[String] = None
+  )
+
   /** GetResult implicit for fetching AccountsRow objects using plain SQL queries */
-  implicit def GetResultAccountsRow(implicit e0: GR[String], e1: GR[Option[String]], e2: GR[Option[Int]], e3: GR[scala.math.BigDecimal]): GR[AccountsRow] = GR{
-    prs => import prs._
-      AccountsRow.tupled((<<[String], <<[String], <<?[String], <<?[Int], <<?[String], <<?[String], <<[scala.math.BigDecimal], <<[scala.math.BigDecimal]))
+  implicit def GetResultAccountsRow(
+      implicit e0: GR[String],
+      e1: GR[Option[String]],
+      e2: GR[Option[Int]],
+      e3: GR[scala.math.BigDecimal],
+      e4: GR[Option[Boolean]]
+  ): GR[AccountsRow] = GR { prs =>
+    import prs._
+    AccountsRow.tupled(
+      (
+        <<[String],
+        <<[String],
+        <<?[String],
+        <<?[Int],
+        <<?[String],
+        <<?[String],
+        <<[scala.math.BigDecimal],
+        <<[scala.math.BigDecimal],
+        <<?[String],
+        <<?[Boolean],
+        <<?[String]
+      )
+    )
   }
+
   /** Table description of table accounts. Objects of this class serve as prototypes for rows in queries. */
   class Accounts(_tableTag: Tag) extends profile.api.Table[AccountsRow](_tableTag, "accounts") {
-    def * = (accountId, blockId, delegate, counter, script, storage, balance, blockLevel) <> (AccountsRow.tupled, AccountsRow.unapply)
+    def * =
+      (
+        accountId,
+        blockId,
+        delegate,
+        counter,
+        script,
+        storage,
+        balance,
+        blockLevel,
+        manager,
+        delegateSetable,
+        delegateValue
+      ) <> (AccountsRow.tupled, AccountsRow.unapply)
+
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? = ((Rep.Some(accountId), Rep.Some(blockId), delegate, counter, script, storage, Rep.Some(balance), Rep.Some(blockLevel))).shaped.<>({r=>import r._; _1.map(_=> AccountsRow.tupled((_1.get, _2.get, _3, _4, _5, _6, _7.get, _8.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+    def ? =
+      (
+        (
+          Rep.Some(accountId),
+          Rep.Some(blockId),
+          delegate,
+          counter,
+          script,
+          storage,
+          Rep.Some(balance),
+          Rep.Some(blockLevel),
+          manager,
+          delegateSetable,
+          delegateValue
+        )
+      ).shaped.<>(
+        { r =>
+          import r._; _1.map(_ => AccountsRow.tupled((_1.get, _2.get, _3, _4, _5, _6, _7.get, _8.get, _9, _10, _11)))
+        },
+        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
+      )
 
     /** Database column account_id SqlType(varchar), PrimaryKey */
     val accountId: Rep[String] = column[String]("account_id", O.PrimaryKey)
+
     /** Database column block_id SqlType(varchar) */
     val blockId: Rep[String] = column[String]("block_id")
+
     /** Database column delegate SqlType(varchar), Default(None) */
     val delegate: Rep[Option[String]] = column[Option[String]]("delegate", O.Default(None))
+
     /** Database column counter SqlType(int4), Default(None) */
     val counter: Rep[Option[Int]] = column[Option[Int]]("counter", O.Default(None))
+
     /** Database column script SqlType(varchar), Default(None) */
     val script: Rep[Option[String]] = column[Option[String]]("script", O.Default(None))
+
     /** Database column storage SqlType(varchar), Default(None) */
     val storage: Rep[Option[String]] = column[Option[String]]("storage", O.Default(None))
+
     /** Database column balance SqlType(numeric) */
     val balance: Rep[scala.math.BigDecimal] = column[scala.math.BigDecimal]("balance")
+
     /** Database column block_level SqlType(numeric), Default(-1) */
-    val blockLevel: Rep[scala.math.BigDecimal] = column[scala.math.BigDecimal]("block_level", O.Default(scala.math.BigDecimal("-1")))
+    val blockLevel: Rep[scala.math.BigDecimal] =
+      column[scala.math.BigDecimal]("block_level", O.Default(scala.math.BigDecimal("-1")))
+
+    /** Database column manager SqlType(varchar), Default(None) */
+    val manager: Rep[Option[String]] = column[Option[String]]("manager", O.Default(None))
+
+    /** Database column delegate_setable SqlType(bool), Default(None) */
+    val delegateSetable: Rep[Option[Boolean]] = column[Option[Boolean]]("delegate_setable", O.Default(None))
+
+    /** Database column delegate_value SqlType(varchar), Default(None) */
+    val delegateValue: Rep[Option[String]] = column[Option[String]]("delegate_value", O.Default(None))
 
     /** Foreign key referencing Blocks (database name accounts_block_id_fkey) */
-    lazy val blocksFk = foreignKey("accounts_block_id_fkey", blockId, Blocks)(r => r.hash, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
+    lazy val blocksFk = foreignKey("accounts_block_id_fkey", blockId, Blocks)(
+      r => r.hash,
+      onUpdate = ForeignKeyAction.NoAction,
+      onDelete = ForeignKeyAction.NoAction
+    )
 
     /** Index over (blockLevel) (database name ix_accounts_block_level) */
     val index1 = index("ix_accounts_block_level", blockLevel)
   }
+
   /** Collection-like TableQuery object for table Accounts */
   lazy val Accounts = new TableQuery(tag => new Accounts(tag))
 
@@ -72,32 +178,51 @@ trait Tables {
     *  @param blockId Database column block_id SqlType(varchar)
     *  @param blockLevel Database column block_level SqlType(int4), Default(-1) */
   case class AccountsCheckpointRow(accountId: String, blockId: String, blockLevel: Int = -1)
+
   /** GetResult implicit for fetching AccountsCheckpointRow objects using plain SQL queries */
-  implicit def GetResultAccountsCheckpointRow(implicit e0: GR[String], e1: GR[Int]): GR[AccountsCheckpointRow] = GR{
-    prs => import prs._
+  implicit def GetResultAccountsCheckpointRow(implicit e0: GR[String], e1: GR[Int]): GR[AccountsCheckpointRow] = GR {
+    prs =>
+      import prs._
       AccountsCheckpointRow.tupled((<<[String], <<[String], <<[Int]))
   }
+
   /** Table description of table accounts_checkpoint. Objects of this class serve as prototypes for rows in queries. */
-  class AccountsCheckpoint(_tableTag: Tag) extends profile.api.Table[AccountsCheckpointRow](_tableTag, "accounts_checkpoint") {
+  class AccountsCheckpoint(_tableTag: Tag)
+      extends profile.api.Table[AccountsCheckpointRow](_tableTag, "accounts_checkpoint") {
     def * = (accountId, blockId, blockLevel) <> (AccountsCheckpointRow.tupled, AccountsCheckpointRow.unapply)
+
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? = ((Rep.Some(accountId), Rep.Some(blockId), Rep.Some(blockLevel))).shaped.<>({r=>import r._; _1.map(_=> AccountsCheckpointRow.tupled((_1.get, _2.get, _3.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+    def ? =
+      ((Rep.Some(accountId), Rep.Some(blockId), Rep.Some(blockLevel))).shaped.<>(
+        { r =>
+          import r._; _1.map(_ => AccountsCheckpointRow.tupled((_1.get, _2.get, _3.get)))
+        },
+        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
+      )
 
     /** Database column account_id SqlType(varchar) */
     val accountId: Rep[String] = column[String]("account_id")
+
     /** Database column block_id SqlType(varchar) */
     val blockId: Rep[String] = column[String]("block_id")
+
     /** Database column block_level SqlType(int4), Default(-1) */
     val blockLevel: Rep[Int] = column[Int]("block_level", O.Default(-1))
 
     /** Foreign key referencing Blocks (database name checkpoint_block_id_fkey) */
-    lazy val blocksFk = foreignKey("checkpoint_block_id_fkey", blockId, Blocks)(r => r.hash, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
+    lazy val blocksFk = foreignKey("checkpoint_block_id_fkey", blockId, Blocks)(
+      r => r.hash,
+      onUpdate = ForeignKeyAction.NoAction,
+      onDelete = ForeignKeyAction.NoAction
+    )
 
     /** Index over (accountId) (database name ix_accounts_checkpoint_account_id) */
     val index1 = index("ix_accounts_checkpoint_account_id", accountId)
+
     /** Index over (blockLevel) (database name ix_accounts_checkpoint_block_level) */
     val index2 = index("ix_accounts_checkpoint_block_level", blockLevel)
   }
+
   /** Collection-like TableQuery object for table AccountsCheckpoint */
   lazy val AccountsCheckpoint = new TableQuery(tag => new AccountsCheckpoint(tag))
 
@@ -107,26 +232,50 @@ trait Tables {
     *  @param delegate Database column delegate SqlType(varchar)
     *  @param priority Database column priority SqlType(int4)
     *  @param estimatedTime Database column estimated_time SqlType(timestamp) */
-  case class BakingRightsRow(blockHash: String, level: Int, delegate: String, priority: Int, estimatedTime: java.sql.Timestamp)
+  case class BakingRightsRow(
+      blockHash: String,
+      level: Int,
+      delegate: String,
+      priority: Int,
+      estimatedTime: java.sql.Timestamp
+  )
+
   /** GetResult implicit for fetching BakingRightsRow objects using plain SQL queries */
-  implicit def GetResultBakingRightsRow(implicit e0: GR[String], e1: GR[Int], e2: GR[java.sql.Timestamp]): GR[BakingRightsRow] = GR{
-    prs => import prs._
-      BakingRightsRow.tupled((<<[String], <<[Int], <<[String], <<[Int], <<[java.sql.Timestamp]))
+  implicit def GetResultBakingRightsRow(
+      implicit e0: GR[String],
+      e1: GR[Int],
+      e2: GR[java.sql.Timestamp]
+  ): GR[BakingRightsRow] = GR { prs =>
+    import prs._
+    BakingRightsRow.tupled((<<[String], <<[Int], <<[String], <<[Int], <<[java.sql.Timestamp]))
   }
+
   /** Table description of table baking_rights. Objects of this class serve as prototypes for rows in queries. */
   class BakingRights(_tableTag: Tag) extends profile.api.Table[BakingRightsRow](_tableTag, "baking_rights") {
     def * = (blockHash, level, delegate, priority, estimatedTime) <> (BakingRightsRow.tupled, BakingRightsRow.unapply)
+
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? = ((Rep.Some(blockHash), Rep.Some(level), Rep.Some(delegate), Rep.Some(priority), Rep.Some(estimatedTime))).shaped.<>({r=>import r._; _1.map(_=> BakingRightsRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+    def ? =
+      ((Rep.Some(blockHash), Rep.Some(level), Rep.Some(delegate), Rep.Some(priority), Rep.Some(estimatedTime))).shaped
+        .<>(
+          { r =>
+            import r._; _1.map(_ => BakingRightsRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get)))
+          },
+          (_: Any) => throw new Exception("Inserting into ? projection not supported.")
+        )
 
     /** Database column block_hash SqlType(varchar) */
     val blockHash: Rep[String] = column[String]("block_hash")
+
     /** Database column level SqlType(int4) */
     val level: Rep[Int] = column[Int]("level")
+
     /** Database column delegate SqlType(varchar) */
     val delegate: Rep[String] = column[String]("delegate")
+
     /** Database column priority SqlType(int4) */
     val priority: Rep[Int] = column[Int]("priority")
+
     /** Database column estimated_time SqlType(timestamp) */
     val estimatedTime: Rep[java.sql.Timestamp] = column[java.sql.Timestamp]("estimated_time")
 
@@ -134,11 +283,16 @@ trait Tables {
     val pk = primaryKey("baking_rights_pkey", (level, delegate))
 
     /** Foreign key referencing Blocks (database name fk_block_hash) */
-    lazy val blocksFk = foreignKey("fk_block_hash", blockHash, Blocks)(r => r.hash, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
+    lazy val blocksFk = foreignKey("fk_block_hash", blockHash, Blocks)(
+      r => r.hash,
+      onUpdate = ForeignKeyAction.NoAction,
+      onDelete = ForeignKeyAction.NoAction
+    )
 
     /** Index over (level) (database name baking_rights_level_idx) */
     val index1 = index("baking_rights_level_idx", level)
   }
+
   /** Collection-like TableQuery object for table BakingRights */
   lazy val BakingRights = new TableQuery(tag => new BakingRights(tag))
 
@@ -154,41 +308,110 @@ trait Tables {
     *  @param delegate Database column delegate SqlType(varchar), Default(None)
     *  @param category Database column category SqlType(varchar), Default(None)
     *  @param operationGroupHash Database column operation_group_hash SqlType(varchar), Default(None) */
-  case class BalanceUpdatesRow(id: Int, source: String, sourceId: Option[Int] = None, sourceHash: Option[String] = None, kind: String, contract: Option[String] = None, change: scala.math.BigDecimal, level: Option[scala.math.BigDecimal] = None, delegate: Option[String] = None, category: Option[String] = None, operationGroupHash: Option[String] = None)
+  case class BalanceUpdatesRow(
+      id: Int,
+      source: String,
+      sourceId: Option[Int] = None,
+      sourceHash: Option[String] = None,
+      kind: String,
+      contract: Option[String] = None,
+      change: scala.math.BigDecimal,
+      level: Option[scala.math.BigDecimal] = None,
+      delegate: Option[String] = None,
+      category: Option[String] = None,
+      operationGroupHash: Option[String] = None
+  )
+
   /** GetResult implicit for fetching BalanceUpdatesRow objects using plain SQL queries */
-  implicit def GetResultBalanceUpdatesRow(implicit e0: GR[Int], e1: GR[String], e2: GR[Option[Int]], e3: GR[Option[String]], e4: GR[scala.math.BigDecimal], e5: GR[Option[scala.math.BigDecimal]]): GR[BalanceUpdatesRow] = GR{
-    prs => import prs._
-      BalanceUpdatesRow.tupled((<<[Int], <<[String], <<?[Int], <<?[String], <<[String], <<?[String], <<[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<?[String], <<?[String], <<?[String]))
+  implicit def GetResultBalanceUpdatesRow(
+      implicit e0: GR[Int],
+      e1: GR[String],
+      e2: GR[Option[Int]],
+      e3: GR[Option[String]],
+      e4: GR[scala.math.BigDecimal],
+      e5: GR[Option[scala.math.BigDecimal]]
+  ): GR[BalanceUpdatesRow] = GR { prs =>
+    import prs._
+    BalanceUpdatesRow.tupled(
+      (
+        <<[Int],
+        <<[String],
+        <<?[Int],
+        <<?[String],
+        <<[String],
+        <<?[String],
+        <<[scala.math.BigDecimal],
+        <<?[scala.math.BigDecimal],
+        <<?[String],
+        <<?[String],
+        <<?[String]
+      )
+    )
   }
+
   /** Table description of table balance_updates. Objects of this class serve as prototypes for rows in queries. */
   class BalanceUpdates(_tableTag: Tag) extends profile.api.Table[BalanceUpdatesRow](_tableTag, "balance_updates") {
-    def * = (id, source, sourceId, sourceHash, kind, contract, change, level, delegate, category, operationGroupHash) <> (BalanceUpdatesRow.tupled, BalanceUpdatesRow.unapply)
+    def * =
+      (id, source, sourceId, sourceHash, kind, contract, change, level, delegate, category, operationGroupHash) <> (BalanceUpdatesRow.tupled, BalanceUpdatesRow.unapply)
+
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? = ((Rep.Some(id), Rep.Some(source), sourceId, sourceHash, Rep.Some(kind), contract, Rep.Some(change), level, delegate, category, operationGroupHash)).shaped.<>({r=>import r._; _1.map(_=> BalanceUpdatesRow.tupled((_1.get, _2.get, _3, _4, _5.get, _6, _7.get, _8, _9, _10, _11)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+    def ? =
+      (
+        (
+          Rep.Some(id),
+          Rep.Some(source),
+          sourceId,
+          sourceHash,
+          Rep.Some(kind),
+          contract,
+          Rep.Some(change),
+          level,
+          delegate,
+          category,
+          operationGroupHash
+        )
+      ).shaped.<>(
+        { r =>
+          import r._;
+          _1.map(_ => BalanceUpdatesRow.tupled((_1.get, _2.get, _3, _4, _5.get, _6, _7.get, _8, _9, _10, _11)))
+        },
+        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
+      )
 
     /** Database column id SqlType(serial), AutoInc, PrimaryKey */
     val id: Rep[Int] = column[Int]("id", O.AutoInc, O.PrimaryKey)
+
     /** Database column source SqlType(varchar) */
     val source: Rep[String] = column[String]("source")
+
     /** Database column source_id SqlType(int4), Default(None) */
     val sourceId: Rep[Option[Int]] = column[Option[Int]]("source_id", O.Default(None))
+
     /** Database column source_hash SqlType(varchar), Default(None) */
     val sourceHash: Rep[Option[String]] = column[Option[String]]("source_hash", O.Default(None))
+
     /** Database column kind SqlType(varchar) */
     val kind: Rep[String] = column[String]("kind")
+
     /** Database column contract SqlType(varchar), Default(None) */
     val contract: Rep[Option[String]] = column[Option[String]]("contract", O.Default(None))
+
     /** Database column change SqlType(numeric) */
     val change: Rep[scala.math.BigDecimal] = column[scala.math.BigDecimal]("change")
+
     /** Database column level SqlType(numeric), Default(None) */
     val level: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("level", O.Default(None))
+
     /** Database column delegate SqlType(varchar), Default(None) */
     val delegate: Rep[Option[String]] = column[Option[String]]("delegate", O.Default(None))
+
     /** Database column category SqlType(varchar), Default(None) */
     val category: Rep[Option[String]] = column[Option[String]]("category", O.Default(None))
+
     /** Database column operation_group_hash SqlType(varchar), Default(None) */
     val operationGroupHash: Rep[Option[String]] = column[Option[String]]("operation_group_hash", O.Default(None))
   }
+
   /** Collection-like TableQuery object for table BalanceUpdates */
   lazy val BalanceUpdates = new TableQuery(tag => new BalanceUpdates(tag))
 
@@ -219,76 +442,205 @@ trait Tables {
     *  @param metaVotingPeriodPosition Database column meta_voting_period_position SqlType(int4), Default(None)
     *  @param expectedCommitment Database column expected_commitment SqlType(bool), Default(None)
     *  @param priority Database column priority SqlType(int4), Default(None) */
-  case class BlocksRow(level: Int, proto: Int, predecessor: String, timestamp: java.sql.Timestamp, validationPass: Int, fitness: String, context: Option[String] = None, signature: Option[String] = None, protocol: String, chainId: Option[String] = None, hash: String, operationsHash: Option[String] = None, periodKind: Option[String] = None, currentExpectedQuorum: Option[Int] = None, activeProposal: Option[String] = None, baker: Option[String] = None, nonceHash: Option[String] = None, consumedGas: Option[scala.math.BigDecimal] = None, metaLevel: Option[Int] = None, metaLevelPosition: Option[Int] = None, metaCycle: Option[Int] = None, metaCyclePosition: Option[Int] = None, metaVotingPeriod: Option[Int] = None, metaVotingPeriodPosition: Option[Int] = None, expectedCommitment: Option[Boolean] = None, priority: Option[Int] = None)
+  case class BlocksRow(
+      level: Int,
+      proto: Int,
+      predecessor: String,
+      timestamp: java.sql.Timestamp,
+      validationPass: Int,
+      fitness: String,
+      context: Option[String] = None,
+      signature: Option[String] = None,
+      protocol: String,
+      chainId: Option[String] = None,
+      hash: String,
+      operationsHash: Option[String] = None,
+      periodKind: Option[String] = None,
+      currentExpectedQuorum: Option[Int] = None,
+      activeProposal: Option[String] = None,
+      baker: Option[String] = None,
+      nonceHash: Option[String] = None,
+      consumedGas: Option[scala.math.BigDecimal] = None,
+      metaLevel: Option[Int] = None,
+      metaLevelPosition: Option[Int] = None,
+      metaCycle: Option[Int] = None,
+      metaCyclePosition: Option[Int] = None,
+      metaVotingPeriod: Option[Int] = None,
+      metaVotingPeriodPosition: Option[Int] = None,
+      expectedCommitment: Option[Boolean] = None,
+      priority: Option[Int] = None
+  )
+
   /** GetResult implicit for fetching BlocksRow objects using plain SQL queries */
-  implicit def GetResultBlocksRow(implicit e0: GR[Int], e1: GR[String], e2: GR[java.sql.Timestamp], e3: GR[Option[String]], e4: GR[Option[Int]], e5: GR[Option[scala.math.BigDecimal]], e6: GR[Option[Boolean]]): GR[BlocksRow] = GR{
-    prs => import prs._
-      BlocksRow(<<[Int], <<[Int], <<[String], <<[java.sql.Timestamp], <<[Int], <<[String], <<?[String], <<?[String], <<[String], <<?[String], <<[String], <<?[String], <<?[String], <<?[Int], <<?[String], <<?[String], <<?[String], <<?[scala.math.BigDecimal], <<?[Int], <<?[Int], <<?[Int], <<?[Int], <<?[Int], <<?[Int], <<?[Boolean], <<?[Int])
+  implicit def GetResultBlocksRow(
+      implicit e0: GR[Int],
+      e1: GR[String],
+      e2: GR[java.sql.Timestamp],
+      e3: GR[Option[String]],
+      e4: GR[Option[Int]],
+      e5: GR[Option[scala.math.BigDecimal]],
+      e6: GR[Option[Boolean]]
+  ): GR[BlocksRow] = GR { prs =>
+    import prs._
+    BlocksRow(
+      <<[Int],
+      <<[Int],
+      <<[String],
+      <<[java.sql.Timestamp],
+      <<[Int],
+      <<[String],
+      <<?[String],
+      <<?[String],
+      <<[String],
+      <<?[String],
+      <<[String],
+      <<?[String],
+      <<?[String],
+      <<?[Int],
+      <<?[String],
+      <<?[String],
+      <<?[String],
+      <<?[scala.math.BigDecimal],
+      <<?[Int],
+      <<?[Int],
+      <<?[Int],
+      <<?[Int],
+      <<?[Int],
+      <<?[Int],
+      <<?[Boolean],
+      <<?[Int]
+    )
   }
+
   /** Table description of table blocks. Objects of this class serve as prototypes for rows in queries. */
   class Blocks(_tableTag: Tag) extends profile.api.Table[BlocksRow](_tableTag, "blocks") {
-    def * = (level :: proto :: predecessor :: timestamp :: validationPass :: fitness :: context :: signature :: protocol :: chainId :: hash :: operationsHash :: periodKind :: currentExpectedQuorum :: activeProposal :: baker :: nonceHash :: consumedGas :: metaLevel :: metaLevelPosition :: metaCycle :: metaCyclePosition :: metaVotingPeriod :: metaVotingPeriodPosition :: expectedCommitment :: priority :: HNil).mapTo[BlocksRow]
+    def * =
+      (level :: proto :: predecessor :: timestamp :: validationPass :: fitness :: context :: signature :: protocol :: chainId :: hash :: operationsHash :: periodKind :: currentExpectedQuorum :: activeProposal :: baker :: nonceHash :: consumedGas :: metaLevel :: metaLevelPosition :: metaCycle :: metaCyclePosition :: metaVotingPeriod :: metaVotingPeriodPosition :: expectedCommitment :: priority :: HNil)
+        .mapTo[BlocksRow]
+
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? = (Rep.Some(level) :: Rep.Some(proto) :: Rep.Some(predecessor) :: Rep.Some(timestamp) :: Rep.Some(validationPass) :: Rep.Some(fitness) :: context :: signature :: Rep.Some(protocol) :: chainId :: Rep.Some(hash) :: operationsHash :: periodKind :: currentExpectedQuorum :: activeProposal :: baker :: nonceHash :: consumedGas :: metaLevel :: metaLevelPosition :: metaCycle :: metaCyclePosition :: metaVotingPeriod :: metaVotingPeriodPosition :: expectedCommitment :: priority :: HNil).shaped.<>(r => BlocksRow(r(0).asInstanceOf[Option[Int]].get, r(1).asInstanceOf[Option[Int]].get, r(2).asInstanceOf[Option[String]].get, r(3).asInstanceOf[Option[java.sql.Timestamp]].get, r(4).asInstanceOf[Option[Int]].get, r(5).asInstanceOf[Option[String]].get, r(6).asInstanceOf[Option[String]], r(7).asInstanceOf[Option[String]], r(8).asInstanceOf[Option[String]].get, r(9).asInstanceOf[Option[String]], r(10).asInstanceOf[Option[String]].get, r(11).asInstanceOf[Option[String]], r(12).asInstanceOf[Option[String]], r(13).asInstanceOf[Option[Int]], r(14).asInstanceOf[Option[String]], r(15).asInstanceOf[Option[String]], r(16).asInstanceOf[Option[String]], r(17).asInstanceOf[Option[scala.math.BigDecimal]], r(18).asInstanceOf[Option[Int]], r(19).asInstanceOf[Option[Int]], r(20).asInstanceOf[Option[Int]], r(21).asInstanceOf[Option[Int]], r(22).asInstanceOf[Option[Int]], r(23).asInstanceOf[Option[Int]], r(24).asInstanceOf[Option[Boolean]], r(25).asInstanceOf[Option[Int]]), (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+    def ? =
+      (Rep.Some(level) :: Rep.Some(proto) :: Rep.Some(predecessor) :: Rep.Some(timestamp) :: Rep.Some(validationPass) :: Rep
+            .Some(fitness) :: context :: signature :: Rep.Some(protocol) :: chainId :: Rep.Some(hash) :: operationsHash :: periodKind :: currentExpectedQuorum :: activeProposal :: baker :: nonceHash :: consumedGas :: metaLevel :: metaLevelPosition :: metaCycle :: metaCyclePosition :: metaVotingPeriod :: metaVotingPeriodPosition :: expectedCommitment :: priority :: HNil).shaped
+        .<>(
+          r =>
+            BlocksRow(
+              r(0).asInstanceOf[Option[Int]].get,
+              r(1).asInstanceOf[Option[Int]].get,
+              r(2).asInstanceOf[Option[String]].get,
+              r(3).asInstanceOf[Option[java.sql.Timestamp]].get,
+              r(4).asInstanceOf[Option[Int]].get,
+              r(5).asInstanceOf[Option[String]].get,
+              r(6).asInstanceOf[Option[String]],
+              r(7).asInstanceOf[Option[String]],
+              r(8).asInstanceOf[Option[String]].get,
+              r(9).asInstanceOf[Option[String]],
+              r(10).asInstanceOf[Option[String]].get,
+              r(11).asInstanceOf[Option[String]],
+              r(12).asInstanceOf[Option[String]],
+              r(13).asInstanceOf[Option[Int]],
+              r(14).asInstanceOf[Option[String]],
+              r(15).asInstanceOf[Option[String]],
+              r(16).asInstanceOf[Option[String]],
+              r(17).asInstanceOf[Option[scala.math.BigDecimal]],
+              r(18).asInstanceOf[Option[Int]],
+              r(19).asInstanceOf[Option[Int]],
+              r(20).asInstanceOf[Option[Int]],
+              r(21).asInstanceOf[Option[Int]],
+              r(22).asInstanceOf[Option[Int]],
+              r(23).asInstanceOf[Option[Int]],
+              r(24).asInstanceOf[Option[Boolean]],
+              r(25).asInstanceOf[Option[Int]]
+            ),
+          (_: Any) => throw new Exception("Inserting into ? projection not supported.")
+        )
 
     /** Database column level SqlType(int4) */
     val level: Rep[Int] = column[Int]("level")
+
     /** Database column proto SqlType(int4) */
     val proto: Rep[Int] = column[Int]("proto")
+
     /** Database column predecessor SqlType(varchar) */
     val predecessor: Rep[String] = column[String]("predecessor")
+
     /** Database column timestamp SqlType(timestamp) */
     val timestamp: Rep[java.sql.Timestamp] = column[java.sql.Timestamp]("timestamp")
+
     /** Database column validation_pass SqlType(int4) */
     val validationPass: Rep[Int] = column[Int]("validation_pass")
+
     /** Database column fitness SqlType(varchar) */
     val fitness: Rep[String] = column[String]("fitness")
+
     /** Database column context SqlType(varchar), Default(None) */
     val context: Rep[Option[String]] = column[Option[String]]("context", O.Default(None))
+
     /** Database column signature SqlType(varchar), Default(None) */
     val signature: Rep[Option[String]] = column[Option[String]]("signature", O.Default(None))
+
     /** Database column protocol SqlType(varchar) */
     val protocol: Rep[String] = column[String]("protocol")
+
     /** Database column chain_id SqlType(varchar), Default(None) */
     val chainId: Rep[Option[String]] = column[Option[String]]("chain_id", O.Default(None))
+
     /** Database column hash SqlType(varchar) */
     val hash: Rep[String] = column[String]("hash")
+
     /** Database column operations_hash SqlType(varchar), Default(None) */
     val operationsHash: Rep[Option[String]] = column[Option[String]]("operations_hash", O.Default(None))
+
     /** Database column period_kind SqlType(varchar), Default(None) */
     val periodKind: Rep[Option[String]] = column[Option[String]]("period_kind", O.Default(None))
+
     /** Database column current_expected_quorum SqlType(int4), Default(None) */
     val currentExpectedQuorum: Rep[Option[Int]] = column[Option[Int]]("current_expected_quorum", O.Default(None))
+
     /** Database column active_proposal SqlType(varchar), Default(None) */
     val activeProposal: Rep[Option[String]] = column[Option[String]]("active_proposal", O.Default(None))
+
     /** Database column baker SqlType(varchar), Default(None) */
     val baker: Rep[Option[String]] = column[Option[String]]("baker", O.Default(None))
+
     /** Database column nonce_hash SqlType(varchar), Default(None) */
     val nonceHash: Rep[Option[String]] = column[Option[String]]("nonce_hash", O.Default(None))
+
     /** Database column consumed_gas SqlType(numeric), Default(None) */
-    val consumedGas: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("consumed_gas", O.Default(None))
+    val consumedGas: Rep[Option[scala.math.BigDecimal]] =
+      column[Option[scala.math.BigDecimal]]("consumed_gas", O.Default(None))
+
     /** Database column meta_level SqlType(int4), Default(None) */
     val metaLevel: Rep[Option[Int]] = column[Option[Int]]("meta_level", O.Default(None))
+
     /** Database column meta_level_position SqlType(int4), Default(None) */
     val metaLevelPosition: Rep[Option[Int]] = column[Option[Int]]("meta_level_position", O.Default(None))
+
     /** Database column meta_cycle SqlType(int4), Default(None) */
     val metaCycle: Rep[Option[Int]] = column[Option[Int]]("meta_cycle", O.Default(None))
+
     /** Database column meta_cycle_position SqlType(int4), Default(None) */
     val metaCyclePosition: Rep[Option[Int]] = column[Option[Int]]("meta_cycle_position", O.Default(None))
+
     /** Database column meta_voting_period SqlType(int4), Default(None) */
     val metaVotingPeriod: Rep[Option[Int]] = column[Option[Int]]("meta_voting_period", O.Default(None))
+
     /** Database column meta_voting_period_position SqlType(int4), Default(None) */
     val metaVotingPeriodPosition: Rep[Option[Int]] = column[Option[Int]]("meta_voting_period_position", O.Default(None))
+
     /** Database column expected_commitment SqlType(bool), Default(None) */
     val expectedCommitment: Rep[Option[Boolean]] = column[Option[Boolean]]("expected_commitment", O.Default(None))
+
     /** Database column priority SqlType(int4), Default(None) */
     val priority: Rep[Option[Int]] = column[Option[Int]]("priority", O.Default(None))
 
     /** Uniqueness Index over (hash) (database name blocks_hash_key) */
-    val index1 = index("blocks_hash_key", hash :: HNil, unique=true)
+    val index1 = index("blocks_hash_key", hash :: HNil, unique = true)
+
     /** Index over (level) (database name ix_blocks_level) */
     val index2 = index("ix_blocks_level", level :: HNil)
   }
+
   /** Collection-like TableQuery object for table Blocks */
   lazy val Blocks = new TableQuery(tag => new Blocks(tag))
 
@@ -302,40 +654,105 @@ trait Tables {
     *  @param deactivated Database column deactivated SqlType(bool)
     *  @param gracePeriod Database column grace_period SqlType(int4)
     *  @param blockLevel Database column block_level SqlType(int4), Default(-1) */
-  case class DelegatesRow(pkh: String, blockId: String, balance: Option[scala.math.BigDecimal] = None, frozenBalance: Option[scala.math.BigDecimal] = None, stakingBalance: Option[scala.math.BigDecimal] = None, delegatedBalance: Option[scala.math.BigDecimal] = None, deactivated: Boolean, gracePeriod: Int, blockLevel: Int = -1)
+  case class DelegatesRow(
+      pkh: String,
+      blockId: String,
+      balance: Option[scala.math.BigDecimal] = None,
+      frozenBalance: Option[scala.math.BigDecimal] = None,
+      stakingBalance: Option[scala.math.BigDecimal] = None,
+      delegatedBalance: Option[scala.math.BigDecimal] = None,
+      deactivated: Boolean,
+      gracePeriod: Int,
+      blockLevel: Int = -1
+  )
+
   /** GetResult implicit for fetching DelegatesRow objects using plain SQL queries */
-  implicit def GetResultDelegatesRow(implicit e0: GR[String], e1: GR[Option[scala.math.BigDecimal]], e2: GR[Boolean], e3: GR[Int]): GR[DelegatesRow] = GR{
-    prs => import prs._
-      DelegatesRow.tupled((<<[String], <<[String], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<[Boolean], <<[Int], <<[Int]))
+  implicit def GetResultDelegatesRow(
+      implicit e0: GR[String],
+      e1: GR[Option[scala.math.BigDecimal]],
+      e2: GR[Boolean],
+      e3: GR[Int]
+  ): GR[DelegatesRow] = GR { prs =>
+    import prs._
+    DelegatesRow.tupled(
+      (
+        <<[String],
+        <<[String],
+        <<?[scala.math.BigDecimal],
+        <<?[scala.math.BigDecimal],
+        <<?[scala.math.BigDecimal],
+        <<?[scala.math.BigDecimal],
+        <<[Boolean],
+        <<[Int],
+        <<[Int]
+      )
+    )
   }
+
   /** Table description of table delegates. Objects of this class serve as prototypes for rows in queries. */
   class Delegates(_tableTag: Tag) extends profile.api.Table[DelegatesRow](_tableTag, "delegates") {
-    def * = (pkh, blockId, balance, frozenBalance, stakingBalance, delegatedBalance, deactivated, gracePeriod, blockLevel) <> (DelegatesRow.tupled, DelegatesRow.unapply)
+    def * =
+      (pkh, blockId, balance, frozenBalance, stakingBalance, delegatedBalance, deactivated, gracePeriod, blockLevel) <> (DelegatesRow.tupled, DelegatesRow.unapply)
+
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? = ((Rep.Some(pkh), Rep.Some(blockId), balance, frozenBalance, stakingBalance, delegatedBalance, Rep.Some(deactivated), Rep.Some(gracePeriod), Rep.Some(blockLevel))).shaped.<>({r=>import r._; _1.map(_=> DelegatesRow.tupled((_1.get, _2.get, _3, _4, _5, _6, _7.get, _8.get, _9.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+    def ? =
+      (
+        (
+          Rep.Some(pkh),
+          Rep.Some(blockId),
+          balance,
+          frozenBalance,
+          stakingBalance,
+          delegatedBalance,
+          Rep.Some(deactivated),
+          Rep.Some(gracePeriod),
+          Rep.Some(blockLevel)
+        )
+      ).shaped.<>(
+        { r =>
+          import r._; _1.map(_ => DelegatesRow.tupled((_1.get, _2.get, _3, _4, _5, _6, _7.get, _8.get, _9.get)))
+        },
+        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
+      )
 
     /** Database column pkh SqlType(varchar), PrimaryKey */
     val pkh: Rep[String] = column[String]("pkh", O.PrimaryKey)
+
     /** Database column block_id SqlType(varchar) */
     val blockId: Rep[String] = column[String]("block_id")
+
     /** Database column balance SqlType(numeric), Default(None) */
     val balance: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("balance", O.Default(None))
+
     /** Database column frozen_balance SqlType(numeric), Default(None) */
-    val frozenBalance: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("frozen_balance", O.Default(None))
+    val frozenBalance: Rep[Option[scala.math.BigDecimal]] =
+      column[Option[scala.math.BigDecimal]]("frozen_balance", O.Default(None))
+
     /** Database column staking_balance SqlType(numeric), Default(None) */
-    val stakingBalance: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("staking_balance", O.Default(None))
+    val stakingBalance: Rep[Option[scala.math.BigDecimal]] =
+      column[Option[scala.math.BigDecimal]]("staking_balance", O.Default(None))
+
     /** Database column delegated_balance SqlType(numeric), Default(None) */
-    val delegatedBalance: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("delegated_balance", O.Default(None))
+    val delegatedBalance: Rep[Option[scala.math.BigDecimal]] =
+      column[Option[scala.math.BigDecimal]]("delegated_balance", O.Default(None))
+
     /** Database column deactivated SqlType(bool) */
     val deactivated: Rep[Boolean] = column[Boolean]("deactivated")
+
     /** Database column grace_period SqlType(int4) */
     val gracePeriod: Rep[Int] = column[Int]("grace_period")
+
     /** Database column block_level SqlType(int4), Default(-1) */
     val blockLevel: Rep[Int] = column[Int]("block_level", O.Default(-1))
 
     /** Foreign key referencing Blocks (database name delegates_block_id_fkey) */
-    lazy val blocksFk = foreignKey("delegates_block_id_fkey", blockId, Blocks)(r => r.hash, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
+    lazy val blocksFk = foreignKey("delegates_block_id_fkey", blockId, Blocks)(
+      r => r.hash,
+      onUpdate = ForeignKeyAction.NoAction,
+      onDelete = ForeignKeyAction.NoAction
+    )
   }
+
   /** Collection-like TableQuery object for table Delegates */
   lazy val Delegates = new TableQuery(tag => new Delegates(tag))
 
@@ -344,30 +761,48 @@ trait Tables {
     *  @param blockId Database column block_id SqlType(varchar)
     *  @param blockLevel Database column block_level SqlType(int4), Default(-1) */
   case class DelegatesCheckpointRow(delegatePkh: String, blockId: String, blockLevel: Int = -1)
+
   /** GetResult implicit for fetching DelegatesCheckpointRow objects using plain SQL queries */
-  implicit def GetResultDelegatesCheckpointRow(implicit e0: GR[String], e1: GR[Int]): GR[DelegatesCheckpointRow] = GR{
-    prs => import prs._
+  implicit def GetResultDelegatesCheckpointRow(implicit e0: GR[String], e1: GR[Int]): GR[DelegatesCheckpointRow] = GR {
+    prs =>
+      import prs._
       DelegatesCheckpointRow.tupled((<<[String], <<[String], <<[Int]))
   }
+
   /** Table description of table delegates_checkpoint. Objects of this class serve as prototypes for rows in queries. */
-  class DelegatesCheckpoint(_tableTag: Tag) extends profile.api.Table[DelegatesCheckpointRow](_tableTag, "delegates_checkpoint") {
+  class DelegatesCheckpoint(_tableTag: Tag)
+      extends profile.api.Table[DelegatesCheckpointRow](_tableTag, "delegates_checkpoint") {
     def * = (delegatePkh, blockId, blockLevel) <> (DelegatesCheckpointRow.tupled, DelegatesCheckpointRow.unapply)
+
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? = ((Rep.Some(delegatePkh), Rep.Some(blockId), Rep.Some(blockLevel))).shaped.<>({r=>import r._; _1.map(_=> DelegatesCheckpointRow.tupled((_1.get, _2.get, _3.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+    def ? =
+      ((Rep.Some(delegatePkh), Rep.Some(blockId), Rep.Some(blockLevel))).shaped.<>(
+        { r =>
+          import r._; _1.map(_ => DelegatesCheckpointRow.tupled((_1.get, _2.get, _3.get)))
+        },
+        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
+      )
 
     /** Database column delegate_pkh SqlType(varchar) */
     val delegatePkh: Rep[String] = column[String]("delegate_pkh")
+
     /** Database column block_id SqlType(varchar) */
     val blockId: Rep[String] = column[String]("block_id")
+
     /** Database column block_level SqlType(int4), Default(-1) */
     val blockLevel: Rep[Int] = column[Int]("block_level", O.Default(-1))
 
     /** Foreign key referencing Blocks (database name delegate_checkpoint_block_id_fkey) */
-    lazy val blocksFk = foreignKey("delegate_checkpoint_block_id_fkey", blockId, Blocks)(r => r.hash, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
+    lazy val blocksFk = foreignKey("delegate_checkpoint_block_id_fkey", blockId, Blocks)(
+      r => r.hash,
+      onUpdate = ForeignKeyAction.NoAction,
+      onDelete = ForeignKeyAction.NoAction
+    )
 
     /** Index over (blockLevel) (database name ix_delegates_checkpoint_block_level) */
     val index1 = index("ix_delegates_checkpoint_block_level", blockLevel)
   }
+
   /** Collection-like TableQuery object for table DelegatesCheckpoint */
   lazy val DelegatesCheckpoint = new TableQuery(tag => new DelegatesCheckpoint(tag))
 
@@ -377,26 +812,49 @@ trait Tables {
     *  @param delegate Database column delegate SqlType(varchar)
     *  @param slot Database column slot SqlType(int4)
     *  @param estimatedTime Database column estimated_time SqlType(timestamp) */
-  case class EndorsingRightsRow(blockHash: String, level: Int, delegate: String, slot: Int, estimatedTime: java.sql.Timestamp)
+  case class EndorsingRightsRow(
+      blockHash: String,
+      level: Int,
+      delegate: String,
+      slot: Int,
+      estimatedTime: java.sql.Timestamp
+  )
+
   /** GetResult implicit for fetching EndorsingRightsRow objects using plain SQL queries */
-  implicit def GetResultEndorsingRightsRow(implicit e0: GR[String], e1: GR[Int], e2: GR[java.sql.Timestamp]): GR[EndorsingRightsRow] = GR{
-    prs => import prs._
-      EndorsingRightsRow.tupled((<<[String], <<[Int], <<[String], <<[Int], <<[java.sql.Timestamp]))
+  implicit def GetResultEndorsingRightsRow(
+      implicit e0: GR[String],
+      e1: GR[Int],
+      e2: GR[java.sql.Timestamp]
+  ): GR[EndorsingRightsRow] = GR { prs =>
+    import prs._
+    EndorsingRightsRow.tupled((<<[String], <<[Int], <<[String], <<[Int], <<[java.sql.Timestamp]))
   }
+
   /** Table description of table endorsing_rights. Objects of this class serve as prototypes for rows in queries. */
   class EndorsingRights(_tableTag: Tag) extends profile.api.Table[EndorsingRightsRow](_tableTag, "endorsing_rights") {
     def * = (blockHash, level, delegate, slot, estimatedTime) <> (EndorsingRightsRow.tupled, EndorsingRightsRow.unapply)
+
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? = ((Rep.Some(blockHash), Rep.Some(level), Rep.Some(delegate), Rep.Some(slot), Rep.Some(estimatedTime))).shaped.<>({r=>import r._; _1.map(_=> EndorsingRightsRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+    def ? =
+      ((Rep.Some(blockHash), Rep.Some(level), Rep.Some(delegate), Rep.Some(slot), Rep.Some(estimatedTime))).shaped.<>(
+        { r =>
+          import r._; _1.map(_ => EndorsingRightsRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get)))
+        },
+        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
+      )
 
     /** Database column block_hash SqlType(varchar) */
     val blockHash: Rep[String] = column[String]("block_hash")
+
     /** Database column level SqlType(int4) */
     val level: Rep[Int] = column[Int]("level")
+
     /** Database column delegate SqlType(varchar) */
     val delegate: Rep[String] = column[String]("delegate")
+
     /** Database column slot SqlType(int4) */
     val slot: Rep[Int] = column[Int]("slot")
+
     /** Database column estimated_time SqlType(timestamp) */
     val estimatedTime: Rep[java.sql.Timestamp] = column[java.sql.Timestamp]("estimated_time")
 
@@ -404,11 +862,16 @@ trait Tables {
     val pk = primaryKey("endorsing_rights_pkey", (level, delegate, slot))
 
     /** Foreign key referencing Blocks (database name fk_block_hash) */
-    lazy val blocksFk = foreignKey("fk_block_hash", blockHash, Blocks)(r => r.hash, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
+    lazy val blocksFk = foreignKey("fk_block_hash", blockHash, Blocks)(
+      r => r.hash,
+      onUpdate = ForeignKeyAction.NoAction,
+      onDelete = ForeignKeyAction.NoAction
+    )
 
     /** Index over (level) (database name endorsing_rights_level_idx) */
     val index1 = index("endorsing_rights_level_idx", level)
   }
+
   /** Collection-like TableQuery object for table EndorsingRights */
   lazy val EndorsingRights = new TableQuery(tag => new EndorsingRights(tag))
 
@@ -420,33 +883,62 @@ trait Tables {
     *  @param kind Database column kind SqlType(varchar)
     *  @param cycle Database column cycle SqlType(int4), Default(None)
     *  @param level Database column level SqlType(int4), Default(None) */
-  case class FeesRow(low: Int, medium: Int, high: Int, timestamp: java.sql.Timestamp, kind: String, cycle: Option[Int] = None, level: Option[Int] = None)
+  case class FeesRow(
+      low: Int,
+      medium: Int,
+      high: Int,
+      timestamp: java.sql.Timestamp,
+      kind: String,
+      cycle: Option[Int] = None,
+      level: Option[Int] = None
+  )
+
   /** GetResult implicit for fetching FeesRow objects using plain SQL queries */
-  implicit def GetResultFeesRow(implicit e0: GR[Int], e1: GR[java.sql.Timestamp], e2: GR[String], e3: GR[Option[Int]]): GR[FeesRow] = GR{
-    prs => import prs._
-      FeesRow.tupled((<<[Int], <<[Int], <<[Int], <<[java.sql.Timestamp], <<[String], <<?[Int], <<?[Int]))
+  implicit def GetResultFeesRow(
+      implicit e0: GR[Int],
+      e1: GR[java.sql.Timestamp],
+      e2: GR[String],
+      e3: GR[Option[Int]]
+  ): GR[FeesRow] = GR { prs =>
+    import prs._
+    FeesRow.tupled((<<[Int], <<[Int], <<[Int], <<[java.sql.Timestamp], <<[String], <<?[Int], <<?[Int]))
   }
+
   /** Table description of table fees. Objects of this class serve as prototypes for rows in queries. */
   class Fees(_tableTag: Tag) extends profile.api.Table[FeesRow](_tableTag, "fees") {
     def * = (low, medium, high, timestamp, kind, cycle, level) <> (FeesRow.tupled, FeesRow.unapply)
+
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? = ((Rep.Some(low), Rep.Some(medium), Rep.Some(high), Rep.Some(timestamp), Rep.Some(kind), cycle, level)).shaped.<>({r=>import r._; _1.map(_=> FeesRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get, _6, _7)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+    def ? =
+      ((Rep.Some(low), Rep.Some(medium), Rep.Some(high), Rep.Some(timestamp), Rep.Some(kind), cycle, level)).shaped.<>(
+        { r =>
+          import r._; _1.map(_ => FeesRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get, _6, _7)))
+        },
+        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
+      )
 
     /** Database column low SqlType(int4) */
     val low: Rep[Int] = column[Int]("low")
+
     /** Database column medium SqlType(int4) */
     val medium: Rep[Int] = column[Int]("medium")
+
     /** Database column high SqlType(int4) */
     val high: Rep[Int] = column[Int]("high")
+
     /** Database column timestamp SqlType(timestamp) */
     val timestamp: Rep[java.sql.Timestamp] = column[java.sql.Timestamp]("timestamp")
+
     /** Database column kind SqlType(varchar) */
     val kind: Rep[String] = column[String]("kind")
+
     /** Database column cycle SqlType(int4), Default(None) */
     val cycle: Rep[Option[Int]] = column[Option[Int]]("cycle", O.Default(None))
+
     /** Database column level SqlType(int4), Default(None) */
     val level: Rep[Option[Int]] = column[Option[Int]]("level", O.Default(None))
   }
+
   /** Collection-like TableQuery object for table Fees */
   lazy val Fees = new TableQuery(tag => new Fees(tag))
 
@@ -458,30 +950,68 @@ trait Tables {
     *  @param signature Database column signature SqlType(varchar), Default(None)
     *  @param blockId Database column block_id SqlType(varchar)
     *  @param blockLevel Database column block_level SqlType(int4) */
-  case class OperationGroupsRow(protocol: String, chainId: Option[String] = None, hash: String, branch: String, signature: Option[String] = None, blockId: String, blockLevel: Int)
+  case class OperationGroupsRow(
+      protocol: String,
+      chainId: Option[String] = None,
+      hash: String,
+      branch: String,
+      signature: Option[String] = None,
+      blockId: String,
+      blockLevel: Int
+  )
+
   /** GetResult implicit for fetching OperationGroupsRow objects using plain SQL queries */
-  implicit def GetResultOperationGroupsRow(implicit e0: GR[String], e1: GR[Option[String]], e2: GR[Int]): GR[OperationGroupsRow] = GR{
-    prs => import prs._
-      OperationGroupsRow.tupled((<<[String], <<?[String], <<[String], <<[String], <<?[String], <<[String], <<[Int]))
+  implicit def GetResultOperationGroupsRow(
+      implicit e0: GR[String],
+      e1: GR[Option[String]],
+      e2: GR[Int]
+  ): GR[OperationGroupsRow] = GR { prs =>
+    import prs._
+    OperationGroupsRow.tupled((<<[String], <<?[String], <<[String], <<[String], <<?[String], <<[String], <<[Int]))
   }
+
   /** Table description of table operation_groups. Objects of this class serve as prototypes for rows in queries. */
   class OperationGroups(_tableTag: Tag) extends profile.api.Table[OperationGroupsRow](_tableTag, "operation_groups") {
-    def * = (protocol, chainId, hash, branch, signature, blockId, blockLevel) <> (OperationGroupsRow.tupled, OperationGroupsRow.unapply)
+    def * =
+      (protocol, chainId, hash, branch, signature, blockId, blockLevel) <> (OperationGroupsRow.tupled, OperationGroupsRow.unapply)
+
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? = ((Rep.Some(protocol), chainId, Rep.Some(hash), Rep.Some(branch), signature, Rep.Some(blockId), Rep.Some(blockLevel))).shaped.<>({r=>import r._; _1.map(_=> OperationGroupsRow.tupled((_1.get, _2, _3.get, _4.get, _5, _6.get, _7.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+    def ? =
+      (
+        (
+          Rep.Some(protocol),
+          chainId,
+          Rep.Some(hash),
+          Rep.Some(branch),
+          signature,
+          Rep.Some(blockId),
+          Rep.Some(blockLevel)
+        )
+      ).shaped.<>(
+        { r =>
+          import r._; _1.map(_ => OperationGroupsRow.tupled((_1.get, _2, _3.get, _4.get, _5, _6.get, _7.get)))
+        },
+        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
+      )
 
     /** Database column protocol SqlType(varchar) */
     val protocol: Rep[String] = column[String]("protocol")
+
     /** Database column chain_id SqlType(varchar), Default(None) */
     val chainId: Rep[Option[String]] = column[Option[String]]("chain_id", O.Default(None))
+
     /** Database column hash SqlType(varchar) */
     val hash: Rep[String] = column[String]("hash")
+
     /** Database column branch SqlType(varchar) */
     val branch: Rep[String] = column[String]("branch")
+
     /** Database column signature SqlType(varchar), Default(None) */
     val signature: Rep[Option[String]] = column[Option[String]]("signature", O.Default(None))
+
     /** Database column block_id SqlType(varchar) */
     val blockId: Rep[String] = column[String]("block_id")
+
     /** Database column block_level SqlType(int4) */
     val blockLevel: Rep[Int] = column[Int]("block_level")
 
@@ -489,11 +1019,16 @@ trait Tables {
     val pk = primaryKey("OperationGroups_pkey", (blockId, hash))
 
     /** Foreign key referencing Blocks (database name block) */
-    lazy val blocksFk = foreignKey("block", blockId, Blocks)(r => r.hash, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
+    lazy val blocksFk = foreignKey("block", blockId, Blocks)(
+      r => r.hash,
+      onUpdate = ForeignKeyAction.NoAction,
+      onDelete = ForeignKeyAction.NoAction
+    )
 
     /** Index over (blockLevel) (database name ix_operation_groups_block_level) */
     val index1 = index("ix_operation_groups_block_level", blockLevel)
   }
+
   /** Collection-like TableQuery object for table OperationGroups */
   lazy val OperationGroups = new TableQuery(tag => new OperationGroups(tag))
 
@@ -537,113 +1072,311 @@ trait Tables {
     *  @param internal Database column internal SqlType(bool)
     *  @param period Database column period SqlType(int4), Default(None)
     *  @param timestamp Database column timestamp SqlType(timestamp) */
-  case class OperationsRow(branch: Option[String] = None, numberOfSlots: Option[Int] = None, cycle: Option[Int] = None, operationId: Int, operationGroupHash: String, kind: String, level: Option[Int] = None, delegate: Option[String] = None, slots: Option[String] = None, nonce: Option[String] = None, pkh: Option[String] = None, secret: Option[String] = None, source: Option[String] = None, fee: Option[scala.math.BigDecimal] = None, counter: Option[scala.math.BigDecimal] = None, gasLimit: Option[scala.math.BigDecimal] = None, storageLimit: Option[scala.math.BigDecimal] = None, publicKey: Option[String] = None, amount: Option[scala.math.BigDecimal] = None, destination: Option[String] = None, parameters: Option[String] = None, managerPubkey: Option[String] = None, balance: Option[scala.math.BigDecimal] = None, proposal: Option[String] = None, spendable: Option[Boolean] = None, delegatable: Option[Boolean] = None, script: Option[String] = None, storage: Option[String] = None, status: Option[String] = None, consumedGas: Option[scala.math.BigDecimal] = None, storageSize: Option[scala.math.BigDecimal] = None, paidStorageSizeDiff: Option[scala.math.BigDecimal] = None, originatedContracts: Option[String] = None, blockHash: String, blockLevel: Int, ballot: Option[String] = None, internal: Boolean, period: Option[Int] = None, timestamp: java.sql.Timestamp)
+  case class OperationsRow(
+      branch: Option[String] = None,
+      numberOfSlots: Option[Int] = None,
+      cycle: Option[Int] = None,
+      operationId: Int,
+      operationGroupHash: String,
+      kind: String,
+      level: Option[Int] = None,
+      delegate: Option[String] = None,
+      slots: Option[String] = None,
+      nonce: Option[String] = None,
+      pkh: Option[String] = None,
+      secret: Option[String] = None,
+      source: Option[String] = None,
+      fee: Option[scala.math.BigDecimal] = None,
+      counter: Option[scala.math.BigDecimal] = None,
+      gasLimit: Option[scala.math.BigDecimal] = None,
+      storageLimit: Option[scala.math.BigDecimal] = None,
+      publicKey: Option[String] = None,
+      amount: Option[scala.math.BigDecimal] = None,
+      destination: Option[String] = None,
+      parameters: Option[String] = None,
+      managerPubkey: Option[String] = None,
+      balance: Option[scala.math.BigDecimal] = None,
+      proposal: Option[String] = None,
+      spendable: Option[Boolean] = None,
+      delegatable: Option[Boolean] = None,
+      script: Option[String] = None,
+      storage: Option[String] = None,
+      status: Option[String] = None,
+      consumedGas: Option[scala.math.BigDecimal] = None,
+      storageSize: Option[scala.math.BigDecimal] = None,
+      paidStorageSizeDiff: Option[scala.math.BigDecimal] = None,
+      originatedContracts: Option[String] = None,
+      blockHash: String,
+      blockLevel: Int,
+      ballot: Option[String] = None,
+      internal: Boolean,
+      period: Option[Int] = None,
+      timestamp: java.sql.Timestamp
+  )
+
   /** GetResult implicit for fetching OperationsRow objects using plain SQL queries */
-  implicit def GetResultOperationsRow(implicit e0: GR[Option[String]], e1: GR[Option[Int]], e2: GR[Int], e3: GR[String], e4: GR[Option[scala.math.BigDecimal]], e5: GR[Option[Boolean]], e6: GR[Boolean], e7: GR[java.sql.Timestamp]): GR[OperationsRow] = GR{
-    prs => import prs._
-      OperationsRow(<<?[String], <<?[Int], <<?[Int], <<[Int], <<[String], <<[String], <<?[Int], <<?[String], <<?[String], <<?[String], <<?[String], <<?[String], <<?[String], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<?[String], <<?[scala.math.BigDecimal], <<?[String], <<?[String], <<?[String], <<?[scala.math.BigDecimal], <<?[String], <<?[Boolean], <<?[Boolean], <<?[String], <<?[String], <<?[String], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<?[scala.math.BigDecimal], <<?[String], <<[String], <<[Int], <<?[String], <<[Boolean], <<?[Int], <<[java.sql.Timestamp])
+  implicit def GetResultOperationsRow(
+      implicit e0: GR[Option[String]],
+      e1: GR[Option[Int]],
+      e2: GR[Int],
+      e3: GR[String],
+      e4: GR[Option[scala.math.BigDecimal]],
+      e5: GR[Option[Boolean]],
+      e6: GR[Boolean],
+      e7: GR[java.sql.Timestamp]
+  ): GR[OperationsRow] = GR { prs =>
+    import prs._
+    OperationsRow(
+      <<?[String],
+      <<?[Int],
+      <<?[Int],
+      <<[Int],
+      <<[String],
+      <<[String],
+      <<?[Int],
+      <<?[String],
+      <<?[String],
+      <<?[String],
+      <<?[String],
+      <<?[String],
+      <<?[String],
+      <<?[scala.math.BigDecimal],
+      <<?[scala.math.BigDecimal],
+      <<?[scala.math.BigDecimal],
+      <<?[scala.math.BigDecimal],
+      <<?[String],
+      <<?[scala.math.BigDecimal],
+      <<?[String],
+      <<?[String],
+      <<?[String],
+      <<?[scala.math.BigDecimal],
+      <<?[String],
+      <<?[Boolean],
+      <<?[Boolean],
+      <<?[String],
+      <<?[String],
+      <<?[String],
+      <<?[scala.math.BigDecimal],
+      <<?[scala.math.BigDecimal],
+      <<?[scala.math.BigDecimal],
+      <<?[String],
+      <<[String],
+      <<[Int],
+      <<?[String],
+      <<[Boolean],
+      <<?[Int],
+      <<[java.sql.Timestamp]
+    )
   }
+
   /** Table description of table operations. Objects of this class serve as prototypes for rows in queries. */
   class Operations(_tableTag: Tag) extends profile.api.Table[OperationsRow](_tableTag, "operations") {
-    def * = (branch :: numberOfSlots :: cycle :: operationId :: operationGroupHash :: kind :: level :: delegate :: slots :: nonce :: pkh :: secret :: source :: fee :: counter :: gasLimit :: storageLimit :: publicKey :: amount :: destination :: parameters :: managerPubkey :: balance :: proposal :: spendable :: delegatable :: script :: storage :: status :: consumedGas :: storageSize :: paidStorageSizeDiff :: originatedContracts :: blockHash :: blockLevel :: ballot :: internal :: period :: timestamp :: HNil).mapTo[OperationsRow]
+    def * =
+      (branch :: numberOfSlots :: cycle :: operationId :: operationGroupHash :: kind :: level :: delegate :: slots :: nonce :: pkh :: secret :: source :: fee :: counter :: gasLimit :: storageLimit :: publicKey :: amount :: destination :: parameters :: managerPubkey :: balance :: proposal :: spendable :: delegatable :: script :: storage :: status :: consumedGas :: storageSize :: paidStorageSizeDiff :: originatedContracts :: blockHash :: blockLevel :: ballot :: internal :: period :: timestamp :: HNil)
+        .mapTo[OperationsRow]
+
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? = (branch :: numberOfSlots :: cycle :: Rep.Some(operationId) :: Rep.Some(operationGroupHash) :: Rep.Some(kind) :: level :: delegate :: slots :: nonce :: pkh :: secret :: source :: fee :: counter :: gasLimit :: storageLimit :: publicKey :: amount :: destination :: parameters :: managerPubkey :: balance :: proposal :: spendable :: delegatable :: script :: storage :: status :: consumedGas :: storageSize :: paidStorageSizeDiff :: originatedContracts :: Rep.Some(blockHash) :: Rep.Some(blockLevel) :: ballot :: Rep.Some(internal) :: period :: Rep.Some(timestamp) :: HNil).shaped.<>(r => OperationsRow(r(0).asInstanceOf[Option[String]], r(1).asInstanceOf[Option[Int]], r(2).asInstanceOf[Option[Int]], r(3).asInstanceOf[Option[Int]].get, r(4).asInstanceOf[Option[String]].get, r(5).asInstanceOf[Option[String]].get, r(6).asInstanceOf[Option[Int]], r(7).asInstanceOf[Option[String]], r(8).asInstanceOf[Option[String]], r(9).asInstanceOf[Option[String]], r(10).asInstanceOf[Option[String]], r(11).asInstanceOf[Option[String]], r(12).asInstanceOf[Option[String]], r(13).asInstanceOf[Option[scala.math.BigDecimal]], r(14).asInstanceOf[Option[scala.math.BigDecimal]], r(15).asInstanceOf[Option[scala.math.BigDecimal]], r(16).asInstanceOf[Option[scala.math.BigDecimal]], r(17).asInstanceOf[Option[String]], r(18).asInstanceOf[Option[scala.math.BigDecimal]], r(19).asInstanceOf[Option[String]], r(20).asInstanceOf[Option[String]], r(21).asInstanceOf[Option[String]], r(22).asInstanceOf[Option[scala.math.BigDecimal]], r(23).asInstanceOf[Option[String]], r(24).asInstanceOf[Option[Boolean]], r(25).asInstanceOf[Option[Boolean]], r(26).asInstanceOf[Option[String]], r(27).asInstanceOf[Option[String]], r(28).asInstanceOf[Option[String]], r(29).asInstanceOf[Option[scala.math.BigDecimal]], r(30).asInstanceOf[Option[scala.math.BigDecimal]], r(31).asInstanceOf[Option[scala.math.BigDecimal]], r(32).asInstanceOf[Option[String]], r(33).asInstanceOf[Option[String]].get, r(34).asInstanceOf[Option[Int]].get, r(35).asInstanceOf[Option[String]], r(36).asInstanceOf[Option[Boolean]].get, r(37).asInstanceOf[Option[Int]], r(38).asInstanceOf[Option[java.sql.Timestamp]].get), (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+    def ? =
+      (branch :: numberOfSlots :: cycle :: Rep.Some(operationId) :: Rep.Some(operationGroupHash) :: Rep.Some(kind) :: level :: delegate :: slots :: nonce :: pkh :: secret :: source :: fee :: counter :: gasLimit :: storageLimit :: publicKey :: amount :: destination :: parameters :: managerPubkey :: balance :: proposal :: spendable :: delegatable :: script :: storage :: status :: consumedGas :: storageSize :: paidStorageSizeDiff :: originatedContracts :: Rep.Some(
+            blockHash
+          ) :: Rep.Some(blockLevel) :: ballot :: Rep.Some(internal) :: period :: Rep.Some(timestamp) :: HNil).shaped.<>(
+        r =>
+          OperationsRow(
+            r(0).asInstanceOf[Option[String]],
+            r(1).asInstanceOf[Option[Int]],
+            r(2).asInstanceOf[Option[Int]],
+            r(3).asInstanceOf[Option[Int]].get,
+            r(4).asInstanceOf[Option[String]].get,
+            r(5).asInstanceOf[Option[String]].get,
+            r(6).asInstanceOf[Option[Int]],
+            r(7).asInstanceOf[Option[String]],
+            r(8).asInstanceOf[Option[String]],
+            r(9).asInstanceOf[Option[String]],
+            r(10).asInstanceOf[Option[String]],
+            r(11).asInstanceOf[Option[String]],
+            r(12).asInstanceOf[Option[String]],
+            r(13).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(14).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(15).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(16).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(17).asInstanceOf[Option[String]],
+            r(18).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(19).asInstanceOf[Option[String]],
+            r(20).asInstanceOf[Option[String]],
+            r(21).asInstanceOf[Option[String]],
+            r(22).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(23).asInstanceOf[Option[String]],
+            r(24).asInstanceOf[Option[Boolean]],
+            r(25).asInstanceOf[Option[Boolean]],
+            r(26).asInstanceOf[Option[String]],
+            r(27).asInstanceOf[Option[String]],
+            r(28).asInstanceOf[Option[String]],
+            r(29).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(30).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(31).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(32).asInstanceOf[Option[String]],
+            r(33).asInstanceOf[Option[String]].get,
+            r(34).asInstanceOf[Option[Int]].get,
+            r(35).asInstanceOf[Option[String]],
+            r(36).asInstanceOf[Option[Boolean]].get,
+            r(37).asInstanceOf[Option[Int]],
+            r(38).asInstanceOf[Option[java.sql.Timestamp]].get
+          ),
+        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
+      )
 
     /** Database column branch SqlType(varchar), Default(None) */
     val branch: Rep[Option[String]] = column[Option[String]]("branch", O.Default(None))
+
     /** Database column number_of_slots SqlType(int4), Default(None) */
     val numberOfSlots: Rep[Option[Int]] = column[Option[Int]]("number_of_slots", O.Default(None))
+
     /** Database column cycle SqlType(int4), Default(None) */
     val cycle: Rep[Option[Int]] = column[Option[Int]]("cycle", O.Default(None))
+
     /** Database column operation_id SqlType(serial), AutoInc, PrimaryKey */
     val operationId: Rep[Int] = column[Int]("operation_id", O.AutoInc, O.PrimaryKey)
+
     /** Database column operation_group_hash SqlType(varchar) */
     val operationGroupHash: Rep[String] = column[String]("operation_group_hash")
+
     /** Database column kind SqlType(varchar) */
     val kind: Rep[String] = column[String]("kind")
+
     /** Database column level SqlType(int4), Default(None) */
     val level: Rep[Option[Int]] = column[Option[Int]]("level", O.Default(None))
+
     /** Database column delegate SqlType(varchar), Default(None) */
     val delegate: Rep[Option[String]] = column[Option[String]]("delegate", O.Default(None))
+
     /** Database column slots SqlType(varchar), Default(None) */
     val slots: Rep[Option[String]] = column[Option[String]]("slots", O.Default(None))
+
     /** Database column nonce SqlType(varchar), Default(None) */
     val nonce: Rep[Option[String]] = column[Option[String]]("nonce", O.Default(None))
+
     /** Database column pkh SqlType(varchar), Default(None) */
     val pkh: Rep[Option[String]] = column[Option[String]]("pkh", O.Default(None))
+
     /** Database column secret SqlType(varchar), Default(None) */
     val secret: Rep[Option[String]] = column[Option[String]]("secret", O.Default(None))
+
     /** Database column source SqlType(varchar), Default(None) */
     val source: Rep[Option[String]] = column[Option[String]]("source", O.Default(None))
+
     /** Database column fee SqlType(numeric), Default(None) */
     val fee: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("fee", O.Default(None))
+
     /** Database column counter SqlType(numeric), Default(None) */
     val counter: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("counter", O.Default(None))
+
     /** Database column gas_limit SqlType(numeric), Default(None) */
-    val gasLimit: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("gas_limit", O.Default(None))
+    val gasLimit: Rep[Option[scala.math.BigDecimal]] =
+      column[Option[scala.math.BigDecimal]]("gas_limit", O.Default(None))
+
     /** Database column storage_limit SqlType(numeric), Default(None) */
-    val storageLimit: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("storage_limit", O.Default(None))
+    val storageLimit: Rep[Option[scala.math.BigDecimal]] =
+      column[Option[scala.math.BigDecimal]]("storage_limit", O.Default(None))
+
     /** Database column public_key SqlType(varchar), Default(None) */
     val publicKey: Rep[Option[String]] = column[Option[String]]("public_key", O.Default(None))
+
     /** Database column amount SqlType(numeric), Default(None) */
     val amount: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("amount", O.Default(None))
+
     /** Database column destination SqlType(varchar), Default(None) */
     val destination: Rep[Option[String]] = column[Option[String]]("destination", O.Default(None))
+
     /** Database column parameters SqlType(varchar), Default(None) */
     val parameters: Rep[Option[String]] = column[Option[String]]("parameters", O.Default(None))
+
     /** Database column manager_pubkey SqlType(varchar), Default(None) */
     val managerPubkey: Rep[Option[String]] = column[Option[String]]("manager_pubkey", O.Default(None))
+
     /** Database column balance SqlType(numeric), Default(None) */
     val balance: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("balance", O.Default(None))
+
     /** Database column proposal SqlType(varchar), Default(None) */
     val proposal: Rep[Option[String]] = column[Option[String]]("proposal", O.Default(None))
+
     /** Database column spendable SqlType(bool), Default(None) */
     val spendable: Rep[Option[Boolean]] = column[Option[Boolean]]("spendable", O.Default(None))
+
     /** Database column delegatable SqlType(bool), Default(None) */
     val delegatable: Rep[Option[Boolean]] = column[Option[Boolean]]("delegatable", O.Default(None))
+
     /** Database column script SqlType(varchar), Default(None) */
     val script: Rep[Option[String]] = column[Option[String]]("script", O.Default(None))
+
     /** Database column storage SqlType(varchar), Default(None) */
     val storage: Rep[Option[String]] = column[Option[String]]("storage", O.Default(None))
+
     /** Database column status SqlType(varchar), Default(None) */
     val status: Rep[Option[String]] = column[Option[String]]("status", O.Default(None))
+
     /** Database column consumed_gas SqlType(numeric), Default(None) */
-    val consumedGas: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("consumed_gas", O.Default(None))
+    val consumedGas: Rep[Option[scala.math.BigDecimal]] =
+      column[Option[scala.math.BigDecimal]]("consumed_gas", O.Default(None))
+
     /** Database column storage_size SqlType(numeric), Default(None) */
-    val storageSize: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("storage_size", O.Default(None))
+    val storageSize: Rep[Option[scala.math.BigDecimal]] =
+      column[Option[scala.math.BigDecimal]]("storage_size", O.Default(None))
+
     /** Database column paid_storage_size_diff SqlType(numeric), Default(None) */
-    val paidStorageSizeDiff: Rep[Option[scala.math.BigDecimal]] = column[Option[scala.math.BigDecimal]]("paid_storage_size_diff", O.Default(None))
+    val paidStorageSizeDiff: Rep[Option[scala.math.BigDecimal]] =
+      column[Option[scala.math.BigDecimal]]("paid_storage_size_diff", O.Default(None))
+
     /** Database column originated_contracts SqlType(varchar), Default(None) */
     val originatedContracts: Rep[Option[String]] = column[Option[String]]("originated_contracts", O.Default(None))
+
     /** Database column block_hash SqlType(varchar) */
     val blockHash: Rep[String] = column[String]("block_hash")
+
     /** Database column block_level SqlType(int4) */
     val blockLevel: Rep[Int] = column[Int]("block_level")
+
     /** Database column ballot SqlType(varchar), Default(None) */
     val ballot: Rep[Option[String]] = column[Option[String]]("ballot", O.Default(None))
+
     /** Database column internal SqlType(bool) */
     val internal: Rep[Boolean] = column[Boolean]("internal")
+
     /** Database column period SqlType(int4), Default(None) */
     val period: Rep[Option[Int]] = column[Option[Int]]("period", O.Default(None))
+
     /** Database column timestamp SqlType(timestamp) */
     val timestamp: Rep[java.sql.Timestamp] = column[java.sql.Timestamp]("timestamp")
 
     /** Foreign key referencing Blocks (database name fk_blockhashes) */
-    lazy val blocksFk = foreignKey("fk_blockhashes", blockHash :: HNil, Blocks)(r => r.hash :: HNil, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
+    lazy val blocksFk = foreignKey("fk_blockhashes", blockHash :: HNil, Blocks)(
+      r => r.hash :: HNil,
+      onUpdate = ForeignKeyAction.NoAction,
+      onDelete = ForeignKeyAction.NoAction
+    )
+
     /** Foreign key referencing OperationGroups (database name fk_opgroups) */
-    lazy val operationGroupsFk = foreignKey("fk_opgroups", operationGroupHash :: blockHash :: HNil, OperationGroups)(r => r.hash :: r.blockId :: HNil, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
+    lazy val operationGroupsFk = foreignKey("fk_opgroups", operationGroupHash :: blockHash :: HNil, OperationGroups)(
+      r => r.hash :: r.blockId :: HNil,
+      onUpdate = ForeignKeyAction.NoAction,
+      onDelete = ForeignKeyAction.NoAction
+    )
 
     /** Index over (blockLevel) (database name ix_operations_block_level) */
     val index1 = index("ix_operations_block_level", blockLevel :: HNil)
+
     /** Index over (delegate) (database name ix_operations_delegate) */
     val index2 = index("ix_operations_delegate", delegate :: HNil)
+
     /** Index over (destination) (database name ix_operations_destination) */
     val index3 = index("ix_operations_destination", destination :: HNil)
+
     /** Index over (source) (database name ix_operations_source) */
     val index4 = index("ix_operations_source", source :: HNil)
+
     /** Index over (timestamp) (database name ix_operations_timestamp) */
     val index5 = index("ix_operations_timestamp", timestamp :: HNil)
   }
+
   /** Collection-like TableQuery object for table Operations */
   lazy val Operations = new TableQuery(tag => new Operations(tag))
 
@@ -653,32 +1386,46 @@ trait Tables {
     *  @param blockId Database column block_id SqlType(varchar)
     *  @param blockLevel Database column block_level SqlType(int4) */
   case class RollsRow(pkh: String, rolls: Int, blockId: String, blockLevel: Int)
+
   /** GetResult implicit for fetching RollsRow objects using plain SQL queries */
-  implicit def GetResultRollsRow(implicit e0: GR[String], e1: GR[Int]): GR[RollsRow] = GR{
-    prs => import prs._
-      RollsRow.tupled((<<[String], <<[Int], <<[String], <<[Int]))
+  implicit def GetResultRollsRow(implicit e0: GR[String], e1: GR[Int]): GR[RollsRow] = GR { prs =>
+    import prs._
+    RollsRow.tupled((<<[String], <<[Int], <<[String], <<[Int]))
   }
+
   /** Table description of table rolls. Objects of this class serve as prototypes for rows in queries. */
   class Rolls(_tableTag: Tag) extends profile.api.Table[RollsRow](_tableTag, "rolls") {
     def * = (pkh, rolls, blockId, blockLevel) <> (RollsRow.tupled, RollsRow.unapply)
+
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? = ((Rep.Some(pkh), Rep.Some(rolls), Rep.Some(blockId), Rep.Some(blockLevel))).shaped.<>({r=>import r._; _1.map(_=> RollsRow.tupled((_1.get, _2.get, _3.get, _4.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+    def ? =
+      ((Rep.Some(pkh), Rep.Some(rolls), Rep.Some(blockId), Rep.Some(blockLevel))).shaped.<>({ r =>
+        import r._; _1.map(_ => RollsRow.tupled((_1.get, _2.get, _3.get, _4.get)))
+      }, (_: Any) => throw new Exception("Inserting into ? projection not supported."))
 
     /** Database column pkh SqlType(varchar) */
     val pkh: Rep[String] = column[String]("pkh")
+
     /** Database column rolls SqlType(int4) */
     val rolls: Rep[Int] = column[Int]("rolls")
+
     /** Database column block_id SqlType(varchar) */
     val blockId: Rep[String] = column[String]("block_id")
+
     /** Database column block_level SqlType(int4) */
     val blockLevel: Rep[Int] = column[Int]("block_level")
 
     /** Foreign key referencing Blocks (database name rolls_block_id_fkey) */
-    lazy val blocksFk = foreignKey("rolls_block_id_fkey", blockId, Blocks)(r => r.hash, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
+    lazy val blocksFk = foreignKey("rolls_block_id_fkey", blockId, Blocks)(
+      r => r.hash,
+      onUpdate = ForeignKeyAction.NoAction,
+      onDelete = ForeignKeyAction.NoAction
+    )
 
     /** Index over (blockLevel) (database name ix_rolls_block_level) */
     val index1 = index("ix_rolls_block_level", blockLevel)
   }
+
   /** Collection-like TableQuery object for table Rolls */
   lazy val Rolls = new TableQuery(tag => new Rolls(tag))
 }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -396,11 +396,21 @@ object TezosTypes {
       storageSizeDiff: Option[Int]
   )
 
+  /** retro-compat adapter from protocol 5+ */
+  type AccountDelegate = Either[Protocol4Delegate, PublicKeyHash]
+
+  final case class Protocol4Delegate(
+      setable: Boolean,
+      value: Option[PublicKeyHash]
+  )
+
   final case class Account(
       balance: scala.math.BigDecimal,
-      delegate: Option[PublicKeyHash],
+      delegate: Option[AccountDelegate],
       script: Option[Scripted.Contracts],
-      counter: Option[Int]
+      counter: Option[Int],
+      manager: Option[PublicKeyHash], // retro-compat from protocol 5+
+      spendable: Option[Boolean] // retro-compat from protocol 5+
   )
 
   /** Keeps track of association between some domain type and a block reference

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParser.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParser.scala
@@ -4,7 +4,7 @@ import io.circe.parser.decode
 import cats.syntax.functor._
 import io.circe._
 import io.circe.generic.auto._
-import tech.cryptonomic.conseil.util.JsonUtil.JsonString
+import tech.cryptonomic.conseil.util.JsonUtil.{JsonString, CirceCommonDecoders}
 import tech.cryptonomic.conseil.tezos.michelson.dto.{MichelsonElement, _}
 import tech.cryptonomic.conseil.tezos.michelson.parser.JsonParser.EmbeddedElement.toMichelsonElement
 
@@ -189,7 +189,7 @@ object JsonParser {
       ).reduceLeft(_ or _)
 
     implicit def decodeEither[A, B](implicit leftDecoder: Decoder[A], rightDecoder: Decoder[B]): Decoder[Either[A, B]] =
-      leftDecoder.map(Left.apply) or rightDecoder.map(Right.apply)
+      CirceCommonDecoders.decodeUntaggedEither
   }
 
   trait Parser[T <: MichelsonElement] {

--- a/src/main/scala/tech/cryptonomic/conseil/util/JsonUtil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/util/JsonUtil.scala
@@ -14,6 +14,13 @@ import scala.util.matching.Regex
   */
 object JsonUtil {
 
+  object CirceCommonDecoders {
+    import io.circe.Decoder
+    /** Provides deconding to an Either value, without needing a discrimination "tag" in the json source*/
+    implicit def decodeUntaggedEither[A, B](implicit leftDecoder: Decoder[A], rightDecoder: Decoder[B]): Decoder[Either[A, B]] =
+      leftDecoder.map(Left.apply) or rightDecoder.map(Right.apply)
+  }
+
   private val managerPubkeyMatcher = """("managerPubkey":)""".r
   private val managerPubkeyAdaptation = """"manager_pubkey":"""
 

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTest.scala
@@ -441,6 +441,14 @@ class JsonDecodersTest extends WordSpec with Matchers with EitherValues with Opt
         account shouldEqual expectedAccount
       }
 
+      "decode legacy protocol4 accounts" in new AccountsJsonData {
+        val decoded = decode[Account](legacyAccountJson)
+        decoded shouldBe 'right
+
+        val account = decoded.right.value
+        account shouldEqual expectedLegacyAccount
+      }
+
       "decode account scripts as wrapped and unparsed text, instead of a json object" in new AccountsJsonData {
         val decoded = decode[Account](accountScriptedJson)
         decoded shouldBe 'right

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTestFixtures.scala
@@ -194,6 +194,32 @@ trait DelegatesJsonData {
 
 /* defines example tezos json definitions of accounts and typed counterparts used in the tests */
 trait AccountsJsonData {
+  val legacyAccountJson =
+    """{
+    |  "balance": "2921522468",
+    |  "counter": "0",
+    |  "delegate": {
+    |      "setable": false,
+    |      "value": "tz1LdZ6S8ScNMgaCLqrekDvbBWhLqtUebk23"
+    |  },
+    |  "spendable": true
+    |}""".stripMargin
+
+  val expectedLegacyAccount =
+    Account(
+      balance = 2921522468L,
+      script = None,
+      counter = Some(0),
+      manager = None,
+      spendable = Some(true),
+      delegate = Some(Left(
+        Protocol4Delegate(
+          setable = false,
+          value = Some(PublicKeyHash("tz1LdZ6S8ScNMgaCLqrekDvbBWhLqtUebk23"))
+        )
+      ))
+    )
+
   val accountJson =
     """{
     |  "balance": "2921522468",
@@ -204,9 +230,11 @@ trait AccountsJsonData {
   val expectedAccount =
     Account(
       balance = 2921522468L,
-      delegate = Some(PublicKeyHash("tz1LdZ6S8ScNMgaCLqrekDvbBWhLqtUebk23")),
+      delegate = Some(Right(PublicKeyHash("tz1LdZ6S8ScNMgaCLqrekDvbBWhLqtUebk23"))),
       script = None,
-      counter = Some(0)
+      counter = Some(0),
+      manager = None,
+      spendable = None
     )
 
   val scriptJson =

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
@@ -306,7 +306,7 @@ class TezosDatabaseOperationsTest
           case (row, (id, account)) =>
             row.accountId shouldEqual id.id
             row.blockId shouldEqual block.hash
-            row.delegate shouldEqual account.delegate.map(_.value)
+            row.delegate shouldEqual account.delegate.flatMap(_.right.map(_.value).toOption)
             row.counter shouldEqual account.counter
             row.script shouldEqual account.script.map(_.code.expression)
             row.storage shouldEqual account.script.map(_.storage.expression)
@@ -373,7 +373,7 @@ class TezosDatabaseOperationsTest
           case (row, (id, account)) =>
             row.accountId shouldEqual id.id
             row.blockId shouldEqual hashUpdate
-            row.delegate shouldEqual account.delegate.map(_.value)
+            row.delegate shouldEqual account.delegate.flatMap(_.right.map(_.value).toOption)
             row.counter shouldEqual account.counter
             row.script shouldEqual account.script.map(_.code.expression)
             row.storage shouldEqual account.script.map(_.storage.expression)

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
@@ -49,8 +49,10 @@ trait TezosDataGeneration extends RandomGenerationKit {
         Account(
           balance = rnd.nextInt,
           counter = Some(currentId),
-          delegate = Some(PublicKeyHash("delegate-value")),
-          script = Some(Contracts(Micheline("storage"), Micheline("script")))
+          delegate = Some(Right(PublicKeyHash("delegate-value"))),
+          script = Some(Contracts(Micheline("storage"), Micheline("script"))),
+          manager = None,
+          spendable = None
         )
     }.toMap
 

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
@@ -129,7 +129,11 @@ class TezosPlatformDiscoveryOperationsTest
             Attribute("script", "Script", DataType.String, None, KeyType.NonKey, "accounts"),
             Attribute("storage", "Storage", DataType.String, None, KeyType.NonKey, "accounts"),
             Attribute("balance", "Balance", DataType.Decimal, None, KeyType.NonKey, "accounts"),
-            Attribute("block_level", "Block level", DataType.Decimal, None, KeyType.UniqueKey, "accounts")
+            Attribute("block_level", "Block level", DataType.Decimal, None, KeyType.UniqueKey, "accounts"),
+            Attribute("manager", "Manager", DataType.String, None, KeyType.NonKey, "accounts"),
+            Attribute("spendable", "Spendable", DataType.Boolean, None, KeyType.NonKey, "accounts"),
+            Attribute("delegate_setable", "Delegate setable", DataType.Boolean, None, KeyType.NonKey, "accounts"),
+            Attribute("delegate_value", "Delegate value", DataType.String, None, KeyType.NonKey, "accounts")
           )
         )
       }

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
@@ -318,7 +318,7 @@ class TezosPlatformDiscoveryOperationsTest
 
         val basicBlocks = generateSingleBlock(1, testReferenceDateTime)
         val account =
-          Account(balance = 12.34, counter = Some(1), delegate = None, script = None)
+          Account(balance = 12.34, counter = Some(1), delegate = None, script = None, manager = None, spendable = None)
 
         val accounts = List(
           BlockTagged(basicBlocks.data.hash, 1, Map(AccountId("id-1") -> account.copy())),
@@ -335,7 +335,7 @@ class TezosPlatformDiscoveryOperationsTest
           .futureValue
           .right
           .get shouldBe List("true", "false")
-         */
+       */
       }
 
       "returns a list of errors when asked for medium attribute of Fees without filter - numeric attributes should not be displayed" in {

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosTypesTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosTypesTest.scala
@@ -197,7 +197,9 @@ class TezosTypesTest extends WordSpec with Matchers with OptionValues {
           balance = 0L,
           counter = Some(0),
           delegate = None,
-          script = Some(Contracts(storage = Micheline("storage code"), code = Micheline("Some code here")))
+          script = Some(Contracts(storage = Micheline("storage code"), code = Micheline("Some code here"))),
+          manager = None,
+          spendable = None
         )
 
         sut.scriptLens.getOption(account).value shouldBe "Some code here"
@@ -209,7 +211,9 @@ class TezosTypesTest extends WordSpec with Matchers with OptionValues {
           balance = 0L,
           counter = Some(0),
           delegate = None,
-          script = None
+          script = None,
+          manager = None,
+          spendable = None
         )
 
         sut.scriptLens.getOption(account) shouldBe 'empty
@@ -221,7 +225,9 @@ class TezosTypesTest extends WordSpec with Matchers with OptionValues {
           balance = 0L,
           counter = Some(0),
           delegate = None,
-          script = Some(Contracts(storage = Micheline("storage code"), code = Micheline("Some code here")))
+          script = Some(Contracts(storage = Micheline("storage code"), code = Micheline("Some code here"))),
+          manager = None,
+          spendable = None
         )
 
         val updated = sut.scriptLens.modify(old => old + "; new code")(account)


### PR DESCRIPTION
Fix #587 

Accepts both the old and new json encoding of accounts and store both data formats in a single database table schema.

## Required database changes

The new definition for the accounts table should be

```sql
CREATE TABLE public.accounts (
    account_id character varying NOT NULL,
    block_id character varying NOT NULL,
    delegate character varying,
    counter integer,
    script character varying,
    storage character varying,
    balance numeric NOT NULL,
    block_level numeric DEFAULT '-1'::integer NOT NULL,
    manager character varying, -- retro-compat from protocol 5+
    spendable boolean, -- retro-compat from protocol 5+
    delegate_setable boolean, -- retro-compat from protocol 5+
    delegate_value char varying -- retro-compat from protocol 5+
);
```