### PR TITLE
761 - support StakerDao token updates

### DIFF
--- a/src/main/resources/metadata/tezos.babylonnet.conf
+++ b/src/main/resources/metadata/tezos.babylonnet.conf
@@ -104,6 +104,9 @@
           display-name: "Is Baker"
           visible: true
         }
+        is_activated {
+          visible: true
+        }
       }
     }
     accounts_history {
@@ -190,6 +193,12 @@
         }
         is_baker {
           display-name: "Is Baker"
+          visible: true
+        }
+        is_activated {
+          visible: true
+        }
+        is_active_baker {
           visible: true
         }
       }
@@ -787,6 +796,11 @@
         }
         status: {
           visible: true
+          cache-config {
+            cached: true,
+            min-match-length: 4,
+            max-result-size: 100
+          }
         }
         consumed_gas: {
           visible: true
@@ -861,6 +875,18 @@
           visible: true
         }
         errors: {
+          visible: true
+        }
+        utc_year: {
+          visible: true
+        }
+        utc_month: {
+          visible: true
+        }
+        utc_day: {
+          visible: true
+        }
+        utc_time: {
           visible: true
         }
       }
@@ -1071,6 +1097,9 @@
         estimated_time {
           visible: true
           data-format: "YYYY MMM DD, HH:mm"
+        }
+        endorsed_block {
+          visible: true
         }
       }
     }

--- a/src/main/resources/metadata/tezos.carthagenet.conf
+++ b/src/main/resources/metadata/tezos.carthagenet.conf
@@ -104,6 +104,9 @@
           display-name: "Is Baker"
           visible: true
         }
+        is_activated {
+          visible: true
+        }
       }
     }
     accounts_history {
@@ -190,6 +193,12 @@
         }
         is_baker {
           display-name: "Is Baker"
+          visible: true
+        }
+        is_activated {
+          visible: true
+        }
+        is_active_baker {
           visible: true
         }
       }
@@ -498,6 +507,18 @@
         priority {
           visible: true
         }
+        utc_year: {
+          visible: true
+        }
+        utc_month: {
+          visible: true
+        }
+        utc_day: {
+          visible: true
+        }
+        utc_time: {
+          visible: true
+        }
       }
     }
     fees {
@@ -721,6 +742,11 @@
         }
         status: {
           visible: true
+          cache-config {
+            cached: true,
+            min-match-length: 4,
+            max-result-size: 100
+          }
         }
         consumed_gas: {
           visible: true
@@ -795,6 +821,18 @@
           visible: true
         }
         errors: {
+          visible: true
+        }
+        utc_year: {
+          visible: true
+        }
+        utc_month: {
+          visible: true
+        }
+        utc_day: {
+          visible: true
+        }
+        utc_time: {
           visible: true
         }
       }
@@ -978,6 +1016,9 @@
         estimated_time {
           visible: true
           data-format: "YYYY MMM DD, HH:mm"
+        }
+        endorsed_block {
+          visible: true
         }
       }
     }

--- a/src/main/resources/metadata/tezos.mainnet.conf
+++ b/src/main/resources/metadata/tezos.mainnet.conf
@@ -156,6 +156,9 @@
           display-name: "Is Baker"
           visible: true
         }
+        is_activated {
+          visible: true
+        }
       }
     }
     accounts_history {
@@ -242,6 +245,12 @@
         }
         is_baker {
           display-name: "Is Baker"
+          visible: true
+        }
+        is_activated {
+          visible: true
+        }
+        is_active_baker {
           visible: true
         }
       }
@@ -601,6 +610,18 @@
         priority {
           visible: true
         }
+        utc_year: {
+          visible: true
+        }
+        utc_month: {
+          visible: true
+        }
+        utc_day: {
+          visible: true
+        }
+        utc_time: {
+          visible: true
+        }
       }
     }
     fees {
@@ -843,6 +864,11 @@
         }
         status: {
           visible: true
+          cache-config {
+            cached: true,
+            min-match-length: 4,
+            max-result-size: 100
+          }
         }
         consumed_gas: {
           visible: true
@@ -917,6 +943,18 @@
           visible: true
         }
         errors: {
+          visible: true
+        }
+        utc_year: {
+          visible: true
+        }
+        utc_month: {
+          visible: true
+        }
+        utc_day: {
+          visible: true
+        }
+        utc_time: {
           visible: true
         }
       }
