### PR TITLE
807 - Handle multiple big-map updates and copy for single batch

### DIFF
--- a/conseil-api/src/test/resources/logback-test.xml
+++ b/conseil-api/src/test/resources/logback-test.xml
@@ -10,8 +10,6 @@
     </appender>
 
     <logger name="com.base22" level="TRACE"/>
-    <logger name="tech.cryptonomic.conseil.tezos.BigMapsOperations" level="DEBUG"/>
-    <logger name="tech.cryptonomic.conseil.tezos.michelson.contracts.TNSContracts" level="DEBUG"/>
 
     <root level="OFF">
         <appender-ref ref="STDOUT" />

--- a/conseil-lorre/src/main/resources/logback.xml
+++ b/conseil-lorre/src/main/resources/logback.xml
@@ -31,7 +31,7 @@
 
     <logger name="com.base22" level="TRACE"/>
     <logger name="slick" level="INFO"/>
-    <logger name="tech.cryptonomic.conseil.common.tezos.BigMapsOperations" level="${LORRE_BIG_MAPS_LOG_LEVEL:-OFF}"/>
+    <logger name="tech.cryptonomic.conseil.indexer.tezos.bigmaps.BigMapsOperations" level="${LORRE_BIG_MAPS_LOG_LEVEL:-OFF}"/>
     <logger name="tech.cryptonomic.conseil.indexer.tezos.michelson.contracts.TNSContracts" level="${LORRE_TNS_LOG_LEVEL:-INFO}"/>
 
     <root level="INFO">

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/bigmaps/BigMapsOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/bigmaps/BigMapsOperations.scala
@@ -7,7 +7,7 @@ import scala.concurrent.ExecutionContext
 import scala.collection.immutable.TreeMap
 import cats.implicits._
 import tech.cryptonomic.conseil.common.util.Conversion.Syntax._
