### PR TITLE
Refactor to extract big-map logic from converters

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/tezos/BigMapsOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/BigMapsOperations.scala
@@ -10,7 +10,6 @@ import tech.cryptonomic.conseil.tezos.TezosTypes.{
   AccountId,
   ContractId,
   InternalOperationResults,
-  Micheline,
   Origination,
   Transaction
 }

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
@@ -774,7 +774,7 @@ trait TezosDataGeneration extends RandomGenerationKit {
     def updateOperationsWithBigMapAllocation(
         diffGenerate: PartialFunction[Operation, Contract.BigMapAlloc]
     ): List[Operation] => List[Operation] = {
-      import tech.cryptonomic.conseil.tezos.TezosOptics.Blocks._
+      import tech.cryptonomic.conseil.tezos.TezosOptics.Operations._
 
       //applies to the alloc diffs nested within originations
       updateOperationsToBigMapDiff[Contract.BigMapAlloc](
@@ -792,7 +792,7 @@ trait TezosDataGeneration extends RandomGenerationKit {
     def updateOperationsWithBigMapUpdate(
         diffGenerate: PartialFunction[Operation, Contract.BigMapUpdate]
     ): List[Operation] => List[Operation] = {
-      import tech.cryptonomic.conseil.tezos.TezosOptics.Blocks._
+      import tech.cryptonomic.conseil.tezos.TezosOptics.Operations._
 
       //applies to the update diffs nested within transactions
       updateOperationsToBigMapDiff[Contract.BigMapUpdate](
@@ -810,7 +810,7 @@ trait TezosDataGeneration extends RandomGenerationKit {
     def updateOperationsWithBigMapCopy(
         diffGenerate: PartialFunction[Operation, Contract.BigMapCopy]
     ): List[Operation] => List[Operation] = {
-      import tech.cryptonomic.conseil.tezos.TezosOptics.Blocks._
+      import tech.cryptonomic.conseil.tezos.TezosOptics.Operations._
 
       //applies to the update diffs nested within transactions
       updateOperationsToBigMapDiff[Contract.BigMapCopy](
@@ -828,7 +828,7 @@ trait TezosDataGeneration extends RandomGenerationKit {
     def updateOperationsWithBigMapRemove(
         diffGenerate: PartialFunction[Operation, Contract.BigMapRemove]
     ): List[Operation] => List[Operation] = {
-      import tech.cryptonomic.conseil.tezos.TezosOptics.Blocks._
+      import tech.cryptonomic.conseil.tezos.TezosOptics.Operations._
 
       //applies to the update diffs nested within transactions
       updateOperationsToBigMapDiff[Contract.BigMapRemove](


### PR DESCRIPTION
This change concentrate the logic of big map handling more into the BigMapOperations, and simplifies a lot of the conversion code to database objects, which handled such logic previously.

The goal is to make the steps more obvious, use more meaningful names, separate concerns better.

The changes are extracted from ongoing work to extract Tezos Naming Service information from smart contracts transactions, and are needed to make such work approachable, given that too much was delegated to the Conversion classes, a choice that wouldn't fit in this case.