### PR TITLE
bugfix - fix for Lorre crashing when querying for inactive bakers.

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
@@ -630,16 +630,15 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
           if (blockTaggedAccounts.blockLevel % lorreConf.blockRightsFetching.cycleSize == 1) {
             tezosNodeOperator.fetchActiveDelegates(taggedAccounts.map(x => (x.blockLevel, x.blockHash))).flatMap {
               activeBakers =>
+                val activeBakersIds = activeBakers.toMap.apply(blockTaggedAccounts.blockHash)
                 db.run {
                   TezosDb
-                    .getInactiveBakersFromAccounts(
-                      activeBakers.toMap.apply(blockTaggedAccounts.blockHash)
-                    )
+                    .getInactiveBakersFromAccounts(activeBakersIds)
                     .map(blockTaggedAccounts -> _)
                 }
             }
           } else {
-            Future.successful(blockTaggedAccounts -> List.empty[Tables.AccountsRow])
+            Future.successful(blockTaggedAccounts -> List.empty)
           }
         }
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
@@ -15,7 +15,6 @@ import tech.cryptonomic.conseil.tezos
 import tech.cryptonomic.conseil.tezos.TezosNodeOperator.FetchRights
 import tech.cryptonomic.conseil.tezos.TezosTypes.{BakingRights, Contract, EndorsingRights}
 import com.typesafe.scalalogging.Logger
-import tech.cryptonomic.conseil.tezos.Tables.AccountsHistoryRow
 
 object DatabaseConversions extends LazyLogging {
 
@@ -126,9 +125,9 @@ object DatabaseConversions extends LazyLogging {
     }
 
   implicit val blockAccountsToAccountHistoryRows =
-    new Conversion[List, (BlockTagged[Map[AccountId, Account]], List[AccountsHistoryRow]), Tables.AccountsHistoryRow] {
+    new Conversion[List, (BlockTagged[Map[AccountId, Account]], List[Tables.AccountsRow]), Tables.AccountsHistoryRow] {
       override def convert(
-          from: (BlockTagged[Map[AccountId, Account]], List[AccountsHistoryRow])
+          from: (BlockTagged[Map[AccountId, Account]], List[Tables.AccountsRow])
       ): List[Tables.AccountsHistoryRow] = {
         import tech.cryptonomic.conseil.util.Conversion.Syntax._
         val (blockTaggedAccounts, inactiveBakers) = from
@@ -153,8 +152,17 @@ object DatabaseConversions extends LazyLogging {
 
         val untouchedAccounts =
           inactiveBakers
-            .map(_.copy(isActiveBaker = Some(false)))
-            .filterNot(accountsHistoryRow => touched.contains(accountsHistoryRow.accountId))
+            .filterNot(inactiveAccountsRow => touched.contains(inactiveAccountsRow.accountId))
+            .map {
+              _.into[Tables.AccountsHistoryRow]
+                .withFieldConst(
+                  _.asof,
+                  Timestamp.from(blockTaggedAccounts.timestamp.getOrElse(Instant.ofEpochMilli(0)))
+                )
+                .withFieldConst(_.cycle, blockTaggedAccounts.cycle)
+                .withFieldConst(_.isActiveBaker, Some(false))
+                .transform
+            }
 
         untouchedAccounts ::: touchedAccounts
       }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
@@ -152,7 +152,7 @@ object DatabaseConversions extends LazyLogging {
 
         val untouchedAccounts =
           inactiveBakers
-            .filterNot(inactiveAccountsRow => touched.contains(inactiveAccountsRow.accountId))
+            .filterNot(row => touched.contains(row.accountId))
             .map {
               _.into[Tables.AccountsHistoryRow]
                 .withFieldConst(
@@ -160,7 +160,7 @@ object DatabaseConversions extends LazyLogging {
                   Timestamp.from(blockTaggedAccounts.timestamp.getOrElse(Instant.ofEpochMilli(0)))
                 )
                 .withFieldConst(_.cycle, blockTaggedAccounts.cycle)
-                .withFieldConst(_.blockLevel, blockTaggedAccounts.blockLevel)
+                .withFieldConst(_.blockLevel, BigDecimal(blockTaggedAccounts.blockLevel))
                 .withFieldConst(_.blockId, blockTaggedAccounts.blockHash.value)
                 .withFieldConst(_.isActiveBaker, Some(false))
                 .transform

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
@@ -160,11 +160,13 @@ object DatabaseConversions extends LazyLogging {
                   Timestamp.from(blockTaggedAccounts.timestamp.getOrElse(Instant.ofEpochMilli(0)))
                 )
                 .withFieldConst(_.cycle, blockTaggedAccounts.cycle)
+                .withFieldConst(_.blockLevel, blockTaggedAccounts.blockLevel)
+                .withFieldConst(_.blockId, blockTaggedAccounts.blockHash.value)
                 .withFieldConst(_.isActiveBaker, Some(false))
                 .transform
             }
 
-        untouchedAccounts ::: touchedAccounts
+        (untouchedAccounts ::: touchedAccounts).distinct
       }
     }
 


### PR DESCRIPTION
 Fix for Lorre crashing when querying accounts_history table  for inactive bakers.
The query took too long and it occurred in timeout. Testing on my PC it took ~1m45s.
Now querying `accounts` table this time went down to under 1s.