### PR TITLE
chores - put assembled fat-jar into a local project sub-folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY --chown=builduser:builduser ./conseil-lorre/src /src/conseil-lorre/src
 COPY --chown=builduser:builduser ./build.sbt /src
 COPY --chown=builduser:builduser ./publishing.sbt /src
 WORKDIR /src
-RUN sbt clean assembly -J-Xss32m
+RUN sbt 'set api / assembly / assemblyOutputPath := file(s"/tmp/conseil-api.jar")' 'set lorre / assembly / assemblyOutputPath := file(s"/tmp/conseil-lorre.jar")' clean assembly -J-Xss32m
 
 FROM openjdk:13-alpine
 RUN apk --no-cache add ca-certificates

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,7 @@
 version: "3.1"
 
+# This file is meant exclusively to support local development on a single machine
+# Please refrain from using this to deploy the software
 services:
   conseil-postgres:
     image: postgres:11.6

--- a/project/Assembly.scala
+++ b/project/Assembly.scala
@@ -12,12 +12,14 @@ object Assembly {
       project
         .settings(
           mainClass in assembly := mainClass.value,
-          assemblyOutputPath in assembly := file(s"/tmp/${name.value}.jar"),
+          assemblyOutputPath in assembly := file(
+                s"${(baseDirectory in ThisBuild).value}/dist/${name.value}-${version.value}.jar"
+              ),
           test in assembly := {},
           assemblyMergeStrategy in assembly := {
-            case "application.conf" => MergeStrategy.concat
-            case x => (assemblyMergeStrategy in assembly).value(x)
-          }
+              case "application.conf" => MergeStrategy.concat
+              case x => (assemblyMergeStrategy in assembly).value(x)
+            }
         )
         .enablePlugins(AssemblyPlugin)
 


### PR DESCRIPTION
This PR aims to make it easier to find the assembled jars, related to the wiki instructions on how to run the app from those.

* the jars will be found inside a local project sub-folder: namely `dist`
* the jar names will have a version in the naming [1]


[1] @vishakh @anonymoussprocket There was a particular reason not to produce versioned jar-names? If that's the case I'll revert to the previous behaviour.