### PR TITLE
Bugfix/644 michelson parser error

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParser.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParser.scala
@@ -163,7 +163,7 @@ object JsonParser {
 
     private def extractCode: Result[MichelsonCode] =
       code.collectFirst {
-        case it:JsonCodeSection => it.toMichelsonCode
+        case it @ JsonCodeSection("code", _) => it.toMichelsonCode
       }.toRight(ParserError("No code section found"))
   }
 

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParserSpec.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/parser/JsonParserSpec.scala
@@ -441,6 +441,47 @@ class JsonParserSpec extends FlatSpec with Matchers {
       )
     }
 
+  it should "convert json with code wrapped in single array to MichelsonSchema" in {
+
+      val json =
+        """[
+        |  {
+        |    "prim": "parameter",
+        |    "args": [
+        |      {
+        |        "prim": "int"
+        |      }
+        |    ]
+        |  },
+        |  {
+        |    "prim": "storage",
+        |    "args": [
+        |      {
+        |        "prim": "int"
+        |      }
+        |    ]
+        |  },
+        |  {
+        |    "prim": "code",
+        |    "args": [
+               {
+        |        "prim": "DUP"
+        |      }
+        |    ]
+        |  }
+        |]""".stripMargin
+
+      parse[MichelsonSchema](json) should equal(
+        Right(
+          MichelsonSchema(
+            MichelsonType("int"),
+            MichelsonType("int"),
+            MichelsonCode(List(MichelsonSingleInstruction("DUP")))
+          )
+        )
+      )
+    }
+
   it should "parse MichelsonCode" in {
       val json = """[{"prim": "DUP"}]"""
 
@@ -457,7 +498,7 @@ class JsonParserSpec extends FlatSpec with Matchers {
       val json =
         """[{"prim": "parameter", "args": [{"prim": "unit"}]}, {"prim": "storage", "args": [{"prim": "unit"}]}]"""
 
-      parse[MichelsonSchema](json) should equal(Left(ParserError("No code code found")))
+      parse[MichelsonSchema](json) should equal(Left(ParserError("No code section found")))
     }
 
   it should "parse empty schema" in {


### PR DESCRIPTION
closes #644 

This is a fix for a bug related to a contract with single brackets around the `code` section. Normally all the contracts have double brackets but I found those with single hence the reason to introduce support for both formats. 