### PR TITLE
Use a function to read hex-account addresses for tokens on big map diffs key

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/contracts/TokenContracts.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/contracts/TokenContracts.scala
@@ -134,22 +134,6 @@ object TokenContracts extends LazyLogging {
 
   /** Defines enc-dec operation used for token big maps */
   object Codecs {
-    import scorex.util.encode.{Base16 => Hex}
-    import scorex.crypto.hash.{Blake2b256 => Blake}
-
-    /** Complete sequence to compute key_hash from a tz#|KT1... account address */
-    def computeKeyHash(address: AccountId): Try[String] =
-      for {
-        packed <- CryptoUtil.packAddress(address.id)
-        binary <- Hex.decode(packed)
-        hashed <- encodeBigMapKey(binary)
-      } yield hashed
-
-    /** Takes the bytes for a map key and creates the key-hash */
-    def encodeBigMapKey(bytes: Array[Byte]): Try[String] = {
-      val hashed = Blake.hash(bytes).toSeq
-      CryptoUtil.base58CheckEncode(hashed, "expr")
-    }
 
     /** Tries to read the map id as an hex bytestring, and convert it to a valid account id */
     def decodeBigMapKey(hexEncoded: String): Option[AccountId] = {

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/contracts/TokenContractsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/contracts/TokenContractsTest.scala
@@ -156,34 +156,6 @@ class TokenContractsTest extends WordSpec with Matchers with OptionValues {
 
       }
 
-      "allow computation of the correct key hash for an account address" in {
-        //example taken from relevant conseil.js tests
-        val hash = TokenContracts.Codecs.computeKeyHash(AccountId("tz1eEnQhbwf6trb8Q8mPb2RaPkNk2rN7BKi8"))
-        hash shouldBe Success("exprv7U7pkJHbeUGhs7Wj8GTUnvfZfJRUcSCRo2EYqRSnUx1xWKrY9")
-      }
-
-      "compute the correct key hash for the sample babylon account address" in {
-        //some values sampled from a real babylon use-case
-        val hash = TokenContracts.Codecs.computeKeyHash(AccountId("tz1dae51wqhBwC7YdGiJAAU5JYwEvVH3Usf2"))
-        hash shouldBe Success("exprvMHy4mAi1igbigE5BeEbEAE5ayx82ne5BA7UUXmfGpAiiVF3vx")
-      }
-
-      "allow computation of the correct hash from a binary string" in {
-        //example taken from relevant conseil.js tests
-        val bytes = scorex.util.encode.Base16.decode("050a000000160000cc04e65d3e38e4e8059041f27a649c76630f95e2")
-        bytes shouldBe a[Success[_]]
-        val hash = TokenContracts.Codecs.encodeBigMapKey(bytes.get)
-        hash shouldBe Success("exprv7U7pkJHbeUGhs7Wj8GTUnvfZfJRUcSCRo2EYqRSnUx1xWKrY9")
-      }
-
-      "compute the correct hash from the sample babylon key bytes" in {
-        //some values sampled from a real babylon use-case
-        val bytes = scorex.util.encode.Base16.decode("050a000000160000cc04e65d3e38e4e8059041f27a649c76630f95e2")
-        bytes shouldBe a[Success[_]]
-        val hash = TokenContracts.Codecs.encodeBigMapKey(bytes.get)
-        hash shouldBe Success("exprv7U7pkJHbeUGhs7Wj8GTUnvfZfJRUcSCRo2EYqRSnUx1xWKrY9")
-      }
-
     }
 
 }

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/contracts/TokenContractsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/contracts/TokenContractsTest.scala
@@ -43,8 +43,8 @@ class TokenContractsTest extends WordSpec with Matchers with OptionValues {
         val balanceUpdate = sut.readBalance(ledgerId)(mapUpdate)
 
         //then
-        val (keyHash, balance) = balanceUpdate.value
-        keyHash shouldEqual mapUpdate.key_hash
+        val (AccountId(id), balance) = balanceUpdate.value
+        id shouldEqual "tz1dae51wqhBwC7YdGiJAAU5JYwEvVH3Usf2"
         balance shouldEqual BigInt(10000)
 
       }

--- a/src/test/scala/tech/cryptonomic/conseil/util/CryptoUtilTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/util/CryptoUtilTest.scala
@@ -4,18 +4,31 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class CryptoUtilTest extends FlatSpec with Matchers {
 
-  "CryptoUtil" should "correctly decode and encode a Tezos account ID" in {
+  "CryptoUtil" should "correctly decode and encode a Tezos account ID as bytes" in {
       val accountID = "tz1Z5pFi5Sy99Kcz36XA5WtKW7Z6NVG9LdA4"
       val decoded = CryptoUtil.base58CheckDecode(accountID, "tz1").get
       val encoded = CryptoUtil.base58CheckEncode(decoded.toList, "tz1").get
       encoded should be(accountID)
     }
 
-  "CryptoUtil" should "correctly decode and encode a Tezos operation ID" in {
+  it should "correctly decode and encode a Tezos operation ID" in {
       val operationID = "op26bhfiE1tVKiZHfkujRcasnghyRnvDx9gnKGiNwAW98M71EWF"
       val decoded = CryptoUtil.base58CheckDecode(operationID, "op").get
       val encoded = CryptoUtil.base58CheckEncode(decoded.toList, "op").get
       encoded should be(operationID)
+    }
+
+  it should "correctly pack and unpack a Tezos account ID as hex-string" in {
+      val accountID = "tz1Z5pFi5Sy99Kcz36XA5WtKW7Z6NVG9LdA4"
+      val packed = CryptoUtil.packAddress(accountID).get
+      //packing adds the packet length at the beginning, read doesn't care
+      val unpacked = CryptoUtil.readAddress(packed.drop(12)).get
+      unpacked should be(accountID)
+    }
+
+  it should "read a binary address to its b58check tezos id" in {
+      val address = CryptoUtil.readAddress("0000a8d45bdc966ddaaac83188a1e1c1fde2a3e05e5c").get
+      address shouldBe "tz1b2icJC4E7Y2ED1xsZXuqYpF7cxHDtduuP"
     }
 
 }


### PR DESCRIPTION
Preparatory PR for #761 

Previously the code didn't convert big map keys directly to accounts' addresses, but inferred it by checking a key-hashed version of it with anything involved in the transaction call code parameters.

Using a function to simply do the conversion extremely simplifies the token parsing of data and it's fundamental to be able to do that for stakerdao contracts