@@ -1141,6 +1179,9 @@
         estimated_time {
           visible: true
           data-format: "YYYY MMM DD, HH:mm"
+        }
+        endorsed_block {
+          visible: true
         }
       }
     }

--- a/src/main/resources/metadata/tezos.mainnet.conf
+++ b/src/main/resources/metadata/tezos.mainnet.conf
@@ -33,6 +33,8 @@
             "tz1Z9MxKUBcbA6SKyKu9VLif8PeiQ5fkpCeo": "@tezosnoob"
             "tz1djRgXXWWJiY1rpMECCxr5d9ZBqWewuiU1": "Galleon Support"
             "KT1ChNsEFxwyCbJyWGSL3KdjeXE28AY1Kaog": "TCF Baker Registry"
+            "tz1RaGb8tWxUh194btmAiXT9Tkk6pGBMZVL8": "USDtz Mother"
+            "KT1LN4LPSqTMS7Sd2CJw4bbDGRkMv2t68Fy9": "USDtz Token"
 
             "tz1gk3TDbU7cJuiBRMhwQXVvgDnjsxuWhcEA": "Airfoil"
             "tz1MJx9vhaNRSimcuXPK2rW4fLccQnDAnVKJ": "AirGap"

--- a/src/main/resources/registered_tokens/carthagenet.csv
+++ b/src/main/resources/registered_tokens/carthagenet.csv
@@ -1,2 +1,3 @@
 id, name          , contract_type, account_id
 1 , Sample Token A, FA1.2        , KT1HzQofKBxzfiKoMzGbkxBgjis2mWnCtbC2
+2 , Stacker DAO   , FA1.2        , KT1HcYqwgsAUk8GrQEewWbteE5rKjNmVR6fA

--- a/src/main/resources/registered_tokens/carthagenet.csv
+++ b/src/main/resources/registered_tokens/carthagenet.csv
@@ -1,3 +1,3 @@
-id, name          , contract_type, account_id
-1 , Sample Token A, FA1.2        , KT1HzQofKBxzfiKoMzGbkxBgjis2mWnCtbC2
-2 , Stacker DAO   , FA1.2        , KT1HcYqwgsAUk8GrQEewWbteE5rKjNmVR6fA
+id, name          , contract_type  , account_id
+1 , Sample Token A, FA1.2          , KT1HzQofKBxzfiKoMzGbkxBgjis2mWnCtbC2
+2 , Staker DAO    , FA1.2-StakerDao, KT1HcYqwgsAUk8GrQEewWbteE5rKjNmVR6fA

--- a/src/main/resources/registered_tokens/mainnet.csv
+++ b/src/main/resources/registered_tokens/mainnet.csv
@@ -1,2 +1,2 @@
-id, name       , contract_type, account_id
-1 , Stacker DAO, FA1.2        , KT1EctCuorV2NfVb1XTQgvzJ88MQtWP8cMMv
+id, name      , contract_type  , account_id
+1 , Staker DAO, FA1.2-StakerDao, KT1EctCuorV2NfVb1XTQgvzJ88MQtWP8cMMv

