### PR TITLE
683 - big map contents should update existing records and log debugging info

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -17,6 +17,7 @@
     </appender>
 
     <logger name="com.base22" level="TRACE"/>
+    <logger name="tech.cryptonomic.conseil.tezos.BigMapsOperations" level="OFF"/>
 
     <root level="INFO">
         <appender-ref ref="ASYNC" />

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/BigMapsOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/BigMapsOperations.scala
@@ -25,8 +25,9 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
     val copyDiffs = if (logger.underlying.isDebugEnabled()) {
       val diffMap = blocks.map(b => b.data.hash.value -> TezosOptics.Blocks.readBigMapDiffCopy.getAll(b))
       diffMap.foreach {
-        case (hash, diffs) =>
+        case (hash, diffs) if diffs.nonEmpty =>
           logger.debug("For block hash {}, I'm about to copy the following big maps data: \n\t{}", diffs.mkString(", "))
+        case _ =>
       }
       diffMap.map(_._2).flatten
     } else blocks.flatMap(TezosOptics.Blocks.readBigMapDiffCopy.getAll)
@@ -66,8 +67,9 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
     val removalDiffs = if (logger.underlying.isDebugEnabled()) {
       val diffMap = blocks.map(b => b.data.hash.value -> TezosOptics.Blocks.readBigMapDiffRemove.getAll(b))
       diffMap.foreach {
-        case (hash, diffs) =>
+        case (hash, diffs) if diffs.nonEmpty =>
           logger.debug("For block hash {}, I'm about to delete the big maps for ids: \n\t{}", diffs.mkString(", "))
+        case _ =>
       }
       diffMap.map(_._2).flatten
     } else blocks.flatMap(TezosOptics.Blocks.readBigMapDiffRemove.getAll)
@@ -98,8 +100,9 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
     val maps = if (logger.underlying.isDebugEnabled()) {
       val rowsMap = blocks.map(b => b.data.hash.value -> b.convertToA[List, BigMapsRow])
       rowsMap.foreach {
-        case (hash, rows) =>
+        case (hash, rows) if rows.nonEmpty =>
           logger.debug("For block hash {}, I'm about to add the following big maps: \n\t{}", rows.mkString(", "))
+        case _ =>
       }
       rowsMap.map(_._2).flatten
     } else blocks.flatMap(_.convertToA[List, BigMapsRow])
@@ -119,11 +122,12 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
     val rowsMap = blocks.map(b => b.data.hash -> b.convertToA[List, BigMapContentsRow]).toMap
     if (logger.underlying.isDebugEnabled()) {
       rowsMap.foreach {
-        case (hash, rows) =>
+        case (hash, rows) if rows.nonEmpty =>
           logger.debug(
             "For block hash {}, I'm about to update big map contents with the following data: \n\t{}",
             rows.mkString(", ")
           )
+        case _ =>
       }
     }
 
@@ -157,11 +161,12 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
     val refs = if (logger.underlying.isDebugEnabled()) {
       val rowsMap = blocks.map(b => b.data.hash.value -> b.convertToA[List, OriginatedAccountMapsRow])
       rowsMap.foreach {
-        case (hash, rows) =>
+        case (hash, rows) if rows.nonEmpty =>
           logger.debug(
             "For block hash {}, I'm about to add the following links from big maps to originated accounts: \n\t{}",
             rows.mkString(", ")
           )
+        case _ =>
       }
       rowsMap.map(_._2).flatten
     } else blocks.flatMap(_.convertToA[List, OriginatedAccountMapsRow])

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/BigMapsOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/BigMapsOperations.scala
@@ -26,7 +26,11 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
       val diffMap = blocks.map(b => b.data.hash.value -> TezosOptics.Blocks.readBigMapDiffCopy.getAll(b))
       diffMap.foreach {
         case (hash, diffs) if diffs.nonEmpty =>
-          logger.debug("For block hash {}, I'm about to copy the following big maps data: \n\t{}", diffs.mkString(", "))
+          logger.debug(
+            "For block hash {}, I'm about to copy the following big maps data: \n\t{}",
+            hash.value,
+            diffs.mkString(", ")
+          )
         case _ =>
       }
       diffMap.map(_._2).flatten