-import tech.cryptonomic.conseil.indexer.tezos.michelson.contracts.TokenContracts
+import tech.cryptonomic.conseil.indexer.tezos.michelson.contracts.{TNSContract, TokenContracts}
 import tech.cryptonomic.conseil.common.tezos.TezosTypes.{
   Block,
   Contract,
@@ -25,7 +25,6 @@ import TezosOptics.Operations.{
   extractAppliedTransactions,
   extractAppliedTransactionsResults
 }
-import tech.cryptonomic.conseil.common.tezos.michelson.contracts.TNSContract
 
 /** Defines big-map-diffs specific handling, from block data extraction to database storage
   *

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/bigmaps/BigMapsOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/bigmaps/BigMapsOperations.scala
@@ -4,6 +4,7 @@ import com.typesafe.scalalogging.LazyLogging
 import com.github.tminglei.slickpg.ExPostgresProfile
 
 import scala.concurrent.ExecutionContext
+import scala.collection.immutable.TreeMap
 import cats.implicits._
 import tech.cryptonomic.conseil.common.util.Conversion.Syntax._
 import tech.cryptonomic.conseil.indexer.tezos.michelson.contracts.TokenContracts
@@ -19,7 +20,12 @@ import tech.cryptonomic.conseil.common.tezos.TezosTypes.Contract.BigMapUpdate
 import tech.cryptonomic.conseil.common.tezos.Tables
 import tech.cryptonomic.conseil.common.tezos.Tables.{BigMapContentsRow, BigMapsRow, OriginatedAccountMapsRow}
 import tech.cryptonomic.conseil.common.tezos.TezosOptics
-import tech.cryptonomic.conseil.indexer.tezos.michelson.contracts.TNSContract
+import TezosOptics.Operations.{
+  extractAppliedOriginationsResults,
+  extractAppliedTransactions,
+  extractAppliedTransactionsResults
+}
+import tech.cryptonomic.conseil.common.tezos.michelson.contracts.TNSContract
 
 /** Defines big-map-diffs specific handling, from block data extraction to database storage
   *
@@ -34,43 +40,64 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
     * @param ec needed to compose db operations
     * @return the count of records added
     */
-  def copyContent(blocks: List[Block])(implicit ec: ExecutionContext): DBIO[Int] = {
-    val copyDiffs = if (logger.underlying.isDebugEnabled()) {
-      val diffsPerBlock = blocks.map(b => b.data.hash.value -> TezosOptics.Blocks.readBigMapDiffCopy.getAll(b))
+  def copyContent(blocks: List[Block])(implicit ec: ExecutionContext): DBIO[Option[Int]] = {
+    val diffsPerBlock = blocks.map(b => b.data -> TezosOptics.Blocks.readBigMapDiffCopy.getAll(b))
+    if (logger.underlying.isDebugEnabled()) {
       diffsPerBlock.foreach {
-        case (hash, diffs) if diffs.nonEmpty =>
+        case (blockData, diffs) if diffs.nonEmpty =>
           logger.debug(
             "For block hash {}, I'm about to copy the following big maps data: \n\t{}",
-            hash.value,
+            blockData.hash.value,
             diffs.mkString(", ")
           )
         case _ =>
       }
-      diffsPerBlock.map(_._2).flatten
-    } else blocks.flatMap(TezosOptics.Blocks.readBigMapDiffCopy.getAll)
-
-    //need to load the sources and copy them with a new destination id
-    val contentCopies = copyDiffs.collect {
-      case Contract.BigMapCopy(_, Decimal(sourceId), Decimal(destinationId)) =>
-        Tables.BigMapContents
-          .filter(_.bigMapId === sourceId)
-          .map(it => (destinationId, it.key, it.keyHash, it.operationGroupId, it.value))
-          .result
-          .map(rows => rows.map(BigMapContentsRow.tupled).toList)
     }
 
-    DBIO
-      .sequence(contentCopies)
-      .flatMap { updateRows =>
-        val copies = updateRows.flatten
-        logger.info(
-          "{} big maps will be copied in the db.",
-          if (copies.nonEmpty) s"A total of ${copies.size}"
-          else "No"
-        )
-        Tables.BigMapContents.insertOrUpdateAll(copies)
+    /* we load the sources and copy them with a new destination id
+     * collecting relevant diffs per block level
+     * What we get out is a sequence of queries whose results are the new rows
+     * to write back to db, sorted by growing level
+     */
+    val sortedQueries = {
+      val copyDataByLevel = diffsPerBlock.map {
+        case (blockData, diffs) =>
+          val queries = diffs.collect {
+            case Contract.BigMapCopy(_, Decimal(sourceId), Decimal(destinationId)) =>
+              Tables.BigMapContents
+                .filter(_.bigMapId === sourceId)
+                .map(it => (destinationId, it.key, it.keyHash, it.operationGroupId, it.value))
+                .result
+                .headOption
+          }
+          blockData.header.level -> DBIO.sequence(queries).map(_.flatten)
+
       }
-      .map(_.sum)
+      TreeMap(copyDataByLevel: _*)
+    }
+
+    def dedup(contents: List[BigMapContentsRow]) =
+      contents
+        .groupBy(row => (row.bigMapId, row.key))
+        .values
+        .flatMap(_.lastOption)
+
+    val writesByLevel = sortedQueries.values.map(
+      readAction =>
+        readAction.flatMap { updateData =>
+          val rowsToWrite = dedup(updateData.map(BigMapContentsRow.tupled))
+          Tables.BigMapContents.insertOrUpdateAll(rowsToWrite)
+        }
+    )
+
+    DBIO.sequence(writesByLevel).map { upserts =>
+      val all = upserts.fold(Some(0))(_ |+| _)
+      logger.info(
+        "{} big maps will be actually copied in the db.",
+        all.fold("An unspecified number of")(String.valueOf)
+      )
+      all
+    }
 
   }
 
@@ -118,7 +145,6 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
     * @return the count of records added, if available from the underlying db-engine
     */
   def saveMaps(blocks: List[Block]): DBIO[Option[Int]] = {
-    import TezosOptics.Operations.extractAppliedOriginationsResults
 
     val diffsPerBlock = blocks.flatMap(
       b =>
@@ -161,7 +187,6 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
     * @return the count of records added, if available from the underlying db-engine
     */
   def upsertContent(blocks: List[Block]): DBIO[Option[Int]] = {
-    import TezosOptics.Operations.extractAppliedTransactionsResults
 
     val diffsPerBlock = blocks.flatMap(
       b =>
@@ -198,8 +223,8 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
       .foldLeft(Map.empty[(BigDecimal, String), BigMapContentsRow]) {
         case (collected, block) =>
           val seen = collected.keySet
-          val rows = blocks
-            .flatMap(b => rowsPerBlock.getOrElse(b.data.hash, List.empty))
+          val rows = rowsPerBlock
+            .getOrElse(block.data.hash, List.empty)
             .filterNot(row => seen((row.bigMapId, row.key)))
           collected ++ rows.map(row => (row.bigMapId, row.key) -> row)
       }
@@ -219,7 +244,6 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
     * @return the count of records added, if available from the underlying db-engine
     */
   def saveContractOrigin(blocks: List[Block]): DBIO[List[OriginatedAccountMapsRow]] = {
-    import TezosOptics.Operations.extractAppliedOriginationsResults
 
     val diffsPerBlock = blocks.flatMap(
       b =>
@@ -310,7 +334,6 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
       blocks: List[Block]
   )(implicit ec: ExecutionContext, tokenContracts: TokenContracts): DBIO[Option[Int]] = {
     import slickeffect.implicits._
-    import TezosOptics.Operations.extractAppliedTransactions
 
     val toSql = (zdt: java.time.ZonedDateTime) => java.sql.Timestamp.from(zdt.toInstant)
 

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperationsTestFixtures.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperationsTestFixtures.scala
@@ -683,14 +683,14 @@ trait TezosDatabaseOperationsTestFixtures extends RandomGenerationKit {
       * In this case the generation needs happen only for Originations
       */
     def updateOperationsWithBigMapAllocation(
-        diffGenerate: PartialFunction[Operation, Contract.BigMapAlloc]
+        diffGenerate: PartialFunction[Operation, List[Contract.BigMapAlloc]]
     ): List[Operation] => List[Operation] = {
       import tech.cryptonomic.conseil.common.tezos.TezosOptics.Operations._
 
       //applies to the alloc diffs nested within originations
       updateOperationsToBigMapDiff[Contract.BigMapAlloc](
         diffGenerate,
-        selectOrigination composeLens originationResult composeOptional originationBigMapDiffs
+        whenOrigination composeLens onOriginationResult composeOptional onOriginationBigMapDiffs
       )
     }
 
@@ -701,14 +701,14 @@ trait TezosDatabaseOperationsTestFixtures extends RandomGenerationKit {
       * In this case the generation needs happen only for Transacions
       */
     def updateOperationsWithBigMapUpdate(
-        diffGenerate: PartialFunction[Operation, Contract.BigMapUpdate]
+        diffGenerate: PartialFunction[Operation, List[Contract.BigMapUpdate]]
     ): List[Operation] => List[Operation] = {
       import tech.cryptonomic.conseil.common.tezos.TezosOptics.Operations._
 
       //applies to the update diffs nested within transactions
       updateOperationsToBigMapDiff[Contract.BigMapUpdate](
         diffGenerate,
-        selectTransaction composeLens transactionResult composeOptional transactionBigMapDiffs
+        whenTransaction composeLens onTransactionResult composeOptional onTransactionBigMapDiffs
       )
     }
 
@@ -719,14 +719,14 @@ trait TezosDatabaseOperationsTestFixtures extends RandomGenerationKit {
       * In this case the generation needs happen only for Transactions
       */
     def updateOperationsWithBigMapCopy(
-        diffGenerate: PartialFunction[Operation, Contract.BigMapCopy]
+        diffGenerate: PartialFunction[Operation, List[Contract.BigMapCopy]]
     ): List[Operation] => List[Operation] = {
       import tech.cryptonomic.conseil.common.tezos.TezosOptics.Operations._
 
       //applies to the update diffs nested within transactions
       updateOperationsToBigMapDiff[Contract.BigMapCopy](
         diffGenerate,
-        selectTransaction composeLens transactionResult composeOptional transactionBigMapDiffs
+        whenTransaction composeLens onTransactionResult composeOptional onTransactionBigMapDiffs
       )
     }
 
@@ -737,14 +737,14 @@ trait TezosDatabaseOperationsTestFixtures extends RandomGenerationKit {
       * In this case the generation needs happen only for Transacions
       */
     def updateOperationsWithBigMapRemove(
-        diffGenerate: PartialFunction[Operation, Contract.BigMapRemove]
+        diffGenerate: PartialFunction[Operation, List[Contract.BigMapRemove]]
     ): List[Operation] => List[Operation] = {
       import tech.cryptonomic.conseil.common.tezos.TezosOptics.Operations._
 
       //applies to the update diffs nested within transactions
       updateOperationsToBigMapDiff[Contract.BigMapRemove](
         diffGenerate,
-        selectTransaction composeLens transactionResult composeOptional transactionBigMapDiffs
+        whenTransaction composeLens onTransactionResult composeOptional onTransactionBigMapDiffs
       )
     }
 
@@ -757,17 +757,17 @@ trait TezosDatabaseOperationsTestFixtures extends RandomGenerationKit {
      * @return the updated operations
      */
     private def updateOperationsToBigMapDiff[Diff <: Contract.BigMapDiff](
-        diffGenerate: PartialFunction[Operation, Diff],
+        diffGenerate: PartialFunction[Operation, List[Diff]],
         diffSetter: Optional[Operation, List[Contract.CompatBigMapDiff]]
     )(operations: List[Operation]): List[Operation] =
       operations.map { op =>
         // applies the function to create a possible value to set on each individual operation
-        val maybeDiff = PartialFunction.condOpt(op)(diffGenerate)
+        val maybeDiffs = PartialFunction.condOpt(op)(diffGenerate)
 
         //sets the diff value list in the optional field of the operation if there's something, or returns the unchanged operation
-        maybeDiff.fold(op) { diff =>
-          val diffFieldValue = Left(diff) //look at how CompatBigMapDiff is defined
-          diffSetter.modify(diffs => diffFieldValue :: diffs)(op)
+        maybeDiffs.fold(op) { diffs =>
+          val diffFieldValues = diffs.map(Left(_)) //look at how CompatBigMapDiff is defined
+          diffSetter.modify(diffs => diffFieldValues ::: diffs)(op)
         }
       }
 

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/bigmaps/BigMapsOperationsTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/bigmaps/BigMapsOperationsTest.scala
@@ -8,7 +8,12 @@ import slick.jdbc.PostgresProfile.api._
 import tech.cryptonomic.conseil.common.sql.CustomProfileExtension
 import tech.cryptonomic.conseil.common.testkit.InMemoryDatabase
 import tech.cryptonomic.conseil.common.testkit.util.RandomSeed
-import tech.cryptonomic.conseil.common.tezos.Tables.{BigMapContentsRow, BigMapsRow, OriginatedAccountMapsRow, TokenBalancesRow}
+import tech.cryptonomic.conseil.common.tezos.Tables.{
+  BigMapContentsRow,
+  BigMapsRow,
+  OriginatedAccountMapsRow,
+  TokenBalancesRow
+}
 import tech.cryptonomic.conseil.common.tezos.{Tables, TezosTypes}
 import tech.cryptonomic.conseil.common.tezos.TezosTypes._
 import tech.cryptonomic.conseil.indexer.tezos.michelson.contracts.TokenContracts
@@ -44,7 +49,7 @@ class BigMapsOperationsTest
               big_map = Decimal(1),
               key_type = Micheline("""{"prim":"address"}"""),
               value_type = Micheline("""{"prim":"nat"}""")
-            )
+            ) :: Nil
         }
 
         val block = generateSingleBlock(1, testReferenceDateTime)
@@ -85,7 +90,7 @@ class BigMapsOperationsTest
               key = Micheline("""{"bytes":"0000b2e19a9e74440d86c59f13dab8a18ff873e889ea"}"""),
               key_hash = ScriptId("exprv6UsC1sN3Fk2XfgcJCL8NCerP5rCGy1PRESZAqr7L2JdzX55EN"),
               value = Some(Micheline("""{"prim":"Pair", "args": [{"int":"20"},[]]}"""))
-            )
+            ) :: Nil
         }
 
         //we need this to be referred as a FK from the content record
@@ -138,7 +143,7 @@ class BigMapsOperationsTest
               big_map = Decimal(1),
               key_type = Micheline("""{"prim":"address"}"""),
               value_type = Micheline("""{"prim":"nat"}""")
-            )
+            ) :: Nil
         }
 
         val block = generateSingleBlock(1, testReferenceDateTime)
@@ -190,7 +195,7 @@ class BigMapsOperationsTest
               key = Micheline("""{"bytes":"0000a8d45bdc966ddaaac83188a1e1c1fde2a3e05e5c"}"""),
               key_hash = ScriptId("exprvKTBQDAyXTMRc36TsLBsj9y5GXo1PD529MfF8zDV1pVzNNgehs"),
               value = Some(Micheline("""{"prim":"Pair", "args": [{"int":"50"},[]]}"""))
-            )
+            ) :: Nil
         }
 
         //we're gonna direct any sample transaction to the token contract, referring to a test account
@@ -282,7 +287,7 @@ class BigMapsOperationsTest
               key = Micheline("""{"bytes":"0000b2e19a9e74440d86c59f13dab8a18ff873e889ea"}"""),
               key_hash = ScriptId("exprv6UsC1sN3Fk2XfgcJCL8NCerP5rCGy1PRESZAqr7L2JdzX55EN"),
               value = Some(Micheline("""{"prim":"Pair", "args": [{"int":"50"},[]]}"""))
-            )
+            ) :: Nil
         }
 
         val block = generateSingleBlock(1, testReferenceDateTime)
@@ -309,6 +314,85 @@ class BigMapsOperationsTest
             value = Some("Pair 50 {}")
           )
         )
