### PR TITLE
Tuned connection settings according to emperical data

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -166,13 +166,13 @@ akka {
   # The current configuration is based on local benchmarking against zeronet
   # To improve or check it, look at the tech.cryptonomic.conseil.NodeStreamingBenchmark app
   # On the streaming http client pool we expect a max of:
-  #   30 connections x
+  #   45 connections x
   #    7 requests/conn ~=
-  #  210 ongoing requests at each moment
+  #  315 ongoing requests at each moment
   # The pipelining on each connection might slow down for slow responses, but they should be rare
   tezos-streaming-client {
     max-connections: 45
-    # The 2048 limit is thus overestimated by a factor of roughly 10x, to allow room for
+    # This limit is overestimated by a factor of roughly 10x, to allow room for
     # reuse of the same pool from different threads at the same time, up to that factor
     max-open-requests: 4096
     # essentially keep connections alive across lorre's cycles

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -126,7 +126,7 @@ lorre {
     blockOperationsConcurrencyLevel: 10
 
     #Used to paginate blocks read from tezos before each db storage
-    blockPageSize: 50
+    blockPageSize: 500
 
     #Used to specify the max-time allowed for each block-page to finish processing
     #Currently takes into account the time to process all corresponding accounts for each page
@@ -171,15 +171,15 @@ akka {
   #  210 ongoing requests at each moment
   # The pipelining on each connection might slow down for slow responses, but they should be rare
   tezos-streaming-client {
-    max-connections: 15
+    max-connections: 45
     # The 2048 limit is thus overestimated by a factor of roughly 10x, to allow room for
     # reuse of the same pool from different threads at the same time, up to that factor
-    max-open-requests: 512
+    max-open-requests: 4096
     # essentially keep connections alive across lorre's cycles
     idle-timeout: 10 minutes
     pipelining-limit: 7
     # give more room for async response in head-of-line blocking on the same connection or other slow responses
-    response-entity-subscription-timeout: 15 seconds
+    response-entity-subscription-timeout: 60 seconds
   }
 
   # this is essentially available to enable composition of database operations


### PR DESCRIPTION
Since a lot of our users are having trouble running Lorre in Docker nodes using the stock settings, I am proposing copying over the settings which we have landed on in our staging environment after weeks of testing. 