### PR TITLE
Swap handling of micheline parameters to be more obvious

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -648,16 +648,13 @@ class TezosNodeOperator(
 
     def parseMichelsonScripts: Block => Block = {
       implicit lazy val _ = logger
-      def rewriteParametersInTransactions(transaction: Transaction): Transaction = {
-        val expr = transaction.parameters.map {
-          case Left(Parameters(micheline, _)) => micheline.expression
-          case Right(micheline) => micheline.expression
-        }
-        transaction.copy(parameters_micheline = expr)
-      }
+      val copyParametersToMicheline = (t: Transaction) => t.copy(parameters_micheline = t.parameters)
+
       val codeAlter = codeLens.modify(toMichelsonScript[MichelsonSchema])
       val storageAlter = storageLens.modify(toMichelsonScript[MichelsonInstruction])
-      val setUnparsedMicheline = transactionLens.modify(rewriteParametersInTransactions)
+      val setUnparsedMicheline = transactionLens.modify(copyParametersToMicheline)
+      //TODO focus the lens on the optional field and empty it if the conversion fails
+      //we have a copy anyway in the parameters_micheline
       val parametersAlter = parametersLens.modify(toMichelsonScript[MichelsonInstruction])
 
       codeAlter compose storageAlter compose setUnparsedMicheline compose parametersAlter

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -255,7 +255,7 @@ object TezosTypes {
       source: PublicKeyHash,
       destination: ContractId,
       parameters: Option[ParametersCompatibility],
-      parameters_micheline: Option[String],
+      parameters_micheline: Option[ParametersCompatibility],
       metadata: ResultMetadata[OperationResult.Transaction]
   ) extends Operation
 
@@ -339,7 +339,7 @@ object TezosTypes {
         amount: PositiveBigNumber,
         destination: ContractId,
         parameters: Option[ParametersCompatibility],
-        parameters_micheline: Option[String],
+        parameters_micheline: Option[ParametersCompatibility],
         result: OperationResult.Transaction
     ) extends InternalOperationResult
 

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DatabaseConversionsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DatabaseConversionsTest.scala
@@ -328,6 +328,8 @@ class DatabaseConversionsTest
               converted.amount ::
               converted.destination ::
               converted.parameters ::
+              converted.parametersMicheline ::
+              converted.parametersEntrypoints ::
               converted.managerPubkey ::
               converted.balance ::
               converted.spendable ::
@@ -373,6 +375,8 @@ class DatabaseConversionsTest
               converted.amount ::
               converted.destination ::
               converted.parameters ::
+              converted.parametersMicheline ::
+              converted.parametersEntrypoints ::
               converted.managerPubkey ::
               converted.balance ::
               converted.spendable ::
@@ -418,6 +422,8 @@ class DatabaseConversionsTest
               converted.amount ::
               converted.destination ::
               converted.parameters ::
+              converted.parametersMicheline ::
+              converted.parametersEntrypoints ::
               converted.managerPubkey ::
               converted.balance ::
               converted.spendable ::
@@ -482,6 +488,7 @@ class DatabaseConversionsTest
               converted.amount ::
               converted.destination ::
               converted.parameters ::
+              converted.parametersMicheline ::
               converted.parametersEntrypoints ::
               converted.managerPubkey ::
               converted.balance ::
@@ -532,7 +539,7 @@ class DatabaseConversionsTest
           case _ => converted.amount shouldBe 'empty
         }
         converted.destination.value shouldBe sampleTransaction.destination.id
-        converted.parameters shouldBe sampleTransaction.parameters.map(_.left.value.value.expression)
+        converted.parametersMicheline shouldBe sampleTransaction.parameters.map(_.left.value.value.expression)
         converted.parametersEntrypoints shouldBe sampleTransaction.parameters.flatMap(_.left.value.entrypoint)
         converted.status.value shouldBe sampleTransaction.metadata.operation_result.status
         sampleTransaction.metadata.operation_result.consumed_gas match {
@@ -557,6 +564,7 @@ class DatabaseConversionsTest
               converted.secret ::
               converted.publicKey ::
               converted.managerPubkey ::
+              converted.parameters ::
               converted.balance ::
               converted.spendable ::
               converted.delegatable ::
@@ -633,6 +641,8 @@ class DatabaseConversionsTest
               converted.amount ::
               converted.destination ::
               converted.parameters ::
+              converted.parametersMicheline ::
+              converted.parametersEntrypoints ::
               Nil
         ) {
           _ shouldBe 'empty
@@ -686,6 +696,8 @@ class DatabaseConversionsTest
               converted.amount ::
               converted.destination ::
               converted.parameters ::
+              converted.parametersMicheline ::
+              converted.parametersEntrypoints ::
               converted.managerPubkey ::
               converted.balance ::
               converted.spendable ::
@@ -728,6 +740,8 @@ class DatabaseConversionsTest
               converted.amount ::
               converted.destination ::
               converted.parameters ::
+              converted.parametersMicheline ::
+              converted.parametersEntrypoints ::
               converted.managerPubkey ::
               converted.balance ::
               converted.spendable ::
@@ -773,6 +787,8 @@ class DatabaseConversionsTest
               converted.amount ::
               converted.destination ::
               converted.parameters ::
+              converted.parametersMicheline ::
+              converted.parametersEntrypoints ::
               converted.managerPubkey ::
               converted.balance ::
               converted.spendable ::
@@ -820,6 +836,8 @@ class DatabaseConversionsTest
               converted.amount ::
               converted.destination ::
               converted.parameters ::
+              converted.parametersMicheline ::
+              converted.parametersEntrypoints ::
               converted.managerPubkey ::
               converted.balance ::
               converted.spendable ::
@@ -868,6 +886,8 @@ class DatabaseConversionsTest
               converted.amount ::
               converted.destination ::
               converted.parameters ::
+              converted.parametersMicheline ::
+              converted.parametersEntrypoints ::
               converted.managerPubkey ::
               converted.balance ::
               converted.spendable ::


### PR DESCRIPTION
fix #775 

When micheline conversion fails, the records will keep the value in `parameters_micheline` and leave the `parameters` field empty. 