### PR TITLE
Rename the token contract type column and use commas as separator

### DIFF
--- a/sql/conseil.sql
+++ b/sql/conseil.sql
@@ -125,7 +125,7 @@ CREATE TABLE tezos.processed_chain_events (
 CREATE TABLE tezos.registered_tokens (
     id integer PRIMARY KEY,
     name text NOT NULL,
-    standard text NOT NULL,
+    contract_type text NOT NULL,
     account_id text NOT NULL
 );
 

--- a/src/main/resources/registered_tokens/babylonnet.csv
+++ b/src/main/resources/registered_tokens/babylonnet.csv
@@ -1,2 +1,2 @@
-id|name|standard|account_id
-1 | USDTez | FA1.2 | KT1RmDuQ6LaTFfLrVtKNcBJkMgvnopEATJux
+id, name  , contract_type, account_id
+1 , USDTez, FA1.2        , KT1RmDuQ6LaTFfLrVtKNcBJkMgvnopEATJux

--- a/src/main/resources/registered_tokens/carthagenet.csv
+++ b/src/main/resources/registered_tokens/carthagenet.csv
@@ -1,2 +1,2 @@
-id|name|standard|account_id
-1 | Sample Token A | FA1.2 | KT1HzQofKBxzfiKoMzGbkxBgjis2mWnCtbC2
+id, name          , contract_type, account_id
+1 , Sample Token A, FA1.2        , KT1HzQofKBxzfiKoMzGbkxBgjis2mWnCtbC2

--- a/src/main/resources/registered_tokens/mainnet.csv
+++ b/src/main/resources/registered_tokens/mainnet.csv
@@ -1,1 +1,1 @@
-id|name|standard|account_id
+id, name, contract_type, account_id

--- a/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
@@ -88,7 +88,7 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
   implicit val tokenContracts: TokenContracts = {
 
     val futureTokenContracts =
-      TezosDb.initTableFromCsv(db, Tables.RegisteredTokens, tezosConf.network, separator = '|').map {
+      TezosDb.initTableFromCsv(db, Tables.RegisteredTokens, tezosConf.network).map {
         case (tokenRows, _) =>
           TokenContracts.fromTokens(
             tokenRows.map {

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/Tables.scala
@@ -2405,9 +2405,9 @@ trait Tables {
   /** Entity class storing rows of table RegisteredTokens
     *  @param id Database column id SqlType(int4), PrimaryKey
     *  @param name Database column name SqlType(text)
-    *  @param standard Database column standard SqlType(text)
+    *  @param contractType Database column contract_type SqlType(text)
     *  @param accountId Database column account_id SqlType(text) */
-  case class RegisteredTokensRow(id: Int, name: String, standard: String, accountId: String)
+  case class RegisteredTokensRow(id: Int, name: String, contractType: String, accountId: String)
 
   /** GetResult implicit for fetching RegisteredTokensRow objects using plain SQL queries */
   implicit def GetResultRegisteredTokensRow(implicit e0: GR[Int], e1: GR[String]): GR[RegisteredTokensRow] = GR { prs =>
@@ -2418,11 +2418,11 @@ trait Tables {
   /** Table description of table registered_tokens. Objects of this class serve as prototypes for rows in queries. */
   class RegisteredTokens(_tableTag: Tag)
       extends profile.api.Table[RegisteredTokensRow](_tableTag, Some("tezos"), "registered_tokens") {
-    def * = (id, name, standard, accountId) <> (RegisteredTokensRow.tupled, RegisteredTokensRow.unapply)
+    def * = (id, name, contractType, accountId) <> (RegisteredTokensRow.tupled, RegisteredTokensRow.unapply)
 
     /** Maps whole row to an option. Useful for outer joins. */
     def ? =
-      ((Rep.Some(id), Rep.Some(name), Rep.Some(standard), Rep.Some(accountId))).shaped.<>(
+      ((Rep.Some(id), Rep.Some(name), Rep.Some(contractType), Rep.Some(accountId))).shaped.<>(
         { r =>
           import r._; _1.map(_ => RegisteredTokensRow.tupled((_1.get, _2.get, _3.get, _4.get)))
         },
@@ -2435,8 +2435,8 @@ trait Tables {
     /** Database column name SqlType(text) */
     val name: Rep[String] = column[String]("name")
 
-    /** Database column standard SqlType(text) */
-    val standard: Rep[String] = column[String]("standard")
+    /** Database column contract_type SqlType(text) */
+    val contractType: Rep[String] = column[String]("contract_type")
 
     /** Database column account_id SqlType(text) */
     val accountId: Rep[String] = column[String]("account_id")

--- a/src/test/resources/registered_tokens/testnet.csv
+++ b/src/test/resources/registered_tokens/testnet.csv
@@ -1,2 +1,2 @@
-id|name|standard|account_id
-1 | USDTez | FA1.2 | tz1eEnQhbwf6trb8Q8mPb2RaPkNk2rN7BKi9
+id| name  | contract_type| account_id
+1 | USDTez| FA1.2        | tz1eEnQhbwf6trb8Q8mPb2RaPkNk2rN7BKi9


### PR DESCRIPTION
Minor changes requested to the format of token configuration files.

 * renamed `standard` to `contract_type` to fit more general contracts
    originally requested as `type` which would create unnecessary complications in scala code as a reserved word.
 * using commas as separators now in every csv file.

## Needed changes to db-schema

the new definition for the tokens registration table is

```sql
CREATE TABLE tezos.registered_tokens (
    id integer PRIMARY KEY,
    name text NOT NULL,
    contract_type text NOT NULL,
    account_id text NOT NULL
);
```

the column `standard` was renamed to `contract_type`