### PR TITLE
Remove the existing constraint between big maps and content

### DIFF
--- a/sql/conseil.sql
+++ b/sql/conseil.sql
@@ -380,9 +380,6 @@ CREATE TABLE tezos.big_map_contents (
     PRIMARY KEY (big_map_id, key)
 );
 
-ALTER TABLE ONLY tezos.big_map_contents
-    ADD CONSTRAINT big_map_contents_id_fkey FOREIGN KEY (big_map_id) REFERENCES tezos.big_maps(big_map_id);
-
 CREATE TABLE tezos.originated_account_maps (
     big_map_id numeric,
     account_id character varying,

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
@@ -673,13 +673,6 @@ trait Tables {
 
     /** Primary key of BigMapContents (database name big_map_contents_pkey) */
     val pk = primaryKey("big_map_contents_pkey", (bigMapId, key))
-
-    /** Foreign key referencing BigMaps (database name big_map_contents_id_fkey) */
-    lazy val bigMapsFk = foreignKey("big_map_contents_id_fkey", bigMapId, BigMaps)(
-      r => r.bigMapId,
-      onUpdate = ForeignKeyAction.NoAction,
-      onDelete = ForeignKeyAction.NoAction
-    )
   }
 
   /** Collection-like TableQuery object for table BigMapContents */

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/JsonDecodersTestFixtures.scala
@@ -683,7 +683,8 @@ trait OperationsJsonData {
     storage_limit = PositiveDecimal(0),
     source = PublicKeyHash("tz1MS1g7tETWfiPXtXx6Jx1XUrYJzzFY4QYN"),
     destination = ContractId("KT1XYHyoewY5CMDdcYB5BjN7dQbWreV5cWgH"),
-    parameters = Some(Left(Parameters(Micheline("""{"string":"tz1MS1g7tETWfiPXtXx6Jx1XUrYJzzFY4QYN"}"""), Some("default")))),
+    parameters =
+      Some(Left(Parameters(Micheline("""{"string":"tz1MS1g7tETWfiPXtXx6Jx1XUrYJzzFY4QYN"}"""), Some("default")))),
     metadata = ResultMetadata(
       operation_result = OperationResult.Transaction(
         status = "applied",

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperationsTest.scala
@@ -215,7 +215,14 @@ class TezosPlatformDiscoveryOperationsTest
             Attribute("amount", "Amount", DataType.Decimal, None, KeyType.NonKey, "operations"),
             Attribute("destination", "Destination", DataType.String, None, KeyType.UniqueKey, "operations"),
             Attribute("parameters", "Parameters", DataType.String, None, KeyType.NonKey, "operations"),
-            Attribute("parameters_entrypoints", "Parameters entrypoints", DataType.String, None, KeyType.NonKey, "operations"),
+            Attribute(
+              "parameters_entrypoints",
+              "Parameters entrypoints",
+              DataType.String,
+              None,
+              KeyType.NonKey,
+              "operations"
+            ),
             Attribute("manager_pubkey", "Manager pubkey", DataType.String, None, KeyType.NonKey, "operations"),
             Attribute("balance", "Balance", DataType.Decimal, None, KeyType.NonKey, "operations"),
             Attribute("spendable", "Spendable", DataType.Boolean, None, KeyType.NonKey, "operations"),


### PR DESCRIPTION
 * this should temporarily avoid Lorre from stopping for constraints
   violations
 * further investigation is due to identify how some big maps are not
   stored, possibly because they're from pre-babylon blocks, which
   are not handled in detail