+      }
+
+      "update with only the latest big map content for diffs having the same target map and key: Issue#807" in {
+        //given
+        implicit val randomSeed = RandomSeed(testReferenceTimestamp.getTime)
+
+        val initialBigMap = BigMapsRow(
+          bigMapId = BigDecimal(1),
+          keyType = Some("address"),
+          valueType = Some("nat")
+        )
+        val initialBigMapContent = BigMapContentsRow(
+          bigMapId = BigDecimal(1),
+          key = "0x0000b2e19a9e74440d86c59f13dab8a18ff873e889ea",
+          keyHash = Some("exprv6UsC1sN3Fk2XfgcJCL8NCerP5rCGy1PRESZAqr7L2JdzX55EN"),
+          value = Some("Pair 20 {}")
+        )
+
+        val populate = for {
+          mapAdded <- Tables.BigMaps += initialBigMap
+          contentAdded <- Tables.BigMapContents += initialBigMapContent
+        } yield (mapAdded, contentAdded)
+
+        dbHandler.run(populate).futureValue shouldEqual ((1, 1))
+
+        //here we want to generate multiple updates in different blocks
+        def updatesMap(values: List[Int]): ListTransf[Operation] = Operations.updateOperationsWithBigMapUpdate {
+          case (_: Transaction) =>
+            values.map { value =>
+              Contract.BigMapUpdate(
+                action = "udpate",
+                big_map = Decimal(1),
+                key = Micheline("""{"bytes":"0000b2e19a9e74440d86c59f13dab8a18ff873e889ea"}"""),
+                key_hash = ScriptId("exprv6UsC1sN3Fk2XfgcJCL8NCerP5rCGy1PRESZAqr7L2JdzX55EN"),
+                value = Some(Micheline(s"""{"prim":"Pair", "args": [{"int":"$value"},[]]}"""))
+              )
+            }
+        }
+
+        /* we make two blocks and define which are the big map values to update
+         * therefore adding the diff to the corresponding operations
+         */
+        val blocks = generateBlocks(2, testReferenceDateTime).drop(1)
+
+        val operationsWithDiffs: List[List[OperationsGroup]] = blocks.map { block =>
+          val sampleOperations = generateOperationGroup(block, generateOperations = true)
+          val updateValue = block.data.header.level match {
+            case 1 => List(10) //block-lvl 1 will carry one update
+            case 2 => List(20, 50) //block-lvl 2 will carry both updates
+            case _ => List.empty
+          }
+          sampleOperations.copy(
+            contents = updatesMap(values = updateValue)(sampleOperations.contents)
+          ) :: Nil
+        }
+
+        val blocksToSave =
+          blocks.zip(operationsWithDiffs).map {
+            case (block, ops) => block.copy(operationGroups = ops)
+          }
+
+        //when
+        val writeAndGetRows = sut.upsertContent(blocksToSave) andThen Tables.BigMapContents.result
+
+        val contents = dbHandler.run(writeAndGetRows.transactionally).futureValue
+
+        //then
+        contents.size shouldBe 1
+
+        // we expect only the latest update to take effect
+        contents(0) should matchTo(
+          BigMapContentsRow(
+            bigMapId = BigDecimal(1),
+            key = "0x0000b2e19a9e74440d86c59f13dab8a18ff873e889ea",
+            keyHash = Some("exprv6UsC1sN3Fk2XfgcJCL8NCerP5rCGy1PRESZAqr7L2JdzX55EN"),
+            value = Some("Pair 50 {}")
+          )
+        )
+
       }
 
       "copy big map contents for diffs contained in a list of blocks" in {
@@ -350,7 +434,7 @@ class BigMapsOperationsTest
               action = "copy",
               source_big_map = Decimal(1),
               destination_big_map = Decimal(2)
-            )
+            ) :: Nil
         }
 
         val block = generateSingleBlock(1, testReferenceDateTime)