--- a/src/main/resources/registered_tokens/mainnet.csv
+++ b/src/main/resources/registered_tokens/mainnet.csv
@@ -1,1 +1,2 @@
-id, name, contract_type, account_id
+id, name       , contract_type, account_id
+1 , Stacker DAO, FA1.2        , KT1EctCuorV2NfVb1XTQgvzJ88MQtWP8cMMv

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosPlatformDiscoveryOperations.scala
@@ -208,8 +208,7 @@ class TezosPlatformDiscoveryOperations(
 
   /** Makes list of possible string values of the attributes
     *
-    * @param  tableName             name of the table from which we extract attributes
-    * @param  column                name of the attribute
+    * @param  attributePath         path of the attribute to extract caching config
     * @param  withFilter            optional parameter which can filter attributes
     * @param  attributesCacheConfig optional parameter available when attribute needs to be cached
     * @return Either list of attributes or list of errors
@@ -234,7 +233,8 @@ class TezosPlatformDiscoveryOperations(
                 ),
                 left = Future.successful(List(InvalidAttributeFilterLength(attributePath.attribute, minMatchLength)))
               )
-
+            case (Some(AttributeCacheConfiguration(cached, _, maxResultLength)), None) if cached =>
+              Right(getAttributeValuesFromCache(attributePath.up.entity, attributePath.attribute, "", maxResultLength))
             case _ =>
               val invalidDataTypeValidationResult =
                 if (!attrOpt.exists(attr => canQueryType(attr.dataType)))

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/contracts/TokenContracts.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/michelson/contracts/TokenContracts.scala
@@ -1,6 +1,6 @@
 package tech.cryptonomic.conseil.tezos.michelson.contracts
 
-import tech.cryptonomic.conseil.tezos.TezosTypes.{AccountId, Contract, ContractId, Decimal, ScriptId}
+import tech.cryptonomic.conseil.tezos.TezosTypes.{AccountId, Contract, ContractId, Decimal}
 import tech.cryptonomic.conseil.tezos.TezosTypes.Micheline
 import cats.implicits._
 import scala.collection.immutable.TreeSet
@@ -8,7 +8,6 @@ import scala.util.Try
 import scala.concurrent.SyncVar
 import com.typesafe.scalalogging.LazyLogging
 import tech.cryptonomic.conseil.util.CryptoUtil
-import scala.util.Failure
 
 /** For each specific contract available we store a few
   * relevant bits of data useful to extract information

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -10,6 +10,8 @@
     </appender>
 
     <logger name="com.base22" level="TRACE"/>
+    <logger name="tech.cryptonomic.conseil.tezos.BigMapsOperations" level="DEBUG"/>
+    <logger name="tech.cryptonomic.conseil.tezos.michelson.contracts.TNSContracts" level="DEBUG"/>
 
     <root level="OFF">
         <appender-ref ref="STDOUT" />

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/contracts/StakerDaoTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/contracts/StakerDaoTest.scala
@@ -1,0 +1,107 @@
+package tech.cryptonomic.conseil.tezos.michelson.contracts
+
+import org.scalatest.{Matchers, OptionValues, WordSpec}
+import tech.cryptonomic.conseil.tezos.TezosTypes.{
+  AccountId,
+  Contract,
+  ContractId,
+  Decimal,
+  Micheline,
+  Parameters,
+  ScriptId
+}
+
+class StakerDaoTest extends WordSpec with Matchers with OptionValues {
+
+  "The Token Contracts operations for the StakerDao contract" should {
+
+      "read a balance update from big map diff" in {
+        //given
+
+        //values taken from mainnet operations
+        val ledgerId = ContractId("KT1EctCuorV2NfVb1XTQgvzJ88MQtWP8cMMv")
+        val mapId = 20
+        val params = """
+             |{
+             |  "prim": "Right",
+             |  "args": [
+             |    {
+             |      "prim": "Left",
+             |      "args": [
+             |        {
+             |          "prim": "Left",
+             |          "args": [
+             |            {
+             |              "prim": "Right",
+             |              "args": [
+             |                {
+             |                  "prim": "Pair",
+             |                  "args": [
+             |                    {
+             |                      "bytes": "00007374616b65722d64616f2f7265736572766f6972"
+             |                    },
+             |                    {
+             |                      "prim": "Pair",
+             |                      "args": [
+             |                        {
+             |                          "bytes": "0000c528aa23546060e4459c5b37df752eea5bf5edc3"
+             |                        },
+             |                        {
+             |                          "int": "1"
+             |                        }
+             |                      ]
+             |                    }
+             |                  ]
+             |                }
+             |              ]
+             |            }
+             |          ]
+             |        }
+             |      ]
+             |    }
+             |  ]
+             |}
+          """.stripMargin
+
+        val senderMapUpdate = Contract.BigMapUpdate(
+          action = "update",
+          key = Micheline("""{"bytes": "00007374616b65722d64616f2f7265736572766f6972"}"""),
+          key_hash = ScriptId("exprucaLf6G5Robew77nwXRNR7gAbUJ3da2yAwqJdhyZCXZdEkLz8t"),
+          big_map = Decimal(mapId),
+          value = Some(Micheline("""{"int": "1499998"}"""))
+        )
+
+        val receiverMapUpdate = Contract.BigMapUpdate(
+          action = "update",
+          key = Micheline("""{"bytes": "0000c528aa23546060e4459c5b37df752eea5bf5edc3"}"""),
+          key_hash = ScriptId("exprtv5jtq14XnqMvskagVojNgSd8bXjxTZtDYY58MtAek5gbLKA4C"),
+          big_map = Decimal(mapId),
+          value = Some(Micheline("""{"int": "1"}"""))
+        )
+
+        //register the token info
+        val sut = TokenContracts.fromConfig(List(ledgerId -> "FA1.2-StakerDao"))
+        //set the map id for the contract
+        sut.setMapId(ledgerId, mapId)
+
+        //when
+        val balanceUpdates = List(senderMapUpdate, receiverMapUpdate).map(
+          mapUpdate =>
+            sut
+              .readBalance(ledgerId)(
+                diff = mapUpdate,
+                params = Some(Left(Parameters(Micheline(params))))
+              )
+              .value
+        )
+
+        //then
+        balanceUpdates should contain theSameElementsAs List(
+          AccountId("tz1dcWXLS1UBeGc7EazGvoNE6D8YSzVkAsSa") -> BigInt(1),
+          AccountId("tz1WAVpSaCFtLQKSJkrdVApCQC1TNK8iNxq9") -> BigInt(1499998)
+        )
+
+      }
+    }
+
+}

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/contracts/TokenContractsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/contracts/TokenContractsTest.scala
@@ -3,7 +3,6 @@ package tech.cryptonomic.conseil.tezos.michelson.contracts
 import org.scalatest.{Matchers, WordSpec}
 import tech.cryptonomic.conseil.tezos.TezosTypes.{AccountId, Contract, ContractId, Decimal, Micheline, ScriptId}
 import org.scalatest.OptionValues
-import scala.util.Success
 
 class TokenContractsTest extends WordSpec with Matchers with OptionValues {
 

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/contracts/TokenContractsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/michelson/contracts/TokenContractsTest.scala
@@ -53,6 +53,7 @@ class TokenContractsTest extends WordSpec with Matchers with OptionValues {
 
         //values sampled from a real babylon use-case
         val ledgerId = ContractId("KT1RmDuQ6LaTFfLrVtKNcBJkMgvnopEATJux")
+        val mapId = 1718
         val updateValue = """
                     |{
                     |  "prim": "Pair",
@@ -68,7 +69,7 @@ class TokenContractsTest extends WordSpec with Matchers with OptionValues {
           action = "update",
           key = Micheline("""{"bytes" : "0000c4ce21c7a7ac69810bb3425a043def752fddc817"}"""),
           key_hash = ScriptId("exprvMHy4mAi1igbigE5BeEbEAE5ayx82ne5BA7UUXmfGpAiiVF3vx"),
-          big_map = Decimal(1718),
+          big_map = Decimal(mapId),
           value = Some(Micheline(updateValue))
         )
 
@@ -85,6 +86,7 @@ class TokenContractsTest extends WordSpec with Matchers with OptionValues {
 
         //some values sampled from a real babylon use-case
         val ledgerId = ContractId("KT1RmDuQ6LaTFfLrVtKNcBJkMgvnopEATJux")
+        val mapId = 1718
         val updateValue = """
                     |{
                     |  "prim": "Pair",
@@ -107,7 +109,7 @@ class TokenContractsTest extends WordSpec with Matchers with OptionValues {
         //register the token info
         val sut = TokenContracts.fromConfig(List(ledgerId -> "FA1.2"))
         //set the map id for the contract
-        sut.setMapId(ledgerId, BigDecimal(1718))
+        sut.setMapId(ledgerId, BigDecimal(mapId))
 
         //when
         val balanceUpdate = sut.readBalance(ledgerId)(mapUpdate)


### PR DESCRIPTION
Closes #761 

Some customization was due to the existing token handling code to allow for the slightly different form of the StakerDao contract.
A custom contract type (standard) was needed to handle the differences.

This PR needs first #777  #780  to be merged with `master` and be rebased on top of that.

- [x] custom unit tests missing 