### PR TITLE
602 - changes to future rights fetching

### DIFF
--- a/sql/conseil.sql
+++ b/sql/conseil.sql
@@ -107,7 +107,7 @@ CREATE TABLE tezos.baking_rights (
     level integer NOT NULL,
     delegate character varying NOT NULL,
     priority integer NOT NULL,
-    estimated_time timestamp without time zone NOT NULL,
+    estimated_time timestamp without time zone,
     cycle integer,
     governance_period integer
 );
@@ -222,7 +222,7 @@ CREATE TABLE tezos.endorsing_rights (
     level integer NOT NULL,
     delegate character varying NOT NULL,
     slot integer NOT NULL,
-    estimated_time timestamp without time zone NOT NULL,
+    estimated_time timestamp without time zone,
     cycle integer,
     governance_period integer
 );

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -144,11 +144,11 @@ lorre {
 
   # Configuration for fetching upcoming baking and endorsing rights
   blockRightsFetching {
-    initDelay: 2 minutes
-    interval: 60 minutes
-    cyclesToFetch: 5
-    cycleSize: 4096
-    fetchSize: 200
+    initDelay: 2 minutes # time before starting fetching rights
+    interval: 60 minutes # interval between fetches
+    cyclesToFetch: 5 # how many cycles we want to fetch
+    cycleSize: 4096 # size of the cycle, by default 4096
+    fetchSize: 200 # amount of rights we fetch at once
   }
 
 }