@@ -68,7 +72,11 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
       val diffMap = blocks.map(b => b.data.hash.value -> TezosOptics.Blocks.readBigMapDiffRemove.getAll(b))
       diffMap.foreach {
         case (hash, diffs) if diffs.nonEmpty =>
-          logger.debug("For block hash {}, I'm about to delete the big maps for ids: \n\t{}", diffs.mkString(", "))
+          logger.debug(
+            "For block hash {}, I'm about to delete the big maps for ids: \n\t{}",
+            hash.value,
+            diffs.mkString(", ")
+          )
         case _ =>
       }
       diffMap.map(_._2).flatten
@@ -101,7 +109,11 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
       val rowsMap = blocks.map(b => b.data.hash.value -> b.convertToA[List, BigMapsRow])
       rowsMap.foreach {
         case (hash, rows) if rows.nonEmpty =>
-          logger.debug("For block hash {}, I'm about to add the following big maps: \n\t{}", rows.mkString(", "))
+          logger.debug(
+            "For block hash {}, I'm about to add the following big maps: \n\t{}",
+            hash.value,
+            rows.mkString(", ")
+          )
         case _ =>
       }
       rowsMap.map(_._2).flatten
@@ -125,6 +137,7 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
         case (hash, rows) if rows.nonEmpty =>
           logger.debug(
             "For block hash {}, I'm about to update big map contents with the following data: \n\t{}",
+            hash.value,
             rows.mkString(", ")
           )
         case _ =>
