### PR TITLE
655 - add operation failures' reasons in the db

### DIFF
--- a/sql/conseil.sql
+++ b/sql/conseil.sql
@@ -301,7 +301,8 @@ CREATE TABLE tezos.operations (
     ballot character varying,
     internal boolean NOT NULL,
     period integer,
-    "timestamp" timestamp without time zone NOT NULL
+    "timestamp" timestamp without time zone NOT NULL,
+    errors character varying
 );
 
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
@@ -5,6 +5,7 @@ import tech.cryptonomic.conseil.tezos.TezosTypes._
 import tech.cryptonomic.conseil.tezos.FeeOperations._
 import tech.cryptonomic.conseil.util.Conversion
 import cats.{Id, Show}
+import cats.implicits._
 import java.sql.Timestamp
 import java.time.Instant
 
@@ -39,6 +40,27 @@ object DatabaseConversions extends LazyLogging {
   def extractBigDecimal(number: BigNumber): Option[BigDecimal] = number match {
     case Decimal(value) => Some(value)
     case _ => None
+  }
+
+  private def extractResultErrorIds(errors: Option[List[OperationResult.Error]]) = {
+    def extractId(error: OperationResult.Error): Option[String] = {
+      import io.circe.JsonObject
+
+      //we expect this to work as long as the error was previously built from json parsing
+      //refer to the JsonDecoders
+      for {
+        obj <- io.circe.parser
+          .decode[JsonObject](error.json)
+          .toOption
+        id <- obj("id")
+        idString <- id.asString
+      } yield idString
+    }
+
+    for {
+      es <- errors
+      ids <- es.traverse(extractId)
+    } yield concatenateToString(ids)
   }
 
   //Note, cycle 0 starts at the level 2 block
@@ -240,7 +262,8 @@ object DatabaseConversions extends LazyLogging {
         blockLevel = block.data.header.level,
         timestamp = toSql(block.data.header.timestamp),
         internal = false,
-        cycle = extractCycle(block)
+        cycle = extractCycle(block),
+        errors = extractResultErrorIds(metadata.operation_result.errors)
       )
   }
 
@@ -276,7 +299,8 @@ object DatabaseConversions extends LazyLogging {
         blockLevel = block.data.header.level,
         timestamp = toSql(block.data.header.timestamp),
         internal = false,
-        cycle = extractCycle(block)
+        cycle = extractCycle(block),
+        errors = extractResultErrorIds(metadata.operation_result.errors)
       )
   }
 
@@ -324,7 +348,8 @@ object DatabaseConversions extends LazyLogging {
         blockLevel = block.data.header.level,
         timestamp = toSql(block.data.header.timestamp),
         internal = false,
-        cycle = extractCycle(block)
+        cycle = extractCycle(block),
+        errors = extractResultErrorIds(metadata.operation_result.errors)
       )
   }
 
