### PR TITLE
Fixing deserialization of strings and adding escaping the characters.

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/routes/DataHelpers.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/routes/DataHelpers.scala
@@ -97,7 +97,12 @@ trait DataHelpers extends Validation with server.Endpoints with server.JsonSchem
 
     override def decoder: Decoder[Any] =
       (c: HCursor) => {
-        Right(c.value)
+        // without this check strings are deserialized in double quotes for example "String" instead of String
+        if (c.value.isString) {
+          Right(c.value.asString.get)
+        } else {
+          Right(c.value)
+        }
       }
   }
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
@@ -26,14 +26,10 @@ object ApiOperations {
   /** Sanitizes string to be viable to paste into plain SQL */
   def sanitizeForSql(str: String): String = {
     val supportedCharacters = Set('_', '.', '+', ':', '-', ' ', '%', '"', '(', ')')
-    val escapeExtraCharacters = Set('%') // '"' character is already escaped
-    str
-      .filter(c => c.isLetterOrDigit || supportedCharacters.contains(c))
-      .map {
-        case c if escapeExtraCharacters.contains(c) => "\\" ++ c.toString
-        case c => c.toString
-      }
-      .mkString("")
+    str.filter(c => c.isLetterOrDigit || supportedCharacters.contains(c)).flatMap {
+      case '%' => """\%"""
+      case c => c.toString
+    }
   }
 
   /** Sanitizes datePart aggregate function*/

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
@@ -25,7 +25,7 @@ object ApiOperations {
 
   /** Sanitizes string to be viable to paste into plain SQL */
   def sanitizeForSql(str: String): String = {
-    val supportedCharacters = Set('_', '.', '+', ':', '-', ' ', '%', '"')
+    val supportedCharacters = Set('_', '.', '+', ':', '-', ' ', '%', '"', '(', ')')
     val escapeExtraCharacters = Set('%') // '"' character is already escaped
     str
       .filter(c => c.isLetterOrDigit || supportedCharacters.contains(c))

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/ApiOperations.scala
@@ -25,8 +25,15 @@ object ApiOperations {
 
   /** Sanitizes string to be viable to paste into plain SQL */
   def sanitizeForSql(str: String): String = {
-    val supportedCharacters = Set('_', '.', '+', ':', '-', ' ')
-    str.filter(c => c.isLetterOrDigit || supportedCharacters.contains(c))
+    val supportedCharacters = Set('_', '.', '+', ':', '-', ' ', '%', '"')
+    val escapeExtraCharacters = Set('%') // '"' character is already escaped
+    str
+      .filter(c => c.isLetterOrDigit || supportedCharacters.contains(c))
+      .map {
+        case c if escapeExtraCharacters.contains(c) => "\\" ++ c.toString
+        case c => c.toString
+      }
+      .mkString("")
   }
 
   /** Sanitizes datePart aggregate function*/

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/ApiOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/ApiOperationsTest.scala
@@ -104,13 +104,13 @@ class ApiOperationsTest
 
       "sanitizeForSql alphanumeric string with unsupported characters" in {
         // given
-        val input = ";xyz$%*)("
+        val input = ";xyz$*)("
 
         // when
         val result = ApiOperations.sanitizeForSql(input)
 
         // then
-        result shouldBe "xyz"
+        result shouldBe "xyz)("
       }
 
       "sanitizeForSql and escape characters for SQL" in {
@@ -121,7 +121,7 @@ class ApiOperationsTest
         val result = ApiOperations.sanitizeForSql(input)
 
         // then
-        result shouldBe "\"xyz\\%"
+        result shouldBe "\"xyz\\%)("
       }
 
       "fetchOperationGroup when DB is empty" in {

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/ApiOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/ApiOperationsTest.scala
@@ -113,6 +113,17 @@ class ApiOperationsTest
         result shouldBe "xyz"
       }
 
+      "sanitizeForSql and escape characters for SQL" in {
+        // given
+        val input = "\";xyz$%*)("
+
+        // when
+        val result = ApiOperations.sanitizeForSql(input)
+
+        // then
+        result shouldBe "\"xyz\\%"
+      }
+
       "fetchOperationGroup when DB is empty" in {
         // given
         val input = "xyz"


### PR DESCRIPTION
As @anonymoussprocket pointed out, he had troubles with querying Conseil with certain characters - I've added support for `"`, `(`, `)`, and escaping `%` character.
Also needed to fix deserialization of JSON strings in predicates set, as it was deserializing it with quotes. 
It was hidden because previously we were filtering out `"` characters.