### PR TITLE
Remove hard coding from conseil.sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,14 @@ The application expects to read and write from a database compatible with [Types
 
 ##### Using a database instance
 
-Cryptonomic uses Postgres for all its Conseil deployments. Once a Postgres database is set up, `doc/conseil.sql` can be used to set up the latest schema.
+Cryptonomic uses Postgres for all its Conseil deployments. Once a Postgres database is set up, `sql/conseil.sql` can be used to set up the latest schema.
+
+Please note that until a fix is put in place, you will have to execute the following instaces after applying the latest SQL schema. `$conseil-user` and `$conseil-database` should be replaced with actual values:
+
+```sql
+ALTER ROLE $conseil-user SET search_path TO tezos,public;
+ALTER DATABASE "$conseil-database" SET search_path TO tezos,public;
+```
 
 *For non-Postgres databases*: the schema file might have to be updated to reflect the idiosyncrasies of the particular SQL dialect being used.
 Additionally you will probably need to generate the proper scala classes and update the codebase to use a different db-profile with Slick. To generate the code from a running up-to-date database you can run the sbt task from the project root:

--- a/sql/conseil.sql
+++ b/sql/conseil.sql
@@ -20,8 +20,6 @@ SET row_security = off;
 
 SET default_tablespace = '';
 CREATE SCHEMA IF NOT EXISTS tezos;
-ALTER ROLE conseiluser SET search_path TO tezos,public;
-ALTER DATABASE "conseil-local" SET search_path TO tezos,public;
 
 --
 -- Name: truncate_tables(character varying); Type: FUNCTION; Schema: tezos; Owner: -


### PR DESCRIPTION
The hard coded user name and database name in the SQL file is breaking our infrastructure deployments. 