--- a/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
@@ -86,7 +86,7 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
 
   /** Fetches future baking and endorsing rights to insert it into the DB */
   def writeFutureRights(): Unit = {
-    val berLogger = LoggerFactory.getLogger("BER")
+    val berLogger = LoggerFactory.getLogger("RightsFetcher")
 
     import cats.implicits._
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
@@ -625,7 +625,7 @@ object DatabaseConversions {
         bakingRights
           .into[Tables.BakingRightsRow]
           .withFieldConst(_.blockHash, fetchRights.blockHash.map(_.value))
-          .withFieldConst(_.estimatedTime, toSql(bakingRights.estimated_time))
+          .withFieldConst(_.estimatedTime, bakingRights.estimated_time.map(toSql))
           .withFieldConst(_.cycle, fetchRights.cycle)
           .withFieldConst(_.governancePeriod, fetchRights.governancePeriod)
           .transform
@@ -641,7 +641,7 @@ object DatabaseConversions {
         endorsingRights.slots.map { slot =>
           endorsingRights
             .into[Tables.EndorsingRightsRow]
-            .withFieldConst(_.estimatedTime, toSql(endorsingRights.estimated_time))
+            .withFieldConst(_.estimatedTime, endorsingRights.estimated_time.map(toSql))
             .withFieldConst(_.slot, slot)
             .withFieldConst(_.blockHash, fetchRights.blockHash.map(_.value))
             .withFieldConst(_.cycle, fetchRights.cycle)
@@ -657,7 +657,7 @@ object DatabaseConversions {
       bakingRights
         .into[Tables.BakingRightsRow]
         .withFieldConst(_.blockHash, None)
-        .withFieldConst(_.estimatedTime, toSql(bakingRights.estimated_time))
+        .withFieldConst(_.estimatedTime, bakingRights.estimated_time.map(toSql))
         .transform
     }
   }
@@ -669,7 +669,7 @@ object DatabaseConversions {
         endorsingRights.slots.map { slot =>
           endorsingRights
             .into[Tables.EndorsingRightsRow]
-            .withFieldConst(_.estimatedTime, toSql(endorsingRights.estimated_time))
+            .withFieldConst(_.estimatedTime, endorsingRights.estimated_time.map(toSql))
             .withFieldConst(_.slot, slot)
             .withFieldConst(_.blockHash, None)
             .transform

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
@@ -372,7 +372,7 @@ trait Tables {
     *  @param level Database column level SqlType(int4)
     *  @param delegate Database column delegate SqlType(varchar)
     *  @param priority Database column priority SqlType(int4)
-    *  @param estimatedTime Database column estimated_time SqlType(timestamp)
+    *  @param estimatedTime Database column estimated_time SqlType(timestamp), Default(None)
     *  @param cycle Database column cycle SqlType(int4), Default(None)
     *  @param governancePeriod Database column governance_period SqlType(int4), Default(None) */
   case class BakingRightsRow(
@@ -380,7 +380,7 @@ trait Tables {
       level: Int,
       delegate: String,
       priority: Int,
-      estimatedTime: java.sql.Timestamp,
+      estimatedTime: Option[java.sql.Timestamp] = None,
       cycle: Option[Int] = None,
       governancePeriod: Option[Int] = None
   )
@@ -389,11 +389,12 @@ trait Tables {
   implicit def GetResultBakingRightsRow(
       implicit e0: GR[Option[String]],
       e1: GR[Int],
-      e2: GR[java.sql.Timestamp],
-      e3: GR[Option[Int]]
+      e2: GR[String],
+      e3: GR[Option[java.sql.Timestamp]],
+      e4: GR[Option[Int]]
   ): GR[BakingRightsRow] = GR { prs =>
     import prs._
-    BakingRightsRow.tupled((<<?[String], <<[Int], <<[String], <<[Int], <<[java.sql.Timestamp], <<?[Int], <<?[Int]))
+    BakingRightsRow.tupled((<<?[String], <<[Int], <<[String], <<[Int], <<?[java.sql.Timestamp], <<?[Int], <<?[Int]))
   }
 
   /** Table description of table baking_rights. Objects of this class serve as prototypes for rows in queries. */
@@ -404,22 +405,13 @@ trait Tables {
 
     /** Maps whole row to an option. Useful for outer joins. */
     def ? =
-      (
-        (
-          Rep.Some(blockHash),
-          Rep.Some(level),
-          Rep.Some(delegate),
-          Rep.Some(priority),
-          Rep.Some(estimatedTime),
-          cycle,
-          governancePeriod
+      ((blockHash, Rep.Some(level), Rep.Some(delegate), Rep.Some(priority), estimatedTime, cycle, governancePeriod)).shaped
+        .<>(
+          { r =>
+            import r._; _2.map(_ => BakingRightsRow.tupled((_1, _2.get, _3.get, _4.get, _5, _6, _7)))
+          },
+          (_: Any) => throw new Exception("Inserting into ? projection not supported.")
         )
-      ).shaped.<>(
-        { r =>
-          import r._; _1.map(_ => BakingRightsRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get, _6, _7)))
-        },
-        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
-      )
 
     /** Database column block_hash SqlType(varchar), Default(None) */
     val blockHash: Rep[Option[String]] = column[Option[String]]("block_hash", O.Default(None))
@@ -433,8 +425,9 @@ trait Tables {
     /** Database column priority SqlType(int4) */
     val priority: Rep[Int] = column[Int]("priority")
 
-    /** Database column estimated_time SqlType(timestamp) */
-    val estimatedTime: Rep[java.sql.Timestamp] = column[java.sql.Timestamp]("estimated_time")
+    /** Database column estimated_time SqlType(timestamp), Default(None) */
+    val estimatedTime: Rep[Option[java.sql.Timestamp]] =
+      column[Option[java.sql.Timestamp]]("estimated_time", O.Default(None))
 
     /** Database column cycle SqlType(int4), Default(None) */
     val cycle: Rep[Option[Int]] = column[Option[Int]]("cycle", O.Default(None))
@@ -975,7 +968,7 @@ trait Tables {
     *  @param level Database column level SqlType(int4)
     *  @param delegate Database column delegate SqlType(varchar)
     *  @param slot Database column slot SqlType(int4)
-    *  @param estimatedTime Database column estimated_time SqlType(timestamp)
+    *  @param estimatedTime Database column estimated_time SqlType(timestamp), Default(None)
     *  @param cycle Database column cycle SqlType(int4), Default(None)
     *  @param governancePeriod Database column governance_period SqlType(int4), Default(None) */
   case class EndorsingRightsRow(
@@ -983,7 +976,7 @@ trait Tables {
       level: Int,
       delegate: String,
       slot: Int,
-      estimatedTime: java.sql.Timestamp,
+      estimatedTime: Option[java.sql.Timestamp] = None,
       cycle: Option[Int] = None,
       governancePeriod: Option[Int] = None
   )
@@ -992,11 +985,12 @@ trait Tables {
   implicit def GetResultEndorsingRightsRow(
       implicit e0: GR[Option[String]],
       e1: GR[Int],
-      e2: GR[java.sql.Timestamp],
-      e3: GR[Option[Int]]
+      e2: GR[String],
+      e3: GR[Option[java.sql.Timestamp]],
+      e4: GR[Option[Int]]
   ): GR[EndorsingRightsRow] = GR { prs =>
     import prs._
-    EndorsingRightsRow.tupled((<<?[String], <<[Int], <<[String], <<[Int], <<[java.sql.Timestamp], <<?[Int], <<?[Int]))
+    EndorsingRightsRow.tupled((<<?[String], <<[Int], <<[String], <<[Int], <<?[java.sql.Timestamp], <<?[Int], <<?[Int]))
   }
 
   /** Table description of table endorsing_rights. Objects of this class serve as prototypes for rows in queries. */
@@ -1007,22 +1001,13 @@ trait Tables {
 
     /** Maps whole row to an option. Useful for outer joins. */
     def ? =
-      (
-        (
-          Rep.Some(blockHash),
-          Rep.Some(level),
-          Rep.Some(delegate),
-          Rep.Some(slot),
-          Rep.Some(estimatedTime),
-          cycle,
-          governancePeriod
+      ((blockHash, Rep.Some(level), Rep.Some(delegate), Rep.Some(slot), estimatedTime, cycle, governancePeriod)).shaped
+        .<>(
+          { r =>
+            import r._; _2.map(_ => EndorsingRightsRow.tupled((_1, _2.get, _3.get, _4.get, _5, _6, _7)))
+          },
+          (_: Any) => throw new Exception("Inserting into ? projection not supported.")
         )
-      ).shaped.<>(
-        { r =>
-          import r._; _1.map(_ => EndorsingRightsRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get, _6, _7)))
-        },
-        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
-      )
 
     /** Database column block_hash SqlType(varchar), Default(None) */
     val blockHash: Rep[Option[String]] = column[Option[String]]("block_hash", O.Default(None))
@@ -1036,8 +1021,9 @@ trait Tables {
     /** Database column slot SqlType(int4) */
     val slot: Rep[Int] = column[Int]("slot")
 
-    /** Database column estimated_time SqlType(timestamp) */
-    val estimatedTime: Rep[java.sql.Timestamp] = column[java.sql.Timestamp]("estimated_time")
+    /** Database column estimated_time SqlType(timestamp), Default(None) */
+    val estimatedTime: Rep[Option[java.sql.Timestamp]] =
+      column[Option[java.sql.Timestamp]]("estimated_time", O.Default(None))
 
     /** Database column cycle SqlType(int4), Default(None) */
     val cycle: Rep[Option[Int]] = column[Option[Int]]("cycle", O.Default(None))
@@ -1365,55 +1351,53 @@ trait Tables {
 
     /** Maps whole row to an option. Useful for outer joins. */
     def ? =
-      (branch :: numberOfSlots :: cycle :: Rep.Some(operationId) :: Rep.Some(operationGroupHash) :: Rep.Some(kind) :: level :: delegate :: slots :: nonce :: pkh :: secret :: source :: fee :: counter :: gasLimit :: storageLimit :: publicKey :: amount :: destination :: parameters :: managerPubkey :: balance :: proposal :: spendable :: delegatable :: script :: storage :: status :: consumedGas :: storageSize :: paidStorageSizeDiff :: originatedContracts :: Rep
-            .Some(
-              blockHash
-            ) :: Rep.Some(blockLevel) :: ballot :: Rep.Some(internal) :: period :: Rep.Some(timestamp) :: HNil).shaped
-        .<>(
-          r =>
-            OperationsRow(
-              r(0).asInstanceOf[Option[String]],
-              r(1).asInstanceOf[Option[Int]],
-              r(2).asInstanceOf[Option[Int]],
-              r(3).asInstanceOf[Option[Int]].get,
-              r(4).asInstanceOf[Option[String]].get,
-              r(5).asInstanceOf[Option[String]].get,
-              r(6).asInstanceOf[Option[Int]],
-              r(7).asInstanceOf[Option[String]],
-              r(8).asInstanceOf[Option[String]],
-              r(9).asInstanceOf[Option[String]],
-              r(10).asInstanceOf[Option[String]],
-              r(11).asInstanceOf[Option[String]],
-              r(12).asInstanceOf[Option[String]],
-              r(13).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(14).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(15).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(16).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(17).asInstanceOf[Option[String]],
-              r(18).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(19).asInstanceOf[Option[String]],
-              r(20).asInstanceOf[Option[String]],
-              r(21).asInstanceOf[Option[String]],
-              r(22).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(23).asInstanceOf[Option[String]],
-              r(24).asInstanceOf[Option[Boolean]],
-              r(25).asInstanceOf[Option[Boolean]],
-              r(26).asInstanceOf[Option[String]],
-              r(27).asInstanceOf[Option[String]],
-              r(28).asInstanceOf[Option[String]],
-              r(29).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(30).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(31).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(32).asInstanceOf[Option[String]],
-              r(33).asInstanceOf[Option[String]].get,
-              r(34).asInstanceOf[Option[Int]].get,
-              r(35).asInstanceOf[Option[String]],
-              r(36).asInstanceOf[Option[Boolean]].get,
-              r(37).asInstanceOf[Option[Int]],
-              r(38).asInstanceOf[Option[java.sql.Timestamp]].get
-            ),
-          (_: Any) => throw new Exception("Inserting into ? projection not supported.")
-        )
+      (branch :: numberOfSlots :: cycle :: Rep.Some(operationId) :: Rep.Some(operationGroupHash) :: Rep.Some(kind) :: level :: delegate :: slots :: nonce :: pkh :: secret :: source :: fee :: counter :: gasLimit :: storageLimit :: publicKey :: amount :: destination :: parameters :: managerPubkey :: balance :: proposal :: spendable :: delegatable :: script :: storage :: status :: consumedGas :: storageSize :: paidStorageSizeDiff :: originatedContracts :: Rep.Some(
+            blockHash
+          ) :: Rep.Some(blockLevel) :: ballot :: Rep.Some(internal) :: period :: Rep.Some(timestamp) :: HNil).shaped.<>(
+        r =>
+          OperationsRow(
+            r(0).asInstanceOf[Option[String]],
+            r(1).asInstanceOf[Option[Int]],
+            r(2).asInstanceOf[Option[Int]],
+            r(3).asInstanceOf[Option[Int]].get,
+            r(4).asInstanceOf[Option[String]].get,
+            r(5).asInstanceOf[Option[String]].get,
+            r(6).asInstanceOf[Option[Int]],
+            r(7).asInstanceOf[Option[String]],
+            r(8).asInstanceOf[Option[String]],
+            r(9).asInstanceOf[Option[String]],
+            r(10).asInstanceOf[Option[String]],
+            r(11).asInstanceOf[Option[String]],
+            r(12).asInstanceOf[Option[String]],
+            r(13).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(14).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(15).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(16).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(17).asInstanceOf[Option[String]],
+            r(18).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(19).asInstanceOf[Option[String]],
+            r(20).asInstanceOf[Option[String]],
+            r(21).asInstanceOf[Option[String]],
+            r(22).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(23).asInstanceOf[Option[String]],
+            r(24).asInstanceOf[Option[Boolean]],
+            r(25).asInstanceOf[Option[Boolean]],
+            r(26).asInstanceOf[Option[String]],
+            r(27).asInstanceOf[Option[String]],
+            r(28).asInstanceOf[Option[String]],
+            r(29).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(30).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(31).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(32).asInstanceOf[Option[String]],
+            r(33).asInstanceOf[Option[String]].get,
+            r(34).asInstanceOf[Option[Int]].get,
+            r(35).asInstanceOf[Option[String]],
+            r(36).asInstanceOf[Option[Boolean]].get,
+            r(37).asInstanceOf[Option[Int]],
+            r(38).asInstanceOf[Option[java.sql.Timestamp]].get
+          ),
+        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
+      )
 
     /** Database column branch SqlType(varchar), Default(None) */
     val branch: Rep[Option[String]] = column[Option[String]]("branch", O.Default(None))

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
@@ -401,7 +401,7 @@ object TezosDatabaseOperations extends LazyLogging {
 
     Tables.EndorsingRights.insertOrUpdateAll(transformationResult.flatten)
   }
-  val berLogger = LoggerFactory.getLogger("BER")
+  val berLogger = LoggerFactory.getLogger("RightsFetcher")
 
   /**
     * Writes baking rights to the database

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeFetchers.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeFetchers.scala
@@ -153,7 +153,7 @@ trait BlocksDataFetchers {
 
   }
 
-  val berLogger = LoggerFactory.getLogger("BER")
+  val berLogger = LoggerFactory.getLogger("RightsFetcher")
 
   implicit val futureBakingRightsFetcher = new FutureFetcher {
     import JsonDecoders.Circe.Rights._

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -588,7 +588,7 @@ object TezosTypes {
       level: Int,
       delegate: String,
       priority: Int,
-      estimated_time: ZonedDateTime,
+      estimated_time: Option[ZonedDateTime],
       cycle: Option[Int],
       governancePeriod: Option[Int]
   )
@@ -598,7 +598,7 @@ object TezosTypes {
       level: Int,
       delegate: String,
       slots: List[Int],
-      estimated_time: ZonedDateTime,
+      estimated_time: Option[ZonedDateTime],
       cycle: Option[Int],
       governancePeriod: Option[Int]
   )


### PR DESCRIPTION
Those are additional changes requested by @vishakh.
I was testing this functionality and I've noticed that estimated time can be missing - that's why I've introduced change with making `estimated_time` columns nullable.


## Required DB changes
`estimated_time` in both tables `baking_rights` and `endorsing_rights ` must be changed to nullable