@@ -164,6 +177,7 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
         case (hash, rows) if rows.nonEmpty =>
           logger.debug(
             "For block hash {}, I'm about to add the following links from big maps to originated accounts: \n\t{}",
+            hash.value,
             rows.mkString(", ")
           )
         case _ =>

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/BigMapsOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/BigMapsOperations.scala
@@ -1,0 +1,173 @@
+package tech.cryptonomic.conseil.tezos
+
+import com.typesafe.scalalogging.LazyLogging
+import com.github.tminglei.slickpg.ExPostgresProfile
+import scala.concurrent.ExecutionContext
+import tech.cryptonomic.conseil.util.Conversion.Syntax._
+
+/** Defines big-map-diffs specific handling, from block data extraction to database storage
+  *
+  * @param profile is the actual profile needed to define database operations
+  */
+case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) extends LazyLogging {
+  import TezosTypes.{Block, Contract, Decimal}
+  import Tables.{BigMapContentsRow, BigMapsRow, OriginatedAccountMapsRow}
+  import profile.api._
+  import DatabaseConversions._
+
+  /** Create an action to find and copy big maps based on the diff contained in the blocks
+    *
+    * @param blocks the blocks containing the diffs
+    * @param ec needed to compose db operations
+    * @return the count of records added
+    */
+  def copyContent(blocks: List[Block])(implicit ec: ExecutionContext): DBIO[Int] = {
+    val copyDiffs = if (logger.underlying.isDebugEnabled()) {
+      val diffMap = blocks.map(b => b.data.hash.value -> TezosOptics.Blocks.readBigMapDiffCopy.getAll(b))
+      diffMap.foreach {
+        case (hash, diffs) =>
+          logger.debug("For block hash {}, I'm about to copy the following big maps data: \n\t{}", diffs.mkString(", "))
+      }
+      diffMap.map(_._2).flatten
+    } else blocks.flatMap(TezosOptics.Blocks.readBigMapDiffCopy.getAll)
+
+    //need to load the sources and copy them with a new destination id
+    val contentCopies = copyDiffs.collect {
+      case Contract.BigMapCopy(_, Decimal(sourceId), Decimal(destinationId)) =>
+        Tables.BigMapContents
+          .filter(_.bigMapId === sourceId)
+          .map(it => (destinationId, it.key, it.keyHash, it.value))
+          .result
+          .map(rows => rows.map(BigMapContentsRow.tupled).toList)
+    }
+
+    DBIO
+      .sequence(contentCopies)
+      .flatMap { updateRows =>
+        val copies = updateRows.flatten
+        logger.info(
+          "{} big maps will be copied in the db.",
+          if (copies.nonEmpty) s"A total of ${copies.size}"
+          else "No"
+        )
+        Tables.BigMapContents.insertOrUpdateAll(copies)
+      }
+      .map(_.sum)
+
+  }
+
+  /** Create an action to delete big maps and all related content based on the diff contained in the blocks
+    *
+    * @param blocks the blocks containing the diffs
+    * @return a database operation with no results
+    */
+  def removeMaps(blocks: List[Block]): DBIO[Unit] = {
+
+    val removalDiffs = if (logger.underlying.isDebugEnabled()) {
+      val diffMap = blocks.map(b => b.data.hash.value -> TezosOptics.Blocks.readBigMapDiffRemove.getAll(b))
+      diffMap.foreach {
+        case (hash, diffs) =>
+          logger.debug("For block hash {}, I'm about to delete the big maps for ids: \n\t{}", diffs.mkString(", "))
+      }
+      diffMap.map(_._2).flatten
+    } else blocks.flatMap(TezosOptics.Blocks.readBigMapDiffRemove.getAll)
+
+    val idsToRemove = removalDiffs.collect {
+      case Contract.BigMapRemove(_, Decimal(bigMapId)) =>
+        bigMapId
+    }.toSet
+
+    logger.info(
+      "{} big maps will be removed from the db.",
+      if (idsToRemove.nonEmpty) s"A total of ${idsToRemove.size}" else "No"
+    )
+
+    DBIO.seq(
+      Tables.BigMapContents.filter(_.bigMapId inSet idsToRemove).delete,
+      Tables.BigMaps.filter(_.bigMapId inSet idsToRemove).delete,
+      Tables.OriginatedAccountMaps.filter(_.bigMapId inSet idsToRemove).delete
+    )
+  }
+
+  /** Creates an action to add new maps based on the diff contained in the blocks
+    *
+    * @param blocks the blocks containing the diffs
+    * @return the count of records added, if available from the underlying db-engine
+    */
+  def saveMaps(blocks: List[Block]): DBIO[Option[Int]] = {
+    val maps = if (logger.underlying.isDebugEnabled()) {
+      val rowsMap = blocks.map(b => b.data.hash.value -> b.convertToA[List, BigMapsRow])
+      rowsMap.foreach {
+        case (hash, rows) =>
+          logger.debug("For block hash {}, I'm about to add the following big maps: \n\t{}", rows.mkString(", "))
+      }
+      rowsMap.map(_._2).flatten
+    } else blocks.flatMap(_.convertToA[List, BigMapsRow])
+
+    logger.info("{} big maps will be added to the db.", if (maps.nonEmpty) s"A total of ${maps.size}" else "No")
+    Tables.BigMaps ++= maps
+  }
+
+  /** Creates an action to add or replace map contents based on the diff contained in the blocks
+    * The contents might override existing data with the latest, based on block level
+    *
+    * @param blocks the blocks containing the diffs
+    * @return the count of records added, if available from the underlying db-engine
+    */
+  def upsertContent(blocks: List[Block]): DBIO[Option[Int]] = {
+    //only keep latest values from multiple blocks
+    val rowsMap = blocks.map(b => b.data.hash -> b.convertToA[List, BigMapContentsRow]).toMap
+    if (logger.underlying.isDebugEnabled()) {
+      rowsMap.foreach {
+        case (hash, rows) =>
+          logger.debug(
+            "For block hash {}, I'm about to update big map contents with the following data: \n\t{}",
+            rows.mkString(", ")
+          )
+      }
+    }
+
+    //we want to use block levels to figure out correct processing order
+    //and then collect only the latest contents for each map-id and key
+    val newContent = blocks
+      .sortBy(_.data.header.level)(Ordering[Int].reverse)
+      .foldLeft(Map.empty[(BigDecimal, String), BigMapContentsRow]) {
+        case (collected, block) =>
+          val seen = collected.keySet
+          val rows = blocks
+            .flatMap(b => rowsMap.getOrElse(b.data.hash, List.empty))
+            .filterNot(row => seen((row.bigMapId, row.key)))
+          collected ++ rows.map(row => (row.bigMapId, row.key) -> row)
+      }
+      .values
+    logger.info(
+      "{} big map content entries will be added.",
+      if (newContent.nonEmpty) s"A total of ${newContent.size}" else "No"
+    )
+    Tables.BigMapContents.insertOrUpdateAll(newContent)
+  }
+
+  /** Takes from blocks referring a big map allocation the reference to the
+    * corresponding account, storing that reference in the database
+    *
+    * @param blocks the blocks containing the diffs
+    * @return the count of records added, if available from the underlying db-engine
+    */
+  def saveContractOrigin(blocks: List[Block]): DBIO[Option[Int]] = {
+    val refs = if (logger.underlying.isDebugEnabled()) {
+      val rowsMap = blocks.map(b => b.data.hash.value -> b.convertToA[List, OriginatedAccountMapsRow])
+      rowsMap.foreach {
+        case (hash, rows) =>
+          logger.debug(
+            "For block hash {}, I'm about to add the following links from big maps to originated accounts: \n\t{}",
+            rows.mkString(", ")
+          )
+      }
+      rowsMap.map(_._2).flatten
+    } else blocks.flatMap(_.convertToA[List, OriginatedAccountMapsRow])
+
+    logger.info("{} big map accounts references will be made.", refs.size)
+    Tables.OriginatedAccountMaps ++= refs
+  }
+
+}

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/BigMapsOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/BigMapsOperations.scala
@@ -166,7 +166,7 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
       rowsMap.map(_._2).flatten
     } else blocks.flatMap(_.convertToA[List, OriginatedAccountMapsRow])
 
