### PR TITLE
Config: define big_maps logging level via env vars with default to off

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -17,7 +17,7 @@
     </appender>
 
     <logger name="com.base22" level="TRACE"/>
-    <logger name="tech.cryptonomic.conseil.tezos.BigMapsOperations" level="OFF"/>
+    <logger name="tech.cryptonomic.conseil.tezos.BigMapsOperations" level="${LORRE_BIG_MAPS_LOG_LEVEL:-OFF}"/>
 
     <root level="INFO">
         <appender-ref ref="ASYNC" />


### PR DESCRIPTION
This minor change defines the logging level for BigMapOperations choosing an Environment Variable first, and sets it off if missing.

In this case we add the variable `LORRE_BIG_MAPS_LOG_LEVEL`

Setting this to `DEBUG` will show detailed changes from big maps diffs before thery're applied to the database.