### PR TITLE
Update mainnet and carthagenet metadata overrides

### DIFF
--- a/src/main/resources/metadata/tezos.carthagenet.conf
+++ b/src/main/resources/metadata/tezos.carthagenet.conf
@@ -265,43 +265,6 @@
         }
       }
     }
-    ballots {
-      display-name-plural: "Ballots"
-      display-name: "Ballot"
-      visible: true
-      attributes {
-        pkh {
-          display-name: "Address"
-          visible: true
-          data-type: "accountAddress"
-          reference: {
-            entity: "accounts"
-            key: "account_id"
-          }
-        }
-        ballot {
-          display-name: "Vote"
-          visible: true
-        }
-        block_id {
-          display-name: "Block Hash"
-          data-type: "hash"
-          visible: true
-          reference: {
-            entity: "blocks"
-            key: "hash"
-          }
-        }
-        block_level {
-          display-name: "Block Level"
-          visible: true
-          reference: {
-            entity: "blocks"
-            key: "level"
-          }
-        }
-      }
-    }
     big_maps {
       display-name-plural: "Big Maps"
       display-name: "Big Map"
@@ -887,6 +850,9 @@
           data-type: "currency"
           currency-symbol-code: 42793
         }
+        rolls {
+          visible: true
+        }
         deactivated {
           visible: true
         }
@@ -912,10 +878,7 @@
     accounts_checkpoint {
       visible: false
     }
-    delegates_checkpoint {
-      visible: false
-    }
-    delegated_contracts {
+    bakers_checkpoint {
       visible: false
     }
     baking_rights {
@@ -1026,7 +989,7 @@
           display-name: "Name"
           visible: true
         }
-        standard {
+        contract_type {
           display-name: "Standard"
           visible: true
         }

--- a/src/main/resources/metadata/tezos.mainnet.conf
+++ b/src/main/resources/metadata/tezos.mainnet.conf
@@ -315,43 +315,6 @@
         }
       }
     }
-    ballots {
-      display-name-plural: "Ballots"
-      display-name: "Ballot"
-      visible: true
-      attributes {
-        pkh {
-          display-name: "Address"
-          visible: true
-          data-type: "accountAddress"
-          reference: {
-            entity: "accounts"
-            key: "account_id"
-          }
-        }
-        ballot {
-          display-name: "Vote"
-          visible: true
-        }
-        block_id {
-          display-name: "Block Hash"
-          data-type: "hash"
-          visible: true
-          reference: {
-            entity: "blocks"
-            key: "hash"
-          }
-        }
-        block_level {
-          display-name: "Block Level"
-          visible: true
-          reference: {
-            entity: "blocks"
-            key: "level"
-          }
-        }
-      }
-    }
     big_maps {
       display-name-plural: "Big Maps"
       display-name: "Big Map"
@@ -1048,6 +1011,9 @@
           data-type: "currency"
           currency-symbol-code: 42793
         }
+        rolls {
+          visible: true
+        }
         deactivated {
           visible: true
         }
@@ -1073,10 +1039,7 @@
     accounts_checkpoint {
       visible: false
     }
-    delegates_checkpoint {
-      visible: false
-    }
-    delegated_contracts {
+    bakers_checkpoint {
       visible: false
     }
     baking_rights {
@@ -1187,7 +1150,7 @@
           display-name: "Name"
           visible: true
         }
-        standard {
+        contract_type {
           display-name: "Standard"
           visible: true
         }


### PR DESCRIPTION
Fix #772 

* Removed the `ballots` overrides, since the entity was removed from db
* renamed the token_registry field
* renamed the checkpoint for `bakers`
* added visibility to baker's rolls

I ignored old changes left not overridden for a while, since I assume there might be reasons they've been left as is.