### PR TITLE
700 - only store big maps for applied ops

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
@@ -437,11 +437,10 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
       (
         tezosNodeOperator.getBatchBakingRights(blockHashesWithCycleAndGovernancePeriod),
         tezosNodeOperator.getBatchEndorsingRights(blockHashesWithCycleAndGovernancePeriod)
-      ).mapN {
-        case (br, er) =>
-          val updatedEndorsingRights = updateEndorsingRights(er, fetchingResults)
-          (db.run(TezosDb.upsertBakingRights(br)), db.run(TezosDb.upsertEndorsingRights(updatedEndorsingRights))).void
-      }
+      ).mapN { (br, er) =>
+        val updatedEndorsingRights = updateEndorsingRights(er, fetchingResults)
+        (db.run(TezosDb.upsertBakingRights(br)), db.run(TezosDb.upsertEndorsingRights(updatedEndorsingRights)))
+      }.void
     }
 
     /** Updates endorsing rights with endorsed block */

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/DatabaseConversions.scala
@@ -755,6 +755,9 @@ object DatabaseConversions extends LazyLogging {
    */
   implicit val blockToBigMapsRow = new Conversion[List, Block, Tables.BigMapsRow] {
     import tech.cryptonomic.conseil.util.Conversion.Syntax._
+    import tech.cryptonomic.conseil.tezos.TezosTypes.OperationResult.Status
+
+    def isApplied(status: String) = Status.parse(status).contains(Status.applied)
 
     override def convert(from: TezosTypes.Block): List[Tables.BigMapsRow] = {
 
@@ -768,11 +771,13 @@ object DatabaseConversions extends LazyLogging {
           .flatMap(diff => BlockBigMapDiff((from.data.hash, diff)).convertToA[Option, Tables.BigMapsRow])
 
       ops.toList.flatten.flatMap {
-        case op: Origination => extractDiffsToRows(op.metadata.operation_result)
+        case op: Origination if isApplied(op.metadata.operation_result.status) =>
+          extractDiffsToRows(op.metadata.operation_result)
         case _ => List.empty
       } ++
         intOps.toList.flatten.flatMap {
-          case intOp: InternalOperationResults.Origination => extractDiffsToRows(intOp.result)
+          case intOp: InternalOperationResults.Origination if isApplied(intOp.result.status) =>
+            extractDiffsToRows(intOp.result)
           case _ => List.empty
         }
     }
@@ -785,6 +790,9 @@ object DatabaseConversions extends LazyLogging {
    */
   implicit val blockToBigMapContentsRow = new Conversion[List, Block, Tables.BigMapContentsRow] {
     import tech.cryptonomic.conseil.util.Conversion.Syntax._
+    import tech.cryptonomic.conseil.tezos.TezosTypes.OperationResult.Status
+
+    def isApplied(status: String) = Status.parse(status).contains(Status.applied)
 
     override def convert(from: TezosTypes.Block): List[Tables.BigMapContentsRow] = {
       val (ops, intOps) = extractOperationsWithInternalResults(from).values.unzip
@@ -797,11 +805,13 @@ object DatabaseConversions extends LazyLogging {
           .flatMap(diff => BlockBigMapDiff((from.data.hash, diff)).convertToA[Option, Tables.BigMapContentsRow])
 
       ops.toList.flatten.flatMap {
-        case op: Transaction => extractDiffsToRows(op.metadata.operation_result)
+        case op: Transaction if isApplied(op.metadata.operation_result.status) =>
+          extractDiffsToRows(op.metadata.operation_result)
         case _ => List.empty
       } ++
         intOps.toList.flatten.flatMap {
-          case intOp: InternalOperationResults.Transaction => extractDiffsToRows(intOp.result)
+          case intOp: InternalOperationResults.Transaction if isApplied(intOp.result.status) =>
+            extractDiffsToRows(intOp.result)
           case _ => List.empty
         }
 
@@ -814,6 +824,9 @@ object DatabaseConversions extends LazyLogging {
     */
   implicit val blockToBigMapOriginatedContracts = new Conversion[List, Block, Tables.OriginatedAccountMapsRow] {
     import tech.cryptonomic.conseil.util.Conversion.Syntax._
+    import tech.cryptonomic.conseil.tezos.TezosTypes.OperationResult.Status
+
+    def isApplied(status: String) = Status.parse(status).contains(Status.applied)
 
     override def convert(from: TezosTypes.Block): List[Tables.OriginatedAccountMapsRow] = {
       val (ops, intOps) = extractOperationsWithInternalResults(from).values.unzip
@@ -830,11 +843,13 @@ object DatabaseConversions extends LazyLogging {
         } yield rows
 
       ops.toList.flatten.flatMap {
-        case op: Origination => extractDiffsToRows(op.metadata.operation_result)
+        case op: Origination if isApplied(op.metadata.operation_result.status) =>
+          extractDiffsToRows(op.metadata.operation_result)
         case _ => List.empty
       } ++
         intOps.toList.flatten.flatMap {
-          case intOp: InternalOperationResults.Origination => extractDiffsToRows(intOp.result)
+          case intOp: InternalOperationResults.Origination if isApplied(intOp.result.status) =>
+            extractDiffsToRows(intOp.result)
           case _ => List.empty
         }
     }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -7,6 +7,7 @@ import monocle.{Lens, Traversal}
 import monocle.function.all._
 import monocle.macros.{GenLens, GenPrism}
 import monocle.std.option._
+import scala.util.Try
 
 /**
   * Classes used for deserializing Tezos node RPC results.
@@ -372,6 +373,16 @@ object TezosTypes {
     final case class Error(json: String) extends AnyVal
 
     //we're currently making no difference between different statuses in any of the results
+
+    /** Utility to handle some known status strings */
+    object Status extends Enumeration {
+      type Status = Value
+      val applied, failed, skipped, backtracked = Value
+
+      def parse(in: String): Option[Status] =
+        Try(withName(in)).toOption
+
+    }
 
     final case class Reveal(
         status: String,


### PR DESCRIPTION
fix #700 

When storing rows for big map results based on operations and internal operations both, only consider data for operations with status "applied".