### PR TITLE
Allow specifying JVM settings with reasonable defaults

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,6 +14,8 @@ XTZPORT=${XTZ_Port:=8732}
 XTZNET=${XTZ_Network:=mainnet}
 APIPORT=${API_PORT:=80}
 APIKEY=${API_KEY:=conseil}
+JVM_XMX_LORRE=${JVM_Xmx_Lorre:=8g}
+JVM_XMX_CONSEIL=${JVM_Xmx_Conseil:=4g}
 
 CONFIG=${CONFIG:-none}
 
@@ -42,9 +44,9 @@ else
 fi
 
 if [ $1 = "conseil" ]; then
-      java -Dconfig.file=$CONFIG -cp /root/conseil.jar tech.cryptonomic.conseil.Conseil
+      java -Xmx $JVM_XMX_CONSEIL -Dconfig.file=$CONFIG -cp /root/conseil.jar tech.cryptonomic.conseil.Conseil
 fi
 
 if [ $1 = "lorre" ]; then
-   java -Dconfig.file=$CONFIG -cp /root/conseil.jar tech.cryptonomic.conseil.Lorre $XTZNET
+   java -Xmx $JVM_XMX_LORRE -Dconfig.file=$CONFIG -cp /root/conseil.jar tech.cryptonomic.conseil.Lorre $XTZNET
 fi


### PR DESCRIPTION
The Lorre container chokes on mainnet since no suitable `Xmx` is specified. 