### PR TITLE
CI speed-up with latest sbt and simplified script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ jdk:
   - openjdk8
 scala:
    - 2.12.10
+script: "sbt ++$TRAVIS_SCALA_VERSION test:compile"
 after_success: "sbt coverage test coverageReport coveralls"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The Conseil server should be run behind a proxy such as Nginx with TLS enabled t
 Development
 - JDK (> 8.x)
 - Scala (> 2.12.x)
-- SBT (> 1.2.6)
+- SBT (> 1.3.x)
 - A database supported by Typesafe Slick, e.g. Postgres
 
 Deployment
@@ -188,7 +188,7 @@ To stop the database
 ```bash
 docker-compose stop
 ```
-This will stop container but will not remove the data. You can remove container and the data with 
+This will stop container but will not remove the data. You can remove container and the data with
 ```bash
 docker-compose rm
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ Should you chose to compile from source, a Scala development environment will be
 
 - JDK (> 8.x)
 - Scala (> 2.12.x)
-- SBT (> 1.2.6)
+- SBT (> 1.3.x)
 
 To package, simply run `sbt -J-Xss32m clean assembly`. This process may take a minute to complete, once it's done, `.jar` will be produced in `/tmp/conseil.jar`. To just compile, run `sbt -J-Xss32m clean compile`.
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.3.4


### PR DESCRIPTION
Using latest sbt should parallelize more work and possibly improve compile times.

This change simplifies the default ci script to only compile and not run the tests.
This will remove the need to re-run the tests twice, for the coverage check