@@ -384,6 +468,105 @@ class BigMapsOperationsTest
           )
         )
 
+      }
+
+      "copy only the latest big map content for diffs copying to the same target map and key: Issue#807" in {
+        //given
+        implicit val randomSeed = RandomSeed(testReferenceTimestamp.getTime)
+
+        //we need 3 pre-existing big maps to transafer content between
+        val initialBigMaps =
+          1 :: 2 :: 3 :: Nil map (
+                  i =>
+                    BigMapsRow(
+                      bigMapId = BigDecimal(i),
+                      keyType = None,
+                      valueType = None
+                    )
+                )
+
+        //the content to copy
+        val initialBigMapsContent = List(
+          BigMapContentsRow(
+            bigMapId = BigDecimal(1),
+            key = "0x0000b2e19a9e74440d86c59f13dab8a18ff873e889ea",
+            keyHash = Some("exprv6UsC1sN3Fk2XfgcJCL8NCerP5rCGy1PRESZAqr7L2JdzX55EN"),
+            value = Some("Pair 10 {}")
+          ),
+          BigMapContentsRow(
+            bigMapId = BigDecimal(2),
+            key = "0x0000b2e19a9e74440d86c59f13dab8a18ff873e889ea",
+            keyHash = Some("exprv6UsC1sN3Fk2XfgcJCL8NCerP5rCGy1PRESZAqr7L2JdzX55EN"),
+            value = Some("Pair 20 {}")
+          )
+        )
+
+        //store the data
+        val populate = for {
+          maps <- Tables.BigMaps ++= initialBigMaps
+          contents <- Tables.BigMapContents ++= initialBigMapsContent
+        } yield (maps, contents)
+
+        dbHandler.run(populate.transactionally).futureValue shouldEqual ((Some(3), Some(2)))
+
+        //we want to copy content between the first two maps and the third map, on the same key
+        def copyMap(from: List[Int], to: Int): ListTransf[Operation] = Operations.updateOperationsWithBigMapCopy {
+          case (_: Transaction) =>
+            from.map { sourceId =>
+              Contract.BigMapCopy(
+                action = "copy",
+                source_big_map = Decimal(sourceId),
+                destination_big_map = Decimal(to)
+              )
+
+            }
+        }
+
+        /* we make two blocks and define which are the big map ids to copy
+         * therefore adding the copy diff to the corresponding operations
+         */
+        val blocks = generateBlocks(2, testReferenceDateTime).drop(1)
+
+        val operationsWithDiffs: List[List[OperationsGroup]] = blocks.map { block =>
+          val sampleOperations = generateOperationGroup(block, generateOperations = true)
+          val sourceIdsToCopy = block.data.header.level match {
+            case 1 => List(1) //block-lvl 1 will copy contents from map 1
+            case 2 => List(1, 2) //block-lvl 2 will copy contents from map 1 and 2 both
+            case _ => List.empty
+          }
+          sampleOperations.copy(
+            contents = copyMap(from = sourceIdsToCopy, to = 3)(sampleOperations.contents)
+          ) :: Nil
+        }
+
+        val blocksToSave =
+          blocks.zip(operationsWithDiffs).map {
+            case (block, ops) => block.copy(operationGroups = ops)
+          }
+
+        //when
+        val writeAndGetRows = for {
+          _ <- sut.copyContent(blocksToSave)
+          maps <- Tables.BigMaps.result
+          contents <- Tables.BigMapContents.result
+        } yield (maps, contents)
+
+        val (maps, contents) = dbHandler.run(writeAndGetRows).futureValue
+
+        //then
+        maps.size shouldBe initialBigMaps.size
+
+        contents.size shouldBe 3
+
+        // we expect the destination map to only consider the very last copy applied
+        contents(2) should matchTo(
+          BigMapContentsRow(
+            bigMapId = BigDecimal(3),
+            key = "0x0000b2e19a9e74440d86c59f13dab8a18ff873e889ea",
+            keyHash = Some("exprv6UsC1sN3Fk2XfgcJCL8NCerP5rCGy1PRESZAqr7L2JdzX55EN"),
+            value = Some("Pair 20 {}")
+          )
+        )
       }
 
       "delete all data in selected big maps for diffs contained in a list of blocks" in {
@@ -437,7 +620,7 @@ class BigMapsOperationsTest
             Contract.BigMapRemove(
               action = "remove",
               big_map = Decimal(1)
-            )
+            ) :: Nil
         }
 
         val block = generateSingleBlock(1, testReferenceDateTime)

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/bigmaps/BigMapsOperationsTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/bigmaps/BigMapsOperationsTest.scala
@@ -375,8 +375,11 @@ class BigMapsOperationsTest
             case (block, ops) => block.copy(operationGroups = ops)
           }
 
