### PR TITLE
597 - Micro optimize database writes of accounts and delegates

### DIFF
--- a/sql/conseil.sql
+++ b/sql/conseil.sql
@@ -483,6 +483,9 @@ CREATE INDEX ix_accounts_checkpoint_block_level ON tezos.accounts_checkpoint USI
 
 CREATE INDEX ix_accounts_manager ON tezos.accounts USING btree (manager);
 
+CREATE INDEX ix_accounts_block_id ON tezos.accounts USING btree (block_id);
+
+CREATE INDEX ix_accounts_history_block_id ON tezos.accounts_history USING btree (block_id);
 
 --
 -- Name: ix_blocks_level; Type: INDEX; Schema: tezos; Owner: -

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
@@ -362,6 +362,9 @@ trait Tables {
 
     /** Database column cycle SqlType(int4), Default(None) */
     val cycle: Rep[Option[Int]] = column[Option[Int]]("cycle", O.Default(None))
+
+    /** Index over (blockId) (database name ix_accounts_history_block_id) */
+    val index1 = index("ix_accounts_history_block_id", blockId)
   }
 
   /** Collection-like TableQuery object for table AccountsHistory */
@@ -1351,55 +1354,53 @@ trait Tables {
 
     /** Maps whole row to an option. Useful for outer joins. */
     def ? =
-      (branch :: numberOfSlots :: cycle :: Rep.Some(operationId) :: Rep.Some(operationGroupHash) :: Rep.Some(kind) :: level :: delegate :: slots :: nonce :: pkh :: secret :: source :: fee :: counter :: gasLimit :: storageLimit :: publicKey :: amount :: destination :: parameters :: managerPubkey :: balance :: proposal :: spendable :: delegatable :: script :: storage :: status :: consumedGas :: storageSize :: paidStorageSizeDiff :: originatedContracts :: Rep
-            .Some(
-              blockHash
-            ) :: Rep.Some(blockLevel) :: ballot :: Rep.Some(internal) :: period :: Rep.Some(timestamp) :: HNil).shaped
-        .<>(
-          r =>
-            OperationsRow(
-              r(0).asInstanceOf[Option[String]],
-              r(1).asInstanceOf[Option[Int]],
-              r(2).asInstanceOf[Option[Int]],
-              r(3).asInstanceOf[Option[Int]].get,
-              r(4).asInstanceOf[Option[String]].get,
-              r(5).asInstanceOf[Option[String]].get,
-              r(6).asInstanceOf[Option[Int]],
-              r(7).asInstanceOf[Option[String]],
-              r(8).asInstanceOf[Option[String]],
-              r(9).asInstanceOf[Option[String]],
-              r(10).asInstanceOf[Option[String]],
-              r(11).asInstanceOf[Option[String]],
-              r(12).asInstanceOf[Option[String]],
-              r(13).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(14).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(15).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(16).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(17).asInstanceOf[Option[String]],
-              r(18).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(19).asInstanceOf[Option[String]],
-              r(20).asInstanceOf[Option[String]],
-              r(21).asInstanceOf[Option[String]],
-              r(22).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(23).asInstanceOf[Option[String]],
-              r(24).asInstanceOf[Option[Boolean]],
-              r(25).asInstanceOf[Option[Boolean]],
-              r(26).asInstanceOf[Option[String]],
-              r(27).asInstanceOf[Option[String]],
-              r(28).asInstanceOf[Option[String]],
-              r(29).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(30).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(31).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(32).asInstanceOf[Option[String]],
-              r(33).asInstanceOf[Option[String]].get,
-              r(34).asInstanceOf[Option[Int]].get,
-              r(35).asInstanceOf[Option[String]],
-              r(36).asInstanceOf[Option[Boolean]].get,
-              r(37).asInstanceOf[Option[Int]],
-              r(38).asInstanceOf[Option[java.sql.Timestamp]].get
-            ),
-          (_: Any) => throw new Exception("Inserting into ? projection not supported.")
-        )
+      (branch :: numberOfSlots :: cycle :: Rep.Some(operationId) :: Rep.Some(operationGroupHash) :: Rep.Some(kind) :: level :: delegate :: slots :: nonce :: pkh :: secret :: source :: fee :: counter :: gasLimit :: storageLimit :: publicKey :: amount :: destination :: parameters :: managerPubkey :: balance :: proposal :: spendable :: delegatable :: script :: storage :: status :: consumedGas :: storageSize :: paidStorageSizeDiff :: originatedContracts :: Rep.Some(
+            blockHash
+          ) :: Rep.Some(blockLevel) :: ballot :: Rep.Some(internal) :: period :: Rep.Some(timestamp) :: HNil).shaped.<>(
+        r =>
+          OperationsRow(
+            r(0).asInstanceOf[Option[String]],
+            r(1).asInstanceOf[Option[Int]],
+            r(2).asInstanceOf[Option[Int]],
+            r(3).asInstanceOf[Option[Int]].get,
+            r(4).asInstanceOf[Option[String]].get,
+            r(5).asInstanceOf[Option[String]].get,
+            r(6).asInstanceOf[Option[Int]],
+            r(7).asInstanceOf[Option[String]],
+            r(8).asInstanceOf[Option[String]],
+            r(9).asInstanceOf[Option[String]],
+            r(10).asInstanceOf[Option[String]],
+            r(11).asInstanceOf[Option[String]],
+            r(12).asInstanceOf[Option[String]],
+            r(13).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(14).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(15).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(16).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(17).asInstanceOf[Option[String]],
+            r(18).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(19).asInstanceOf[Option[String]],
+            r(20).asInstanceOf[Option[String]],
+            r(21).asInstanceOf[Option[String]],
+            r(22).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(23).asInstanceOf[Option[String]],
+            r(24).asInstanceOf[Option[Boolean]],
+            r(25).asInstanceOf[Option[Boolean]],
+            r(26).asInstanceOf[Option[String]],
+            r(27).asInstanceOf[Option[String]],
+            r(28).asInstanceOf[Option[String]],
+            r(29).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(30).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(31).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(32).asInstanceOf[Option[String]],
+            r(33).asInstanceOf[Option[String]].get,
+            r(34).asInstanceOf[Option[Int]].get,
+            r(35).asInstanceOf[Option[String]],
+            r(36).asInstanceOf[Option[Boolean]].get,
+            r(37).asInstanceOf[Option[Int]],
+            r(38).asInstanceOf[Option[java.sql.Timestamp]].get
+          ),
+        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
+      )
 
     /** Database column branch SqlType(varchar), Default(None) */
     val branch: Rep[Option[String]] = column[Option[String]]("branch", O.Default(None))

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
@@ -447,7 +447,7 @@ object TezosDatabaseOperations extends LazyLogging {
         writeAccountsHistory(accounts),
         writeDelegatesCheckpoint(delegatesKeyHashes.map(_.asTuple))
       )
-    .transactionally
+      .transactionally
   }
 
   /**

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
@@ -309,7 +309,7 @@ class TezosDatabaseOperationsTest
 
         val (stored, dbAccounts) = dbHandler.run(writeAndGetRows.transactionally).futureValue
 
-        stored shouldBe expectedCount
+        stored.value shouldBe expectedCount
 
         dbAccounts should have size expectedCount
 
@@ -373,7 +373,7 @@ class TezosDatabaseOperationsTest
         val (updates, dbAccounts) = dbHandler.run(writeUpdatedAndGetRows.transactionally).futureValue
 
         //number of db changes
-        updates shouldBe accountChanges
+        updates.value shouldBe accountChanges
 
         //total number of rows on db (1 update and 1 insert expected)
         dbAccounts should have size accountChanges
@@ -540,7 +540,7 @@ class TezosDatabaseOperationsTest
 
         val (stored, dbDelegates) = dbHandler.run(writeAndGetRows.transactionally).futureValue
 
-        stored shouldBe expectedCount
+        stored.value shouldBe expectedCount
 
         dbDelegates should have size expectedCount
 
@@ -635,7 +635,7 @@ class TezosDatabaseOperationsTest
         val (updates, dbDelegates) = dbHandler.run(writeUpdatedAndGetRows.transactionally).futureValue
 
         //number of db changes
-        updates shouldBe changes
+        updates.value shouldBe changes
 
         //total number of rows on db (1 update and 1 insert expected)
         dbDelegates should have size changes


### PR DESCRIPTION
Related to #597 

Minor tweaks in the code to improve and simplify bulk insert/upserts to accounts/delegates-related tables.

The resulting throughput impact is quite negligible on the scale of observed load, the code quality should be a bit improved nonetheless.