### PR TITLE
795 - Guarantee safe use of the discardGenesis function

### DIFF
--- a/conseil-common-testkit/src/main/scala/tech/cryptonomic/conseil/common/testkit/InMemoryDatabase.scala
+++ b/conseil-common-testkit/src/main/scala/tech/cryptonomic/conseil/common/testkit/InMemoryDatabase.scala
@@ -47,6 +47,7 @@ trait InMemoryDatabase extends BeforeAndAfterAll with BeforeAndAfterEach with In
     dbInstance.start()
     Await.ready(dbHandler.run(initScript.create), 1.second)
     Await.ready(dbHandler.run(DBIO.sequence(fixtures.map(_.create))), 1.second)
+    ()
   }
 
   override protected def afterAll(): Unit = {

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosOptics.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosOptics.scala
@@ -101,26 +101,22 @@ object TezosOptics {
 
     //Note, cycle 0 starts at the level 2 block
     def extractCycle(block: Block): Option[Int] =
-      discardGenesis
-        .lift(block.data.metadata) //this returns an Option[BlockHeaderMetadata]
+      discardGenesis(block.data.metadata) //this returns an Option[BlockHeaderMetadata]
         .map(_.level.cycle) //this is Option[Int]
 
     //Note, cycle 0 starts at the level 2 block
     def extractCycle(block: BlockData): Option[Int] =
-      discardGenesis
-        .lift(block.metadata) //this returns an Option[BlockHeaderMetadata]
+      discardGenesis(block.metadata) //this returns an Option[BlockHeaderMetadata]
         .map(_.level.cycle) //this is Option[Int]
 
     //Note, cycle 0 starts at the level 2 block
     def extractCyclePosition(block: BlockMetadata): Option[Int] =
-      discardGenesis
-        .lift(block) //this returns an Option[BlockHeaderMetadata]
+      discardGenesis(block) //this returns an Option[BlockHeaderMetadata]
         .map(_.level.cycle_position) //this is Option[Int]
 
     //Note, cycle 0 starts at the level 2 block
     def extractPeriod(block: BlockMetadata): Option[Int] =
-      discardGenesis
-        .lift(block)
+      discardGenesis(block)
         .map(_.level.voting_period)
   }
 

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosTypes.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosTypes.scala
@@ -179,8 +179,11 @@ object TezosTypes {
   )
 
   /** only accepts standard block metadata, discarding the genesis metadata */
-  def discardGenesis: PartialFunction[BlockMetadata, BlockHeaderMetadata] = {
-    case md: BlockHeaderMetadata => md
+  val discardGenesis: BlockMetadata => Option[BlockHeaderMetadata] = {
+    val partialSelector: PartialFunction[BlockMetadata, BlockHeaderMetadata] = {
+      case md: BlockHeaderMetadata => md
+    }
+    partialSelector.lift
   }
 
   /** Naming can be deceiving, we're sticking with the json schema use of `positive_bignumber`

--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/tezos/DatabaseConversionsTest.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/tezos/DatabaseConversionsTest.scala
@@ -97,7 +97,7 @@ class DatabaseConversionsTest
         val converted = block.convertTo[Tables.BlocksRow]
 
         val header = block.data.header
-        val metadata = discardGenesis.lift(block.data.metadata)
+        val metadata = discardGenesis(block.data.metadata)
         val CurrentVotes(expectedQuorum, proposal) = block.votes
 
         converted should have(

--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/tezos/TezosDatabaseOperationsTest.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/tezos/TezosDatabaseOperationsTest.scala
@@ -113,7 +113,7 @@ class TezosDatabaseOperationsTest
 
           forAll(dbBlocks zip generatedBlocks) {
             case (row, block) =>
-              val metadata = discardGenesis.lift(block.data.metadata)
+              val metadata = discardGenesis(block.data.metadata)
 
               row.level shouldEqual block.data.header.level
               row.proto shouldEqual block.data.header.proto

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/Lorre.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/Lorre.scala
@@ -422,32 +422,38 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
       import DatabaseConversions._
       import tech.cryptonomic.conseil.common.util.Conversion.Syntax._
 
+      //DANGER Will Robinson! we assume in the rest of the code that we're not handling the genesis block
+      val safeBlocks = blocks.filterNot(block => TezosNodeOperator.isGenesis(block.data))
+      val safeListings = listings.filterNot { case (block, rolls) => TezosNodeOperator.isGenesis(block.data) }
+
       for {
-        proposals <- tezosNodeOperator.getProposals(blocks.map(_.data))
+        proposals <- tezosNodeOperator.getProposals(safeBlocks.map(_.data))
         blockHashesWithProposals = proposals.filter(_._2.isDefined).map(_._1)
-        blocksWithProposals = blocks.filter(blockData => blockHashesWithProposals.contains(blockData.data.hash))
+        blocksWithProposals = safeBlocks.filter(blockData => blockHashesWithProposals.contains(blockData.data.hash))
         ballotCountsPerCycle <- Future.traverse(blocksWithProposals) { block =>
-          db.run(TezosDb.getBallotOperationsForCycle(TezosTypes.discardGenesis(block.data.metadata).level.cycle))
+          db.run(TezosDb.getBallotOperationsForCycle(TezosTypes.discardGenesis(block.data.metadata).get.level.cycle))
             .map(block -> _)
         }
         ballotCountsPerLevel <- Future.traverse(blocksWithProposals) { block =>
           db.run(TezosDb.getBallotOperationsForLevel(block.data.header.level))
             .map(block -> _)
         }
-        proposalHashes <- Future.traverse(blocks) { block =>
-          db.run(TezosDb.getProposalOperationHashesByCycle(TezosTypes.discardGenesis(block.data.metadata).level.cycle))
+        proposalHashes <- Future.traverse(safeBlocks) { block =>
+          db.run(
+              TezosDb.getProposalOperationHashesByCycle(TezosTypes.discardGenesis(block.data.metadata).get.level.cycle)
+            )
             .map(block -> _)
         }
         ballots <- tezosNodeOperator.getVotes(blocksWithProposals)
         governanceRows = groupGovernanceDataByBlock(
           blocksWithProposals,
           proposals.toMap,
-          listings.map { case (block, listing) => block.data.header.level -> listing }.toMap,
+          safeListings.map { case (block, listing) => block.data.header.level -> listing }.toMap,
           ballots.toMap,
           ballotCountsPerCycle.toMap,
           ballotCountsPerLevel.toMap,
           proposalHashes.toMap
-        ).map(_.convertTo[Tables.GovernanceRow])
+        ).flatMap(_.convertToA[Option, Tables.GovernanceRow])
         _ <- db.run(TezosDb.insertGovernance(governanceRows))
       } yield ()
     }

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosNodeOperator.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosNodeOperator.scala
@@ -668,7 +668,7 @@ class TezosNodeOperator(
 
     def extractAccountIds(blockData: BlockData): List[AccountId] =
       for {
-        blockHeaderMetadata <- discardGenesis.lift(blockData.metadata).toList
+        blockHeaderMetadata <- discardGenesis(blockData.metadata).toList
         balanceUpdate <- blockHeaderMetadata.balance_updates
         id <- balanceUpdate.contract.map(_.id).toList ::: balanceUpdate.delegate.map(_.value).toList
       } yield AccountId(id)


### PR DESCRIPTION
Fixes #795 which might fail at runtime

 * make the function total, by returning an optional value
 * apply all relevant changes to use site

The runtime failure didn't happen 'till because apparently we didn't run from scratch a whole sync, or the unsafe calls where made by chance (or implicit assumptions) only on "safe" blocks.