-    logger.info("{} big map accounts references will be made.", refs.size)
+    logger.info("{} big map accounts references will be made.", if (refs.nonEmpty) s"A total of ${refs.size}" else "No")
     Tables.OriginatedAccountMaps ++= refs
   }
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
@@ -1507,56 +1507,54 @@ trait Tables {
     /** Maps whole row to an option. Useful for outer joins. */
     def ? =
       (branch :: numberOfSlots :: cycle :: Rep.Some(operationId) :: Rep.Some(operationGroupHash) :: Rep.Some(kind) :: level :: delegate :: slots :: nonce :: pkh :: secret :: source :: fee :: counter :: gasLimit :: storageLimit :: publicKey :: amount :: destination :: parameters :: managerPubkey :: balance :: proposal :: spendable :: delegatable :: script :: storage :: status :: consumedGas :: storageSize :: paidStorageSizeDiff :: originatedContracts :: Rep
-            .Some(
-              blockHash
-            ) :: Rep.Some(blockLevel) :: ballot :: Rep.Some(internal) :: period :: Rep.Some(timestamp) :: errors :: HNil).shaped
-        .<>(
-          r =>
-            OperationsRow(
-              r(0).asInstanceOf[Option[String]],
-              r(1).asInstanceOf[Option[Int]],
-              r(2).asInstanceOf[Option[Int]],
-              r(3).asInstanceOf[Option[Int]].get,
-              r(4).asInstanceOf[Option[String]].get,
-              r(5).asInstanceOf[Option[String]].get,
-              r(6).asInstanceOf[Option[Int]],
-              r(7).asInstanceOf[Option[String]],
-              r(8).asInstanceOf[Option[String]],
-              r(9).asInstanceOf[Option[String]],
-              r(10).asInstanceOf[Option[String]],
-              r(11).asInstanceOf[Option[String]],
-              r(12).asInstanceOf[Option[String]],
-              r(13).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(14).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(15).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(16).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(17).asInstanceOf[Option[String]],
-              r(18).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(19).asInstanceOf[Option[String]],
-              r(20).asInstanceOf[Option[String]],
-              r(21).asInstanceOf[Option[String]],
-              r(22).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(23).asInstanceOf[Option[String]],
-              r(24).asInstanceOf[Option[Boolean]],
-              r(25).asInstanceOf[Option[Boolean]],
-              r(26).asInstanceOf[Option[String]],
-              r(27).asInstanceOf[Option[String]],
-              r(28).asInstanceOf[Option[String]],
-              r(29).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(30).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(31).asInstanceOf[Option[scala.math.BigDecimal]],
-              r(32).asInstanceOf[Option[String]],
-              r(33).asInstanceOf[Option[String]].get,
-              r(34).asInstanceOf[Option[Int]].get,
-              r(35).asInstanceOf[Option[String]],
-              r(36).asInstanceOf[Option[Boolean]].get,
-              r(37).asInstanceOf[Option[Int]],
-              r(38).asInstanceOf[Option[Int]],
-              r(39).asInstanceOf[Option[java.sql.Timestamp]].get,
-              r(40).asInstanceOf[Option[String]]
-            ),
-          (_: Any) => throw new Exception("Inserting into ? projection not supported.")
-        )
+            .Some(blockHash) :: Rep.Some(blockLevel) :: ballot :: Rep.Some(internal) :: period :: ballotPeriod :: Rep
+            .Some(timestamp) :: errors :: HNil).shaped.<>(
+        r =>
+          OperationsRow(
+            r(0).asInstanceOf[Option[String]],
+            r(1).asInstanceOf[Option[Int]],
+            r(2).asInstanceOf[Option[Int]],
+            r(3).asInstanceOf[Option[Int]].get,
+            r(4).asInstanceOf[Option[String]].get,
+            r(5).asInstanceOf[Option[String]].get,
+            r(6).asInstanceOf[Option[Int]],
+            r(7).asInstanceOf[Option[String]],
+            r(8).asInstanceOf[Option[String]],
+            r(9).asInstanceOf[Option[String]],
+            r(10).asInstanceOf[Option[String]],
+            r(11).asInstanceOf[Option[String]],
+            r(12).asInstanceOf[Option[String]],
+            r(13).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(14).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(15).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(16).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(17).asInstanceOf[Option[String]],
+            r(18).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(19).asInstanceOf[Option[String]],
+            r(20).asInstanceOf[Option[String]],
+            r(21).asInstanceOf[Option[String]],
+            r(22).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(23).asInstanceOf[Option[String]],
+            r(24).asInstanceOf[Option[Boolean]],
+            r(25).asInstanceOf[Option[Boolean]],
+            r(26).asInstanceOf[Option[String]],
+            r(27).asInstanceOf[Option[String]],
+            r(28).asInstanceOf[Option[String]],
+            r(29).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(30).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(31).asInstanceOf[Option[scala.math.BigDecimal]],
+            r(32).asInstanceOf[Option[String]],
+            r(33).asInstanceOf[Option[String]].get,
+            r(34).asInstanceOf[Option[Int]].get,
+            r(35).asInstanceOf[Option[String]],
+            r(36).asInstanceOf[Option[Boolean]].get,
+            r(37).asInstanceOf[Option[Int]],
+            r(38).asInstanceOf[Option[Int]],
+            r(39).asInstanceOf[Option[java.sql.Timestamp]].get,
+            r(40).asInstanceOf[Option[String]]
+          ),
+        (_: Any) => throw new Exception("Inserting into ? projection not supported.")
+      )
 
     /** Database column branch SqlType(varchar), Default(None) */
     val branch: Rep[Option[String]] = column[Option[String]]("branch", O.Default(None))

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
@@ -16,13 +16,13 @@ import tech.cryptonomic.conseil.util.MathUtil.{mean, stdev}
 import scala.concurrent.ExecutionContext
 import scala.math.{ceil, max}
 import cats.effect.Async
