### PR TITLE
634 - Add regular expression support to select accounts updates for chain events like airdrop

### DIFF
--- a/docs/extra-custom-config.md
+++ b/docs/extra-custom-config.md
@@ -1,4 +1,4 @@
-#### Additional fine-grained configuration
+### Additional fine-grained configuration
 
 You might want to override, _only after careful testing_, part of the following configuration entries
 
@@ -98,3 +98,29 @@ lorre.db {
   maxConnections: 10
 }
 ```
+
+### Chain's "one-off" events handling
+
+To support out-of-the ordinary processing on the data collected and exposed by Conseil, the Lorre configuration supports special handling for generally-named "Chain Events".
+
+Such events might be identified by the Block Level when they need to be handled.
+Currently we only support one type of event, namely
+
+ * `AccountsRefresh`: upon reaching certain levels, Lorre plans a full or partial reload of accounts data
+   from the rpc node. This is instrumental, for example, to take into account the Tezos airdrop after Babylon protocol switch, that impacted many delegated contracts.
+
+The configuration entry specifies, for the running Lorre instance, after which levels such "refresh" is needed, and allows to define a regular expression pattern to select only part of the accounts' hashes.
+
+It will look like the following excerpt
+```
+lorre.chainEvents: [
+  {
+    type: accountsRefresh,
+    levels: {
+      "tz1.*": [655000],
+      ".*"   : [655361]
+    }
+  }
+]
+```
+Here there's a request for `tz1` accounts after level `655000`, and a global one at level `655361`.

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -90,7 +90,7 @@ lorre {
   chainEvents: [
     {
       type: accountsRefresh,
-      levels: []
+      levels: {}
     }
   ]
 

--- a/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
@@ -42,6 +42,8 @@ import tech.cryptonomic.conseil.tezos.TezosTypes.BlockHash
   */
 object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig with LorreOutput {
 
+  type AccountUpdatesEvents = SortedSet[(Int, ChainEvent.AccountIdPattern)]
+
   //reads all configuration upstart, will only complete if all values are found
 
   val config = loadApplicationConfiguration(args)
@@ -110,18 +112,26 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
     }
 
   // Finds unprocessed levels for account refreshes (i.e. when there is a need to reload all accounts data from the chain)
-  private def unprocessedLevelsForRefreshingAccounts() =
+  private def unprocessedLevelsForRefreshingAccounts(): Future[AccountUpdatesEvents] =
     lorreConf.chainEvents.collectFirst {
       case ChainEvent.AccountsRefresh(levelsNeedingRefresh) if levelsNeedingRefresh.nonEmpty =>
         db.run(TezosDb.fetchProcessedEventsLevels(ChainEvent.accountsRefresh.render)).map { levels =>
+          //used to remove processed events
           val processed = levels.map(_.intValue).toSet
-          levelsNeedingRefresh.filterNot(processed).sorted
+          //we want individual event levels with the associated pattern, such that we can sort them by level
+          val unprocessedEvents = levelsNeedingRefresh.toList.flatMap {
+            case (accountPattern, levels) => levels.filterNot(processed).sorted.map(_ -> accountPattern)
+          }
+          SortedSet(unprocessedEvents: _*)
         }
-    }.getOrElse(Future.successful(List.empty))
+    }.getOrElse(Future.successful(SortedSet.empty))
 
   /** The regular loop, once connection with the node is established */
   @tailrec
-  private[this] def mainLoop(iteration: Int, accountsRefreshLevels: SortedSet[Int]): Unit = {
+  private[this] def mainLoop(
+      iteration: Int,
+      accountsRefreshLevels: AccountUpdatesEvents
+  ): Unit = {
     val noOp = Future.successful(())
     val processing = for {
       nextRefreshes <- processAccountRefreshes(accountsRefreshLevels)
@@ -165,25 +175,26 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
   try {
     checkTezosConnection()
     val accountRefreshesToRun = Await.result(unprocessedLevelsForRefreshingAccounts(), atMost = 5.seconds)
-    mainLoop(0, SortedSet(accountRefreshesToRun: _*))
+    mainLoop(0, accountRefreshesToRun)
   } finally {
     shutdown()
   }
 
   /* Possibly updates all accounts if the current block level is past any of the given ones
-   * @param levels the relevant levels that calls for a refresh
+   * @param events the relevant levels, each with its own selection pattern, that calls for a refresh
    */
-  private def processAccountRefreshes(levels: SortedSet[Int]): Future[SortedSet[Int]] =
-    if (levels.nonEmpty) {
+  private def processAccountRefreshes(events: AccountUpdatesEvents): Future[AccountUpdatesEvents] =
+    if (events.nonEmpty) {
       for {
         storedHead <- apiOperations.fetchMaxLevel
-        updated <- if (levels.exists(_ <= storedHead)) {
-          val (past, toCome) = levels.partition(_ <= storedHead)
+        updated <- if (events.exists(_._1 <= storedHead)) {
+          val (past, toCome) = events.partition(_._1 <= storedHead)
+          val (levels, selectors) = past.unzip
           logger.info(
             "A block was reached that requires an update of account data as specified in the configuration file. A full refresh is now underway. Relevant block levels: {}",
-            past.mkString(", ")
+            levels.mkString(", ")
           )
-          apiOperations.fetchBlockAtLevel(past.max).flatMap {
+          apiOperations.fetchBlockAtLevel(levels.max).flatMap {
             case Some(referenceBlockForRefresh) =>
               val (hashRef, levelRef, timestamp) =
                 (
@@ -193,10 +204,10 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
                 )
               db.run(
                   //put all accounts in checkpoint, log the past levels to the db, keep the rest for future cycles
-                  TezosDb.refillAccountsCheckpointFromExisting(hashRef, levelRef, timestamp) >>
+                  TezosDb.refillAccountsCheckpointFromExisting(hashRef, levelRef, timestamp, selectors.toSet) >>
                       TezosDb.writeProcessedEventsLevels(
                         ChainEvent.accountsRefresh.render,
-                        past.map(BigDecimal(_)).toList
+                        levels.map(BigDecimal(_)).toList
                       )
                 )
                 .andThen {
@@ -215,13 +226,13 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
             case None =>
               logger.warn(
                 "I couldn't find in Conseil the block data at level {}, required for the general accounts update, and this is actually unexpected. I'll retry the whole operation at next cycle.",
-                past.max
+                levels.max
               )
-              Future.successful(levels)
+              Future.successful(events)
           }
-        } else Future.successful(levels)
+        } else Future.successful(events)
       } yield updated
-    } else Future.successful(levels)
+    } else Future.successful(events)
 
   /**
     * Fetches all blocks not in the database from the Tezos network and adds them to the database.

--- a/src/main/scala/tech/cryptonomic/conseil/config/Shared.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/config/Shared.scala
@@ -16,6 +16,8 @@ sealed trait ChainEvent extends Product with Serializable
 
 object ChainEvent {
 
+  type AccountIdPattern = String
+
   //used to store strings as typed enumerated values with no runtime overhead, and custom rendering
   case class ChainEventType private (render: String) extends AnyVal with Product with Serializable
 
@@ -23,7 +25,7 @@ object ChainEvent {
   val accountsRefresh = ChainEventType("accountsRefresh")
 
   //these will be used as values
-  final case class AccountsRefresh(levels: List[Int]) extends ChainEvent
+  final case class AccountsRefresh(levels: Map[String, List[Int]]) extends ChainEvent
 
 }
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
@@ -4,6 +4,7 @@ import java.time.Instant
 
 import com.typesafe.scalalogging.LazyLogging
 import slick.jdbc.PostgresProfile.api._
+import tech.cryptonomic.conseil.config.ChainEvent.AccountIdPattern
 import tech.cryptonomic.conseil.generic.chain.DataTypes.{Query => _, _}
 import tech.cryptonomic.conseil.tezos.FeeOperations._
 import tech.cryptonomic.conseil.tezos.TezosTypes._
@@ -222,19 +223,50 @@ object TezosDatabaseOperations extends LazyLogging {
     * Takes all existing account ids and puts them in the
     * checkpoint to be later reloaded, based on the passed block reference
     */
-  def refillAccountsCheckpointFromExisting(hash: BlockHash, level: Int, timestamp: Instant)(
+  def refillAccountsCheckpointFromExisting(
+      hash: BlockHash,
+      level: Int,
+      timestamp: Instant,
+      selectors: Set[AccountIdPattern] = Set(".*")
+  )(
       implicit ec: ExecutionContext
   ): DBIO[Option[Int]] = {
+
+    /* as taken almost literally from this S.O. suggestion
+     * https://stackoverflow.com/questions/46218122/slick-is-there-a-way-to-create-a-where-clause-with-a-regex
+     * will add the postgres '~' operator to slick filters, to do regular expression matching
+     */
+    implicit class postgresPosixRegexMatch(value: Rep[String]) {
+      def ~(pattern: Rep[String]): Rep[Boolean] = {
+        val expr = SimpleExpression.binary[String, String, Boolean] { (v, pat, builder) =>
+          builder.expr(v)
+          builder.sqlBuilder += " ~ "
+          builder.expr(pat)
+        }
+        expr(value, pattern)
+      }
+    }
+
     logger.info(
-      "Fetching all ids for existing accounts and checkpointing them with block hash {}, level {} and time {}",
+      "Fetching all ids for existing accounts matching {} and adding them to checkpoint with block hash {}, level {} and time {}",
+      selectors.mkString(", "),
       hash.value,
       level,
       timestamp
     )
-    Tables.Accounts
-      .map(_.accountId)
-      .distinct
-      .result
+
+    //for each pattern, create a query and then union them all
+    val regexQueries = selectors
+      .map(
+        sel =>
+          Tables.Accounts
+            .filter(_.accountId ~ sel)
+            .map(_.accountId)
+            .distinct
+      )
+      .reduce(_ union _)
+
+    regexQueries.distinct.result
       .flatMap(
         ids =>
           writeAccountsCheckpoint(

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
@@ -3267,6 +3267,58 @@ class TezosDatabaseOperationsTest
         }
       }
 
+      "read selected distinct account ids via regex and add entries for each in the checkpoint" in {
+        //given
+        implicit val randomSeed = RandomSeed(testReferenceTimestamp.getTime)
+
+        val expectedCount = 3
+        val matchingId = AccountId("tz19alkdjf83aadkcl")
+
+        val block = generateBlockRows(1, testReferenceTimestamp).head
+        val BlockTagged(hash, level, ts, accountsContent) =
+          generateAccounts(expectedCount, BlockHash(block.hash), block.level)
+        val updatedContent = accountsContent.map {
+          case (AccountId(id), account) if id == "1" => (matchingId, account)
+          case any => any
+        }
+
+        val accountsInfo = BlockTagged(hash, level, ts, updatedContent)
+
+        val populate =
+          (Tables.Blocks += block) >>
+              sut.writeAccounts(List(accountsInfo))
+
+        val write = dbHandler.run(populate.transactionally)
+
+        write.isReadyWithin(5.seconds) shouldBe true
+
+        //when
+        val dbAction =
+          sut.refillAccountsCheckpointFromExisting(
+            BlockHash(block.hash),
+            block.level,
+            block.timestamp.toInstant,
+            Set("tz1.+")
+          )
+
+        val results = dbHandler.run(dbAction).futureValue
+        results.value shouldBe 1
+
+        //then
+        val checkpoint = dbHandler.run(sut.getLatestAccountsFromCheckpoint).futureValue
+
+        checkpoint.keys.size shouldBe 1
+        checkpoint.keySet should contain only matchingId
+
+        import org.scalatest.Inspectors._
+        forAll(checkpoint.values) {
+          case (hash, level, instantOpt) =>
+            hash.value shouldEqual block.hash
+            level shouldEqual block.level
+            instantOpt.value shouldEqual block.timestamp.toInstant
+        }
+      }
+
     }
 
 }


### PR DESCRIPTION
Closes #634 

To be more exact, w.r.t. the referred issue, the solution accepts more general Posix regular expressions, making use of support from postgres.

The choice is driven by the idea that the patterns will be defined in the configuration file, which should be devoid of a direct reference to the SQL nature of the underlying datastore.

 * add a map structure to define event levels to update only certain
   account ids
 * adapt tests and code
 * add some documentation in the advanced configuration readme

## Changes required to the configuration files

As exemplified in the new documentation section
```coffee
lorre.chainEvents: [
  {
    type: accountsRefresh,
    levels: {
      "tz1.*": [655000],
      ".*"   : [655361]
    }
  }
]
```

in the `lorre` section, the chain-event object for refreshing accounts now expects a `levels` attribute to define a mapping between a regexp string, to match on account-ids, and the corresponding level array that will require updating such accounts.