### PR TITLE
637 - The predicate groups were not being considered to build the query

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/generic/chain/DataTypes.scala
@@ -198,7 +198,8 @@ object DataTypes {
       operation: OperationType,
       set: Option[List[Any]] = Some(List.empty),
       inverse: Option[Boolean] = Some(false),
-      precision: Option[Int] = None
+      precision: Option[Int] = None,
+      group: Option[String] = None
   ) {
 
     /** Method creating Predicate out of ApiPredicate which is received by the API */

--- a/src/main/scala/tech/cryptonomic/conseil/util/DatabaseUtil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/util/DatabaseUtil.scala
@@ -244,9 +244,9 @@ object DatabaseUtil {
         case multiGroups =>
           //first intersperse with internal ORs then add the opening and closing parens
           val orGroups = multiGroups.reduce(
-            (group1, group2) => group1 ::: sql") OR (True " :: group2
+            (group1, group2) => group1 ::: sql") OR (True" :: group2
           )
-          sql" AND (True " :: (orGroups :+ sql") ")
+          sql"AND (True" :: (orGroups :+ sql") ")
       }
     }
 

--- a/src/test/scala/tech/cryptonomic/conseil/util/DatabaseUtilTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/util/DatabaseUtilTest.scala
@@ -1,6 +1,8 @@
 package tech.cryptonomic.conseil.util
 
 import org.scalatest.{Matchers, WordSpec}
+import tech.cryptonomic.conseil.generic.chain.DataTypes.Predicate
+import tech.cryptonomic.conseil.generic.chain.DataTypes.OperationType
 
 class DatabaseUtilTest extends WordSpec with Matchers {
 
@@ -11,13 +13,27 @@ class DatabaseUtilTest extends WordSpec with Matchers {
         sut.insertValuesIntoSqlAction(Seq("a", "b", "c")).queryParts.mkString("") shouldBe "('a','b','c')"
         sut.insertValuesIntoSqlAction(Seq(1, 2, 3)).queryParts.mkString("") shouldBe "('1','2','3')"
       }
+
       "concatenate an empty sequence of values in a sql action" in {
         sut.insertValuesIntoSqlAction(Seq.empty[Any]).queryParts.mkString("") shouldBe "()"
       }
+
       "concatenate a singleton sequence in a sql action" in {
         sut.insertValuesIntoSqlAction(Seq("single")).queryParts.mkString("") shouldBe "('single')"
       }
 
+      "concatenate groups of predicates with OR" in {
+        val predicates =
+          Predicate("fa", OperationType.eq, List("a"), false, None, group = Some("1")) ::
+              Predicate("fb", OperationType.eq, List("b"), false, None, group = Some("1")) ::
+              Predicate("fc", OperationType.eq, List("c"), false, None, group = Some("2")) ::
+              Predicate("fd", OperationType.eq, List("d"), false, None, group = Some("2")) ::
+              Nil
+
+        val first :: rest = sut.makePredicates(predicates)
+        val fragment = sut.concatenateSqlActions(first, rest: _*).queryParts.mkString
+        fragment shouldBe "AND (True AND fa = 'a' AND fb = 'b') OR (True AND fc = 'c' AND fd = 'd') "
+      }
     }
 
 }


### PR DESCRIPTION
Fixes #637 

Previously, the predicate groups passed from the client were not actually considered and passed on to the query engine of conseil, and thus were completely ignored.
This changes address the issue and adds a test to check that the sql is correctly generated.