-import com.github.tminglei.slickpg.ExPostgresProfile
 import org.slf4j.LoggerFactory
-import slick.basic.Capability
 import tech.cryptonomic.conseil.generic.chain.DataTypes.OutputType.OutputType
-import slick.jdbc.JdbcCapabilities
 import tech.cryptonomic.conseil.tezos.TezosNodeOperator.FetchRights
 import tech.cryptonomic.conseil.tezos.TezosTypes.Voting.BakerRolls
+import slick.basic.Capability
+import slick.jdbc.JdbcCapabilities
+import com.github.tminglei.slickpg.ExPostgresProfile
 
 import scala.collection.immutable.Queue
 
@@ -32,6 +32,7 @@ import scala.collection.immutable.Queue
 object TezosDatabaseOperations extends LazyLogging {
 
   import DatabaseConversions._
+  val bigMapOps = BigMapsOperations(CustomPostgresProfile)
 
   /**
     * Writes computed fees averages to a database.
@@ -148,79 +149,13 @@ object TezosDatabaseOperations extends LazyLogging {
     * @param ec the context to run async operations
     */
   def saveBigMaps(blocks: List[Block])(implicit ec: ExecutionContext): DBIO[Unit] = {
-    import Tables.{BigMapContentsRow, BigMapsRow, OriginatedAccountMapsRow}
-    import CustomPostgresProfile.api._
+    import cats.implicits._
+    import slickeffect.implicits._
 
     logger.info("Writing big map differences to DB...")
-    //TODO add log entries at each step
 
-    val copyDiffs = blocks.flatMap(TezosOptics.Blocks.readBigMapDiffCopy.getAll)
-    val removalDiffs = blocks.flatMap(TezosOptics.Blocks.readBigMapDiffRemove.getAll)
-
-    //need to load the sources and copy them with a new destination id
-    val contentCopies = copyDiffs.collect {
-      case Contract.BigMapCopy(_, Decimal(sourceId), Decimal(destinationId)) =>
-        Tables.BigMapContents
-          .filter(_.bigMapId === sourceId)
-          .map(it => (destinationId, it.key, it.keyHash, it.value))
-          .result
-          .map(rows => rows.map(BigMapContentsRow.tupled).toList)
-    }
-
-    val copyContent = DBIO
-      .sequence(contentCopies)
-      .flatMap { updateRows =>
-        val copies = updateRows.flatten
-        logger.info("{} big maps will be copied.", copies.size)
-        Tables.BigMapContents.insertOrUpdateAll(copies)
-      }
-      .map(_.sum)
-
-    val saveMaps = {
-      val maps = blocks.flatMap(_.convertToA[List, BigMapsRow])
-      logger.info("{} big maps will be added.", maps.size)
-      Tables.BigMaps ++= maps
-    }
-
-    val upsertContent = {
-      //only keep latest values from multiple blocks
-      val newContent = blocks
-        .sortBy(_.data.header.level)(Ordering[Int].reverse)
-        .foldLeft(Map.empty[(BigDecimal, String), BigMapContentsRow]) {
-          case (collected, block) =>
-            val seen = collected.keySet
-            val rows = blocks
-              .flatMap(_.convertToA[List, BigMapContentsRow])
-              .filterNot(row => seen((row.bigMapId, row.key)))
-            collected ++ rows.map(row => (row.bigMapId, row.key) -> row)
-        }
-        .values
-      logger.info("{} big map content entries will be added.", newContent.size)
-      Tables.BigMapContents.insertOrUpdateAll(newContent)
-    }
-
-    val saveContractOrigin = {
-      val refs = blocks.flatMap(_.convertToA[List, OriginatedAccountMapsRow])
-      logger.info("{} big map accounts references will be made.", refs.size)
-      Tables.OriginatedAccountMaps ++= refs
-    }
-
-    val removeAnyNeeded: DBIO[Unit] = {
-      val idsToRemove = removalDiffs.collect {
-        case Contract.BigMapRemove(_, Decimal(bigMapId)) =>
-          bigMapId
-      }.toSet
-
-      logger.info("{} big maps will be removed.", idsToRemove.size)
-      DBIO.seq(
-        Tables.BigMapContents.filter(_.bigMapId inSet idsToRemove).delete,
-        Tables.BigMaps.filter(_.bigMapId inSet idsToRemove).delete,
-        Tables.OriginatedAccountMaps.filter(_.bigMapId inSet idsToRemove).delete
-      )
-    }
-
-    /* The interleaving of these operations would actually need more complexity to handle properly,
-     * since we're processing collections of blocks, therefore some operations handled "after" might be
+    /* The interleaving of these operations would actually need a more sophisticated handling to be robust:
+     * we're processing collections of blocks, therefore some operations handled "after" might be
      * referring to something "happening before" or viceversa.
      * E.g. you could find that a new origination creates a map with the same identifier of another previously
      * removed (is this allowed?).
@@ -229,7 +164,19 @@ object TezosDatabaseOperations extends LazyLogging {
      * We might consider improving the situation by doing a pre-check that the altered sequencing of the operations
      * doesn't interfere with the "causality" of the chain events.
      */
-    DBIO.seq(saveMaps, upsertContent, saveContractOrigin, copyContent, removeAnyNeeded)
+    val operationSequence: List[List[Block] => DBIO[Unit]] = List(
+      (bigMapOps.saveMaps _).rmap(_.void),
+      (bigMapOps.upsertContent _).rmap(_.void),
+      (bigMapOps.saveContractOrigin _).rmap(_.void),
+      (bigMapOps.copyContent _).rmap(_.void),
+      (bigMapOps.removeMaps _)
+    )
+
+    operationSequence
+      .traverse[DBIO, Unit](
+        op => op(blocks)
+      )
+      .void
   }
 
   /**


### PR DESCRIPTION
Fixes #683 

This allows updating existing key entries in a previously existing map.
The new code is extracted to a separate module (class) which allows finer grained handling and finer debugging, which needs enabling via the `logback.xml` file for the appropriate log category.

*No database schema change required* 