### PR TITLE
593 - removed delegate column from accounts table

### DIFF
--- a/sql/conseil.sql
+++ b/sql/conseil.sql
@@ -51,7 +51,6 @@ SET default_with_oids = false;
 CREATE TABLE tezos.accounts (
     account_id character varying NOT NULL,
     block_id character varying NOT NULL,
-    delegate character varying,
     counter integer,
     script character varying,
     storage character varying,
@@ -67,7 +66,6 @@ CREATE TABLE tezos.accounts (
 CREATE TABLE tezos.accounts_history (
     account_id character varying NOT NULL,
     block_id character varying NOT NULL,
-    delegate character varying,
     counter integer,
     script character varying,
     storage character varying,

--- a/src/main/scala/tech/cryptonomic/conseil/Conseil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Conseil.scala
@@ -147,7 +147,6 @@ object Conseil
     lazy val platformDiscovery = PlatformDiscovery(metadataService)
     lazy val data = Data(platforms, metadataService, server, metadataOverrides, apiOperations)(tezosDispatcher)
 
-
     val validateApiKey: Directive[Tuple1[String]] = optionalHeaderValueByName("apikey").tflatMap[Tuple1[String]] {
       apiKeyTuple =>
         val apiKey = apiKeyTuple match {

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
@@ -57,6 +57,7 @@ object DatabaseConversions {
 
       val toDelegateValue: Option[AccountDelegate] => Option[String] = delegate =>
         PartialFunction.condOpt(delegate) {
+          case Some(Left(Protocol4Delegate(_, Some(pkh)))) => pkh.value
           case Some(Right(pkh)) => pkh.value
         }
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
@@ -50,11 +50,6 @@ object DatabaseConversions {
 
   implicit val blockAccountsToAccountRows =
     new Conversion[List, BlockTagged[Map[AccountId, Account]], Tables.AccountsRow] {
-      val toDelegateKeyHash: Option[AccountDelegate] => Option[String] = delegate =>
-        PartialFunction.condOpt(delegate) {
-          case Some(Right(pkh)) => pkh.value
-        }
-
       val toDelegateSetable: Option[AccountDelegate] => Option[Boolean] = delegate =>
         PartialFunction.condOpt(delegate) {
           case Some(Left(Protocol4Delegate(setable, _))) => setable
@@ -73,7 +68,6 @@ object DatabaseConversions {
             Tables.AccountsRow(
               accountId = id.id,
               blockId = hash.value,
-              delegate = toDelegateKeyHash(delegate),
               counter = counter,
               script = script.map(_.code.expression),
               storage = script.map(_.storage.expression),

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
@@ -57,7 +57,6 @@ object DatabaseConversions {
 
       val toDelegateValue: Option[AccountDelegate] => Option[String] = delegate =>
         PartialFunction.condOpt(delegate) {
-          case Some(Left(Protocol4Delegate(_, Some(pkh)))) => pkh.value
           case Some(Right(pkh)) => pkh.value
         }
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
@@ -37,7 +37,6 @@ trait Tables {
   /** Entity class storing rows of table Accounts
     *  @param accountId Database column account_id SqlType(varchar), PrimaryKey
     *  @param blockId Database column block_id SqlType(varchar)
-    *  @param delegate Database column delegate SqlType(varchar), Default(None)
     *  @param counter Database column counter SqlType(int4), Default(None)
     *  @param script Database column script SqlType(varchar), Default(None)
     *  @param storage Database column storage SqlType(varchar), Default(None)
@@ -50,7 +49,6 @@ trait Tables {
   case class AccountsRow(
       accountId: String,
       blockId: String,
-      delegate: Option[String] = None,
       counter: Option[Int] = None,
       script: Option[String] = None,
       storage: Option[String] = None,
@@ -65,8 +63,8 @@ trait Tables {
   /** GetResult implicit for fetching AccountsRow objects using plain SQL queries */
   implicit def GetResultAccountsRow(
       implicit e0: GR[String],
-      e1: GR[Option[String]],
-      e2: GR[Option[Int]],
+      e1: GR[Option[Int]],
+      e2: GR[Option[String]],
       e3: GR[scala.math.BigDecimal],
       e4: GR[Option[Boolean]]
   ): GR[AccountsRow] = GR { prs =>
@@ -75,7 +73,6 @@ trait Tables {
       (
         <<[String],
         <<[String],
-        <<?[String],
         <<?[Int],
         <<?[String],
         <<?[String],
@@ -95,7 +92,6 @@ trait Tables {
       (
         accountId,
         blockId,
-        delegate,
         counter,
         script,
         storage,
@@ -113,7 +109,6 @@ trait Tables {
         (
           Rep.Some(accountId),
           Rep.Some(blockId),
-          delegate,
           counter,
           script,
           storage,
@@ -126,8 +121,7 @@ trait Tables {
         )
       ).shaped.<>(
         { r =>
-          import r._;
-          _1.map(_ => AccountsRow.tupled((_1.get, _2.get, _3, _4, _5, _6, _7.get, _8.get, _9, _10, _11, _12)))
+          import r._; _1.map(_ => AccountsRow.tupled((_1.get, _2.get, _3, _4, _5, _6.get, _7.get, _8, _9, _10, _11)))
         },
         (_: Any) => throw new Exception("Inserting into ? projection not supported.")
       )
@@ -137,9 +131,6 @@ trait Tables {
 
     /** Database column block_id SqlType(varchar) */
     val blockId: Rep[String] = column[String]("block_id")
-
-    /** Database column delegate SqlType(varchar), Default(None) */
-    val delegate: Rep[Option[String]] = column[Option[String]]("delegate", O.Default(None))
 
     /** Database column counter SqlType(int4), Default(None) */
     val counter: Rep[Option[Int]] = column[Option[Int]]("counter", O.Default(None))
@@ -249,7 +240,6 @@ trait Tables {
   /** Entity class storing rows of table AccountsHistory
     *  @param accountId Database column account_id SqlType(varchar)
     *  @param blockId Database column block_id SqlType(varchar)
-    *  @param delegate Database column delegate SqlType(varchar), Default(None)
     *  @param counter Database column counter SqlType(int4), Default(None)
     *  @param script Database column script SqlType(varchar), Default(None)
     *  @param storage Database column storage SqlType(varchar), Default(None)
@@ -263,7 +253,6 @@ trait Tables {
   case class AccountsHistoryRow(
       accountId: String,
       blockId: String,
-      delegate: Option[String] = None,
       counter: Option[Int] = None,
       script: Option[String] = None,
       storage: Option[String] = None,
@@ -279,8 +268,8 @@ trait Tables {
   /** GetResult implicit for fetching AccountsHistoryRow objects using plain SQL queries */
   implicit def GetResultAccountsHistoryRow(
       implicit e0: GR[String],
-      e1: GR[Option[String]],
-      e2: GR[Option[Int]],
+      e1: GR[Option[Int]],
+      e2: GR[Option[String]],
       e3: GR[scala.math.BigDecimal],
       e4: GR[Option[Boolean]],
       e5: GR[java.sql.Timestamp]
@@ -290,7 +279,6 @@ trait Tables {
       (
         <<[String],
         <<[String],
-        <<?[String],
         <<?[Int],
         <<?[String],
         <<?[String],
@@ -312,7 +300,6 @@ trait Tables {
       (
         accountId,
         blockId,
-        delegate,
         counter,
         script,
         storage,
@@ -331,7 +318,6 @@ trait Tables {
         (
           Rep.Some(accountId),
           Rep.Some(blockId),
-          delegate,
           counter,
           script,
           storage,
@@ -347,7 +333,7 @@ trait Tables {
         { r =>
           import r._;
           _1.map(
-            _ => AccountsHistoryRow.tupled((_1.get, _2.get, _3, _4, _5, _6, _7.get, _8.get, _9, _10, _11, _12, _13.get))
+            _ => AccountsHistoryRow.tupled((_1.get, _2.get, _3, _4, _5, _6.get, _7.get, _8, _9, _10, _11, _12.get))
           )
         },
         (_: Any) => throw new Exception("Inserting into ? projection not supported.")
@@ -358,9 +344,6 @@ trait Tables {
 
     /** Database column block_id SqlType(varchar) */
     val blockId: Rep[String] = column[String]("block_id")
-
-    /** Database column delegate SqlType(varchar), Default(None) */
-    val delegate: Rep[Option[String]] = column[Option[String]]("delegate", O.Default(None))
 
     /** Database column counter SqlType(int4), Default(None) */
     val counter: Rep[Option[Int]] = column[Option[Int]]("counter", O.Default(None))
@@ -1352,55 +1335,53 @@ trait Tables {
 
     /** Maps whole row to an option. Useful for outer joins. */
     def ? =
-      (branch :: numberOfSlots :: cycle :: Rep.Some(operationId) :: Rep.Some(operationGroupHash) :: Rep.Some(kind) :: level :: delegate :: slots :: nonce :: pkh :: secret :: source :: fee :: counter :: gasLimit :: storageLimit :: publicKey :: amount :: destination :: parameters :: managerPubkey :: balance :: proposal :: spendable :: delegatable :: script :: storage :: status :: consumedGas :: storageSize :: paidStorageSizeDiff :: originatedContracts :: Rep
-            .Some(
-              blockHash
-            ) :: Rep.Some(blockLevel) :: ballot :: Rep.Some(internal) :: period :: Rep.Some(timestamp) :: HNil).shaped
-        .<>(
-          r =>
-            OperationsRow(
-              r(0).asInstanceOf[Option[String]],
-              r(1).asInstanceOf[Option[Int]],
-              r(2).asInstanceOf[Option[Int]],
-              r(3).asInstanceOf[Option[Int]].get,
-              r(4).asInstanceOf[Option[String]].get,
-              r(5).asInstanceOf[Option[String]].get,
-              r(6).asInstanceOf[Option[Int]],
-              r(7).asInstanceOf[Option[String]],
-              r(8).asInstanceOf[Option[String]],
-              r(9).asInstanceOf[Option[String]],
-              r(10).asInstanceOf[Option[String]],
-              r(11).asInstanceOf[Option[String]],
-              r(12).asInstanceOf[Option[String]],
-              r(13).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(14).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(15).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(16).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(17).asInstanceOf[Option[String]],
-              r(18).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(19).asInstanceOf[Option[String]],
-              r(20).asInstanceOf[Option[String]],
-              r(21).asInstanceOf[Option[String]],
-              r(22).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(23).asInstanceOf[Option[String]],
-              r(24).asInstanceOf[Option[Boolean]],
-              r(25).asInstanceOf[Option[Boolean]],
-              r(26).asInstanceOf[Option[String]],
-              r(27).asInstanceOf[Option[String]],
-              r(28).asInstanceOf[Option[String]],
-              r(29).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(30).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(31).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(32).asInstanceOf[Option[String]],
-              r(33).asInstanceOf[Option[String]].get,
-              r(34).asInstanceOf[Option[Int]].get,
-              r(35).asInstanceOf[Option[String]],
-              r(36).asInstanceOf[Option[Boolean]].get,
-              r(37).asInstanceOf[Option[Int]],
-              r(38).asInstanceOf[Option[java.sql.Timestamp]].get
-            ),
-          (_: Any) => throw new Exception("Inserting into ? projection not supported.")
-        )
+      (branch :: numberOfSlots :: cycle :: Rep.Some(operationId) :: Rep.Some(operationGroupHash) :: Rep.Some(kind) :: level :: delegate :: slots :: nonce :: pkh :: secret :: source :: fee :: counter :: gasLimit :: storageLimit :: publicKey :: amount :: destination :: parameters :: managerPubkey :: balance :: proposal :: spendable :: delegatable :: script :: storage :: status :: consumedGas :: storageSize :: paidStorageSizeDiff :: originatedContracts :: Rep.Some(
+            blockHash
+          ) :: Rep.Some(blockLevel) :: ballot :: Rep.Some(internal) :: period :: Rep.Some(timestamp) :: HNil).shaped.<>(
+        r =>
+          OperationsRow(
+            r(0).asInstanceOf[Option[String]],
+            r(1).asInstanceOf[Option[Int]],
+            r(2).asInstanceOf[Option[Int]],
+            r(3).asInstanceOf[Option[Int]].get,
+            r(4).asInstanceOf[Option[String]].get,
+            r(5).asInstanceOf[Option[String]].get,
+            r(6).asInstanceOf[Option[Int]],
+            r(7).asInstanceOf[Option[String]],
+            r(8).asInstanceOf[Option[String]],
+            r(9).asInstanceOf[Option[String]],
+            r(10).asInstanceOf[Option[String]],
+            r(11).asInstanceOf[Option[String]],
+            r(12).asInstanceOf[Option[String]],
+            r(13).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(14).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(15).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(16).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(17).asInstanceOf[Option[String]],
+            r(18).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(19).asInstanceOf[Option[String]],
+            r(20).asInstanceOf[Option[String]],
+            r(21).asInstanceOf[Option[String]],
+            r(22).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(23).asInstanceOf[Option[String]],
+            r(24).asInstanceOf[Option[Boolean]],
+            r(25).asInstanceOf[Option[Boolean]],
+            r(26).asInstanceOf[Option[String]],
+            r(27).asInstanceOf[Option[String]],
+            r(28).asInstanceOf[Option[String]],
+            r(29).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(30).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(31).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(32).asInstanceOf[Option[String]],
+            r(33).asInstanceOf[Option[String]].get,
+            r(34).asInstanceOf[Option[Int]].get,
+            r(35).asInstanceOf[Option[String]],
+            r(36).asInstanceOf[Option[Boolean]].get,
+            r(37).asInstanceOf[Option[Int]],
+            r(38).asInstanceOf[Option[java.sql.Timestamp]].get
+          ),
+        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
+      )
 
     /** Database column branch SqlType(varchar), Default(None) */
     val branch: Rep[Option[String]] = column[Option[String]]("branch", O.Default(None))

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
@@ -307,7 +307,6 @@ class TezosDatabaseOperationsTest
           case (row, (id, account)) =>
             row.accountId shouldEqual id.id
             row.blockId shouldEqual block.hash
-            row.delegate shouldEqual account.delegate.flatMap(_.right.map(_.value).toOption)
             row.counter shouldEqual account.counter
             row.script shouldEqual account.script.map(_.code.expression)
             row.storage shouldEqual account.script.map(_.storage.expression)
@@ -374,7 +373,6 @@ class TezosDatabaseOperationsTest
           case (row, (id, account)) =>
             row.accountId shouldEqual id.id
             row.blockId shouldEqual hashUpdate
-            row.delegate shouldEqual account.delegate.flatMap(_.right.map(_.value).toOption)
             row.counter shouldEqual account.counter
             row.script shouldEqual account.script.map(_.code.expression)
             row.storage shouldEqual account.script.map(_.storage.expression)
@@ -2149,7 +2147,6 @@ class TezosDatabaseOperationsTest
         accountId = 1.toString,
         blockId = "R0NpYZuUeF",
         blockLevel = 0,
-        delegate = None,
         counter = None,
         script = None,
         balance = BigDecimal(1.45)
@@ -3002,7 +2999,6 @@ class TezosDatabaseOperationsTest
         val ahr = AccountsHistoryRow(
           "id",
           "blockid",
-          None,
           None,
           None,
           None,

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
@@ -352,7 +352,6 @@ trait TezosDataGeneration extends RandomGenerationKit {
         blockId = block.hash,
         balance = 0,
         counter = Some(0),
-        delegate = None,
         script = None
       )
     }.toList

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
@@ -124,7 +124,6 @@ class TezosPlatformDiscoveryOperationsTest
           Set(
             Attribute("account_id", "Account id", DataType.String, None, KeyType.UniqueKey, "accounts"),
             Attribute("block_id", "Block id", DataType.String, None, KeyType.NonKey, "accounts"),
-            Attribute("delegate", "Delegate", DataType.String, None, KeyType.NonKey, "accounts"),
             Attribute("counter", "Counter", DataType.Int, None, KeyType.NonKey, "accounts"),
             Attribute("script", "Script", DataType.String, None, KeyType.NonKey, "accounts"),
             Attribute("storage", "Storage", DataType.String, None, KeyType.NonKey, "accounts"),


### PR DESCRIPTION
closes #593 

### Required database changes:

`delegate` column needs to be removed from the `accounts` table.