### PR TITLE
623 - fix the json decoding of new formats for big_map results on transactions

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -151,11 +151,44 @@ object TezosTypes {
   final case class InvalidDecimal(jsonString: String) extends BigNumber
 
   object Contract {
-    final case class BigMapDiff(
+
+    /** retro-compat adapter from protocol 5+ */
+    type CompatBigMapDiff = Either[BigMapDiff, Protocol4BigMapDiff]
+
+    final case class Protocol4BigMapDiff(
         key_hash: ScriptId,
         key: Micheline,
         value: Option[Micheline]
     )
+
+    sealed trait BigMapDiff extends Product with Serializable
+
+    final case class BigMapDiffUpdate(
+        action: String,
+        key: Micheline,
+        key_hash: ScriptId,
+        big_map: BigNumber,
+        value: Option[Micheline]
+    ) extends BigMapDiff
+
+    final case class BigMapDiffCopy(
+        action: String,
+        source_big_map: BigNumber,
+        destination_big_map: BigNumber
+    ) extends BigMapDiff
+
+    final case class BigMapDiffAlloc(
+        action: String,
+        big_map: BigNumber,
+        key_type: Micheline,
+        value_type: Micheline
+    ) extends BigMapDiff
+
+    final case class BigMapDiffRemove(
+        action: String,
+        big_map: BigNumber
+    ) extends BigMapDiff
+
   }
 
   object Scripted {
@@ -330,7 +363,7 @@ object TezosTypes {
         status: String,
         allocated_destination_contract: Option[Boolean],
         balance_updates: Option[List[OperationMetadata.BalanceUpdate]],
-        big_map_diff: Option[List[Contract.BigMapDiff]],
+        big_map_diff: Option[List[Contract.CompatBigMapDiff]],
         consumed_gas: Option[BigNumber],
         originated_contracts: Option[List[ContractId]],
         paid_storage_size_diff: Option[BigNumber],

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTest.scala
@@ -10,6 +10,7 @@ class JsonDecodersTest extends WordSpec with Matchers with EitherValues with Opt
 
   import JsonDecoders.Circe.Accounts._
   import JsonDecoders.Circe.Numbers._
+  import JsonDecoders.Circe.BigMapDiff._
   import JsonDecoders.Circe.Operations._
   import JsonDecoders.Circe.Scripts._
   import JsonDecoders.Circe.Votes._
@@ -282,9 +283,39 @@ class JsonDecodersTest extends WordSpec with Matchers with EitherValues with Opt
         decoded shouldBe 'left
       }
 
-      "decode valid json into a BigMapDiff value" in new OperationsJsonData {
-        val decoded = decode[Contract.BigMapDiff](bigmapdiffJson)
-        decoded.right.value shouldEqual expectedBigMapDiff
+      "decode valid protocol4 json into a BigMapDiff value" in new OperationsJsonData {
+        val decoded = decode[Contract.CompatBigMapDiff](p4BigmapdiffJson)
+        decoded shouldBe 'right
+        decoded.right.value shouldBe 'right
+        decoded.right.value.right.value shouldEqual expectedP4BigMapDiff
+      }
+
+      "decode valid json into a BigMapDiffUpdate value" in new OperationsJsonData {
+        val decoded = decode[Contract.CompatBigMapDiff](bigmapdiffUpdateJson)
+        decoded shouldBe 'right
+        decoded.right.value shouldBe 'left
+        decoded.right.value.left.value shouldEqual expectedBigmapdiffUpdate
+      }
+
+      "decode valid json into a BigMapDiffCopy value" in new OperationsJsonData {
+        val decoded = decode[Contract.CompatBigMapDiff](bigmapdiffCopyJson)
+        decoded shouldBe 'right
+        decoded.right.value shouldBe 'left
+        decoded.right.value.left.value shouldEqual expectedBigmapdiffCopy
+      }
+
+      "decode valid json into a BigMapDiffAlloc value" in new OperationsJsonData {
+        val decoded = decode[Contract.CompatBigMapDiff](bigmapdiffAllocJson)
+        decoded shouldBe 'right
+        decoded.right.value shouldBe 'left
+        decoded.right.value.left.value shouldEqual expectedBigmapdiffAlloc
+      }
+
+      "decode valid json into a BigMapDiffRemove value" in new OperationsJsonData {
+        val decoded = decode[Contract.CompatBigMapDiff](bigmapdiffRemoveJson)
+        decoded shouldBe 'right
+        decoded.right.value shouldBe 'left
+        decoded.right.value.left.value shouldEqual expectedBigmapdiffRemove
       }
 
       "decode valid json into a Scipted.Contracts value" in new OperationsJsonData {

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTestFixtures.scala
@@ -309,14 +309,77 @@ trait OperationsJsonData {
     """{"prim":"code","args":[{"prim":"CAR"},{"prim":"NIL","args":[{"prim":"operation"}]},{"prim":"PAIR"}]}"""
   )
 
-  val bigmapdiffJson =
+  val bigmapdiffAllocJson =
+    s"""{
+    |  "action": "alloc",
+    |  "big_map": "428",
+    |  "key_type": {
+    |      "prim": "int"
+    |  },
+    |  "value_type": {
+    |      "prim": "int"
+    |  }
+    |}""".stripMargin
+
+  val expectedBigmapdiffAlloc =
+      Contract.BigMapDiffAlloc(
+        action = "alloc",
+        big_map = Decimal(BigDecimal(428)),
+        key_type = Micheline("""{"prim":"int"}"""),
+        value_type = Micheline("""{"prim":"int"}""")
+      )
+
+  val bigmapdiffUpdateJson =
+    s"""{
+    |  "action": "update",
+    |  "key_hash": "tz1fyvFH2pd3V9UEq5psqVokVBYkt7rHTKio",
+    |  "key": $michelineJson,
+    |  "big_map": "428"
+    |}""".stripMargin
+
+  val expectedBigmapdiffUpdate =
+    Contract.BigMapDiffUpdate(
+      action = "update",
+      key_hash = ScriptId("tz1fyvFH2pd3V9UEq5psqVokVBYkt7rHTKio"),
+      key = expectedMicheline,
+      big_map = Decimal(BigDecimal(428)),
+      value = None
+    )
+
+  val bigmapdiffCopyJson =
+    s"""{
+    |  "action": "copy",
+    |  "source_big_map": "428",
+    |  "destination_big_map": "748"
+    |}""".stripMargin
+
+  val expectedBigmapdiffCopy =
+    Contract.BigMapDiffCopy(
+      action = "copy",
+      source_big_map = Decimal(BigDecimal(428)),
+      destination_big_map = Decimal(BigDecimal(748))
+    )
+
+  val bigmapdiffRemoveJson =
+    s"""{
+    |  "action": "remove",
+    |  "big_map": "428"
+    |}""".stripMargin
+
+  val expectedBigmapdiffRemove =
+    Contract.BigMapDiffRemove(
+      action = "remove",
+      big_map = Decimal(BigDecimal(428))
+    )
+
+  val p4BigmapdiffJson =
     s"""{
     |  "key_hash": "tz1fyvFH2pd3V9UEq5psqVokVBYkt7rHTKio",
     |  "key": $michelineJson
     |}""".stripMargin
 
-  val expectedBigMapDiff =
-    Contract.BigMapDiff(
+  val expectedP4BigMapDiff =
+    Contract.Protocol4BigMapDiff(
       key_hash = ScriptId("tz1fyvFH2pd3V9UEq5psqVokVBYkt7rHTKio"),
       key = expectedMicheline,
       value = None


### PR DESCRIPTION
Fixes #623 

The referenced json-schema can be currently fetched from

`https://<tezos-node-host:port>/describe/chains/main/blocks/head/operations`

or any equivalent endpoint of a valid tezos node