@@ -346,7 +371,8 @@ object DatabaseConversions extends LazyLogging {
         blockLevel = block.data.header.level,
         timestamp = toSql(block.data.header.timestamp),
         internal = false,
-        cycle = extractCycle(block)
+        cycle = extractCycle(block),
+        errors = extractResultErrorIds(metadata.operation_result.errors)
       )
   }
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
@@ -1349,7 +1349,8 @@ trait Tables {
     *  @param ballot Database column ballot SqlType(varchar), Default(None)
     *  @param internal Database column internal SqlType(bool)
     *  @param period Database column period SqlType(int4), Default(None)
-    *  @param timestamp Database column timestamp SqlType(timestamp) */
+    *  @param timestamp Database column timestamp SqlType(timestamp)
+    *  @param errors Database column errors SqlType(varchar), Default(None) */
   case class OperationsRow(
       branch: Option[String] = None,
       numberOfSlots: Option[Int] = None,
@@ -1389,7 +1390,8 @@ trait Tables {
       ballot: Option[String] = None,
       internal: Boolean,
       period: Option[Int] = None,
-      timestamp: java.sql.Timestamp
+      timestamp: java.sql.Timestamp,
+      errors: Option[String] = None
   )
 
   /** GetResult implicit for fetching OperationsRow objects using plain SQL queries */
@@ -1443,65 +1445,69 @@ trait Tables {
       <<?[String],
       <<[Boolean],
       <<?[Int],
-      <<[java.sql.Timestamp]
+      <<[java.sql.Timestamp],
+      <<?[String]
     )
   }
 
   /** Table description of table operations. Objects of this class serve as prototypes for rows in queries. */
   class Operations(_tableTag: Tag) extends profile.api.Table[OperationsRow](_tableTag, Some("tezos"), "operations") {
     def * =
-      (branch :: numberOfSlots :: cycle :: operationId :: operationGroupHash :: kind :: level :: delegate :: slots :: nonce :: pkh :: secret :: source :: fee :: counter :: gasLimit :: storageLimit :: publicKey :: amount :: destination :: parameters :: managerPubkey :: balance :: proposal :: spendable :: delegatable :: script :: storage :: status :: consumedGas :: storageSize :: paidStorageSizeDiff :: originatedContracts :: blockHash :: blockLevel :: ballot :: internal :: period :: timestamp :: HNil)
+      (branch :: numberOfSlots :: cycle :: operationId :: operationGroupHash :: kind :: level :: delegate :: slots :: nonce :: pkh :: secret :: source :: fee :: counter :: gasLimit :: storageLimit :: publicKey :: amount :: destination :: parameters :: managerPubkey :: balance :: proposal :: spendable :: delegatable :: script :: storage :: status :: consumedGas :: storageSize :: paidStorageSizeDiff :: originatedContracts :: blockHash :: blockLevel :: ballot :: internal :: period :: timestamp :: errors :: HNil)
         .mapTo[OperationsRow]
 
     /** Maps whole row to an option. Useful for outer joins. */
     def ? =
-      (branch :: numberOfSlots :: cycle :: Rep.Some(operationId) :: Rep.Some(operationGroupHash) :: Rep.Some(kind) :: level :: delegate :: slots :: nonce :: pkh :: secret :: source :: fee :: counter :: gasLimit :: storageLimit :: publicKey :: amount :: destination :: parameters :: managerPubkey :: balance :: proposal :: spendable :: delegatable :: script :: storage :: status :: consumedGas :: storageSize :: paidStorageSizeDiff :: originatedContracts :: Rep.Some(
-            blockHash
-          ) :: Rep.Some(blockLevel) :: ballot :: Rep.Some(internal) :: period :: Rep.Some(timestamp) :: HNil).shaped.<>(
-        r =>
-          OperationsRow(
-            r(0).asInstanceOf[Option[String]],
-            r(1).asInstanceOf[Option[Int]],
-            r(2).asInstanceOf[Option[Int]],
-            r(3).asInstanceOf[Option[Int]].get,
-            r(4).asInstanceOf[Option[String]].get,
-            r(5).asInstanceOf[Option[String]].get,
-            r(6).asInstanceOf[Option[Int]],
-            r(7).asInstanceOf[Option[String]],
-            r(8).asInstanceOf[Option[String]],
-            r(9).asInstanceOf[Option[String]],
-            r(10).asInstanceOf[Option[String]],
-            r(11).asInstanceOf[Option[String]],
-            r(12).asInstanceOf[Option[String]],
-            r(13).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(14).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(15).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(16).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(17).asInstanceOf[Option[String]],
-            r(18).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(19).asInstanceOf[Option[String]],
-            r(20).asInstanceOf[Option[String]],
-            r(21).asInstanceOf[Option[String]],
-            r(22).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(23).asInstanceOf[Option[String]],
-            r(24).asInstanceOf[Option[Boolean]],
-            r(25).asInstanceOf[Option[Boolean]],
-            r(26).asInstanceOf[Option[String]],
-            r(27).asInstanceOf[Option[String]],
-            r(28).asInstanceOf[Option[String]],
-            r(29).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(30).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(31).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(32).asInstanceOf[Option[String]],
-            r(33).asInstanceOf[Option[String]].get,
-            r(34).asInstanceOf[Option[Int]].get,
-            r(35).asInstanceOf[Option[String]],
-            r(36).asInstanceOf[Option[Boolean]].get,
-            r(37).asInstanceOf[Option[Int]],
-            r(38).asInstanceOf[Option[java.sql.Timestamp]].get
-          ),
-        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
-      )
+      (branch :: numberOfSlots :: cycle :: Rep.Some(operationId) :: Rep.Some(operationGroupHash) :: Rep.Some(kind) :: level :: delegate :: slots :: nonce :: pkh :: secret :: source :: fee :: counter :: gasLimit :: storageLimit :: publicKey :: amount :: destination :: parameters :: managerPubkey :: balance :: proposal :: spendable :: delegatable :: script :: storage :: status :: consumedGas :: storageSize :: paidStorageSizeDiff :: originatedContracts :: Rep
+            .Some(
+              blockHash
+            ) :: Rep.Some(blockLevel) :: ballot :: Rep.Some(internal) :: period :: Rep.Some(timestamp) :: errors :: HNil).shaped
+        .<>(
+          r =>
+            OperationsRow(
+              r(0).asInstanceOf[Option[String]],
+              r(1).asInstanceOf[Option[Int]],
+              r(2).asInstanceOf[Option[Int]],
+              r(3).asInstanceOf[Option[Int]].get,
+              r(4).asInstanceOf[Option[String]].get,
+              r(5).asInstanceOf[Option[String]].get,
+              r(6).asInstanceOf[Option[Int]],
+              r(7).asInstanceOf[Option[String]],
+              r(8).asInstanceOf[Option[String]],
+              r(9).asInstanceOf[Option[String]],
+              r(10).asInstanceOf[Option[String]],
+              r(11).asInstanceOf[Option[String]],
+              r(12).asInstanceOf[Option[String]],
+              r(13).asInstanceOf[Option[scala.math.BigDecimal]],
+              r(14).asInstanceOf[Option[scala.math.BigDecimal]],
+              r(15).asInstanceOf[Option[scala.math.BigDecimal]],
+              r(16).asInstanceOf[Option[scala.math.BigDecimal]],
+              r(17).asInstanceOf[Option[String]],
+              r(18).asInstanceOf[Option[scala.math.BigDecimal]],
+              r(19).asInstanceOf[Option[String]],
+              r(20).asInstanceOf[Option[String]],
+              r(21).asInstanceOf[Option[String]],
+              r(22).asInstanceOf[Option[scala.math.BigDecimal]],
+              r(23).asInstanceOf[Option[String]],
+              r(24).asInstanceOf[Option[Boolean]],
+              r(25).asInstanceOf[Option[Boolean]],
+              r(26).asInstanceOf[Option[String]],
+              r(27).asInstanceOf[Option[String]],
+              r(28).asInstanceOf[Option[String]],
+              r(29).asInstanceOf[Option[scala.math.BigDecimal]],
+              r(30).asInstanceOf[Option[scala.math.BigDecimal]],
+              r(31).asInstanceOf[Option[scala.math.BigDecimal]],
+              r(32).asInstanceOf[Option[String]],
+              r(33).asInstanceOf[Option[String]].get,
+              r(34).asInstanceOf[Option[Int]].get,
+              r(35).asInstanceOf[Option[String]],
+              r(36).asInstanceOf[Option[Boolean]].get,
+              r(37).asInstanceOf[Option[Int]],
+              r(38).asInstanceOf[Option[java.sql.Timestamp]].get,
+              r(39).asInstanceOf[Option[String]]
+            ),
+          (_: Any) => throw new Exception("Inserting into ? projection not supported.")
+        )
 
     /** Database column branch SqlType(varchar), Default(None) */
     val branch: Rep[Option[String]] = column[Option[String]]("branch", O.Default(None))
@@ -1624,6 +1630,9 @@ trait Tables {
 
     /** Database column timestamp SqlType(timestamp) */
     val timestamp: Rep[java.sql.Timestamp] = column[java.sql.Timestamp]("timestamp")
+
+    /** Database column errors SqlType(varchar), Default(None) */
+    val errors: Rep[Option[String]] = column[Option[String]]("errors", O.Default(None))
 
     /** Foreign key referencing Blocks (database name fk_blockhashes) */
     lazy val blocksFk = foreignKey("fk_blockhashes", blockHash :: HNil, Blocks)(

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -365,7 +365,10 @@ object TezosTypes {
 
   /** defines common result structures, following the json-schema definitions */
   object OperationResult {
-    //we're not yet encoding the complex schema for errors, storing them as simple strings
+    /* we're not yet decoding the complex schema for errors,
+     * as every error can have additional custom fields
+     * see: https://tezos.gitlab.io/api/errors.html
+     */
     final case class Error(json: String) extends AnyVal
 
     //we're currently making no difference between different statuses in any of the results

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DatabaseConversionsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DatabaseConversionsTest.scala
@@ -338,6 +338,7 @@ class DatabaseConversionsTest
               converted.storageSize ::
               converted.paidStorageSizeDiff ::
               converted.originatedContracts ::
+              converted.errors ::
               Nil
         ) {
           _ shouldBe 'empty
@@ -382,6 +383,7 @@ class DatabaseConversionsTest
               converted.storageSize ::
               converted.paidStorageSizeDiff ::
               converted.originatedContracts ::
+              converted.errors ::
               Nil
         ) {
           _ shouldBe 'empty
@@ -426,6 +428,7 @@ class DatabaseConversionsTest
               converted.storageSize ::
               converted.paidStorageSizeDiff ::
               converted.originatedContracts ::
+              converted.errors ::
               Nil
         ) {
           _ shouldBe 'empty
@@ -444,6 +447,8 @@ class DatabaseConversionsTest
         converted.timestamp shouldBe Timestamp.from(block.data.header.timestamp.toInstant)
         converted.kind shouldBe "reveal"
         converted.source.value shouldBe sampleReveal.source.value
+        converted.status.value shouldBe "applied"
+        converted.errors.value shouldBe "[error1,error2]"
         sampleReveal.fee match {
           case PositiveDecimal(bignumber) => converted.fee.value shouldBe bignumber
           case _ => converted.fee shouldBe 'empty
@@ -503,6 +508,8 @@ class DatabaseConversionsTest
         converted.timestamp shouldBe Timestamp.from(block.data.header.timestamp.toInstant)
         converted.kind shouldBe "transaction"
         converted.source.value shouldBe sampleTransaction.source.value
+        converted.status.value shouldBe "applied"
+        converted.errors.value shouldBe "[error1,error2]"
         sampleTransaction.fee match {
           case PositiveDecimal(bignumber) => converted.fee.value shouldBe bignumber
           case _ => converted.fee shouldBe 'empty
@@ -572,6 +579,8 @@ class DatabaseConversionsTest
         converted.kind shouldBe "origination"
         converted.delegate shouldBe sampleOrigination.delegate.map(_.value)
         converted.source.value shouldBe sampleOrigination.source.value
+        converted.status.value shouldBe "applied"
+        converted.errors.value shouldBe "[error1,error2]"
         sampleOrigination.fee match {
           case PositiveDecimal(bignumber) => converted.fee.value shouldBe bignumber
           case _ => converted.fee shouldBe 'empty
@@ -641,6 +650,8 @@ class DatabaseConversionsTest
         converted.kind shouldBe "delegation"
         converted.delegate shouldBe sampleDelegation.delegate.map(_.value)
         converted.source.value shouldBe sampleDelegation.source.value
+        converted.status.value shouldBe "applied"
+        converted.errors.value shouldBe "[error1,error2]"
         sampleDelegation.fee match {
           case PositiveDecimal(bignumber) => converted.fee.value shouldBe bignumber
           case _ => converted.fee shouldBe 'empty
@@ -725,6 +736,7 @@ class DatabaseConversionsTest
               converted.storageSize ::
               converted.paidStorageSizeDiff ::
               converted.originatedContracts ::
+              converted.status ::
               Nil
         ) {
           _ shouldBe 'empty
@@ -769,6 +781,7 @@ class DatabaseConversionsTest
               converted.storageSize ::
               converted.paidStorageSizeDiff ::
               converted.originatedContracts ::
+              converted.status ::
               Nil
         ) {
           _ shouldBe 'empty
@@ -815,6 +828,7 @@ class DatabaseConversionsTest
               converted.storageSize ::
               converted.paidStorageSizeDiff ::
               converted.originatedContracts ::
+              converted.status ::
               Nil
         ) {
           _ shouldBe 'empty
@@ -862,6 +876,7 @@ class DatabaseConversionsTest
               converted.storageSize ::
               converted.paidStorageSizeDiff ::
               converted.originatedContracts ::
+              converted.status ::
               Nil
         ) {
           _ shouldBe 'empty

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DatabaseConversionsTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DatabaseConversionsTestFixtures.scala
@@ -6,6 +6,11 @@ import tech.cryptonomic.conseil.tezos.TezosTypes.Voting.Vote
 
 trait DBConversionsData {
 
+  val sampleOperationResultsErrors = List(
+    OperationResult.Error("""{"id":"error1", "kind":"permanent"}"""),
+    OperationResult.Error("""{"id":"error2", "kind":"temporary"}""")
+  )
+
   val sampleScriptedContract =
     Scripted.Contracts(
       code = Micheline(
@@ -116,7 +121,7 @@ trait DBConversionsData {
         operation_result = OperationResult.Reveal(
           status = "applied",
           consumed_gas = Some(Decimal(10000)),
-          errors = None
+          errors = Some(sampleOperationResultsErrors)
         )
       )
     )
@@ -160,7 +165,7 @@ trait DBConversionsData {
           big_map_diff = None,
           originated_contracts = None,
           paid_storage_size_diff = None,
-          errors = None
+          errors = Some(sampleOperationResultsErrors)
         )
       )
     )
@@ -242,7 +247,7 @@ trait DBConversionsData {
           consumed_gas = Some(Decimal(11262)),
           storage_size = Some(Decimal(46)),
           paid_storage_size_diff = Some(Decimal(46)),
-          errors = None
+          errors = Some(sampleOperationResultsErrors)
         )
       )
     )
@@ -277,7 +282,7 @@ trait DBConversionsData {
         operation_result = OperationResult.Delegation(
           status = "applied",
           consumed_gas = Some(Decimal(10000)),
-          errors = None
+          errors = Some(sampleOperationResultsErrors)
         )
       )
     )

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
@@ -248,7 +248,8 @@ class TezosPlatformDiscoveryOperationsTest
             Attribute("cycle", "Cycle", DataType.Int, None, KeyType.NonKey, "operations"),
             Attribute("branch", "Branch", DataType.String, None, KeyType.NonKey, "operations"),
             Attribute("number_of_slots", "Number of slots", DataType.Int, None, KeyType.NonKey, "operations"),
-            Attribute("period", "Period", DataType.Int, None, KeyType.NonKey, "operations")
+            Attribute("period", "Period", DataType.Int, None, KeyType.NonKey, "operations"),
+            Attribute("errors", "Errors", DataType.String, None, KeyType.NonKey, "operations")
           )
         )
       }


### PR DESCRIPTION
Closes #655 

Currently reads only the `id` of any error for non-applied operations and stores them as single concatenated strings in the database

### Changes needed to DB Schema

We require an additional column on tezos.operations
```sql
    errors character varying
```