### PR TITLE
Removed typo in tezos.carthagenet.conf

### DIFF
--- a/src/main/resources/metadata/tezos.carthagenet.conf
+++ b/src/main/resources/metadata/tezos.carthagenet.conf
@@ -1,4 +1,3 @@
-edited
 {
   visible: true,
   entities {

--- a/src/main/resources/metadata/tezos.mainnet.conf
+++ b/src/main/resources/metadata/tezos.mainnet.conf
@@ -1,4 +1,3 @@
-edited
 {
   visible: true,
   entities {


### PR DESCRIPTION
A PR with a typo was previously erroneously merged. 