+        //we change the order of how blocks come in
+        val reverted = blocksToSave.reverse
+
         //when
-        val writeAndGetRows = sut.upsertContent(blocksToSave) andThen Tables.BigMapContents.result
+        val writeAndGetRows = sut.upsertContent(reverted) andThen Tables.BigMapContents.result
 
         val contents = dbHandler.run(writeAndGetRows.transactionally).futureValue
 
@@ -544,9 +547,12 @@ class BigMapsOperationsTest
             case (block, ops) => block.copy(operationGroups = ops)
           }
 
+        //we change the order of how blocks come in
+        val reverted = blocksToSave.reverse
+
         //when
         val writeAndGetRows = for {
-          _ <- sut.copyContent(blocksToSave)
+          _ <- sut.copyContent(reverted)
           maps <- Tables.BigMaps.result
           contents <- Tables.BigMapContents.result
         } yield (maps, contents)


### PR DESCRIPTION
Fixes #807  

The changes now do a pre-order of both external and internal operations before processing
   them for big-map diffs, so that de-duplication of applied results should
   preserve the actual sequence defined on-chain, and only the latest
   results are considered (by level and then operation order) when
   the identifiers collides (map ids w/ map keys)
 
Includes a correction to a code error in handling upserts of big-maps content, actually leading to unpredictable values being stored on the db for each Lorre cycle.

Now we sort copy diffs by level to avoid conflicting keys on multiple blocks too.

The test suite now includes specific tests for this bug.