### PR TITLE
807 - Handle multiple big-map updates and copy for single batch [backport]

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -31,7 +31,7 @@
 
 
     <logger name="com.base22" level="TRACE"/>
-    <logger name="tech.cryptonomic.conseil.tezos.BigMapsOperations" level="${LORRE_BIG_MAPS_LOG_LEVEL:-INFO}"/>
+    <logger name="tech.cryptonomic.conseil.tezos.bigmaps.BigMapsOperations" level="${LORRE_BIG_MAPS_LOG_LEVEL:-INFO}"/>
     <logger name="tech.cryptonomic.conseil.tezos.michelson.contracts.TNSContracts" level="${LORRE_TNS_LOG_LEVEL:-INFO}"/>
 
     <root level="INFO">

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/bigmaps/BigMapsOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/bigmaps/BigMapsOperations.scala
@@ -4,6 +4,7 @@ import com.typesafe.scalalogging.LazyLogging
 import com.github.tminglei.slickpg.ExPostgresProfile
 
 import scala.concurrent.ExecutionContext
+import scala.collection.immutable.TreeMap
 import cats.implicits._
 import tech.cryptonomic.conseil.util.Conversion.Syntax._
 import tech.cryptonomic.conseil.tezos.michelson.contracts.TokenContracts
@@ -19,6 +20,11 @@ import tech.cryptonomic.conseil.tezos.TezosTypes.Contract.BigMapUpdate
 import tech.cryptonomic.conseil.tezos.Tables
 import tech.cryptonomic.conseil.tezos.Tables.{BigMapContentsRow, BigMapsRow, OriginatedAccountMapsRow}
 import tech.cryptonomic.conseil.tezos.TezosOptics
+import TezosOptics.Operations.{
+  extractAppliedOriginationsResults,
+  extractAppliedTransactions,
+  extractAppliedTransactionsResults
+}
 import tech.cryptonomic.conseil.tezos.michelson.contracts.TNSContract
 
 /** Defines big-map-diffs specific handling, from block data extraction to database storage
@@ -34,43 +40,64 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
     * @param ec needed to compose db operations
     * @return the count of records added
     */
-  def copyContent(blocks: List[Block])(implicit ec: ExecutionContext): DBIO[Int] = {
-    val copyDiffs = if (logger.underlying.isDebugEnabled()) {
-      val diffsPerBlock = blocks.map(b => b.data.hash.value -> TezosOptics.Blocks.readBigMapDiffCopy.getAll(b))
+  def copyContent(blocks: List[Block])(implicit ec: ExecutionContext): DBIO[Option[Int]] = {
+    val diffsPerBlock = blocks.map(b => b.data -> TezosOptics.Blocks.readBigMapDiffCopy.getAll(b))
+    if (logger.underlying.isDebugEnabled()) {
       diffsPerBlock.foreach {
-        case (hash, diffs) if diffs.nonEmpty =>
+        case (blockData, diffs) if diffs.nonEmpty =>
           logger.debug(
             "For block hash {}, I'm about to copy the following big maps data: \n\t{}",
-            hash.value,
+            blockData.hash.value,
             diffs.mkString(", ")
           )
         case _ =>
       }
-      diffsPerBlock.map(_._2).flatten
-    } else blocks.flatMap(TezosOptics.Blocks.readBigMapDiffCopy.getAll)
-
-    //need to load the sources and copy them with a new destination id
-    val contentCopies = copyDiffs.collect {
-      case Contract.BigMapCopy(_, Decimal(sourceId), Decimal(destinationId)) =>
-        Tables.BigMapContents
-          .filter(_.bigMapId === sourceId)
-          .map(it => (destinationId, it.key, it.keyHash, it.operationGroupId, it.value))
-          .result
-          .map(rows => rows.map(BigMapContentsRow.tupled).toList)
     }
 
-    DBIO
-      .sequence(contentCopies)
-      .flatMap { updateRows =>
-        val copies = updateRows.flatten
-        logger.info(
-          "{} big maps will be copied in the db.",
-          if (copies.nonEmpty) s"A total of ${copies.size}"
-          else "No"
-        )
-        Tables.BigMapContents.insertOrUpdateAll(copies)
+    /* we load the sources and copy them with a new destination id
+     * collecting relevant diffs per block level
+     * What we get out is a sequence of queries whose results are the new rows
+     * to write back to db, sorted by growing level
+     */
+    val sortedQueries = {
+      val copyDataByLevel = diffsPerBlock.map {
+        case (blockData, diffs) =>
+          val queries = diffs.collect {
+            case Contract.BigMapCopy(_, Decimal(sourceId), Decimal(destinationId)) =>
+              Tables.BigMapContents
+                .filter(_.bigMapId === sourceId)
+                .map(it => (destinationId, it.key, it.keyHash, it.operationGroupId, it.value))
+                .result
+                .headOption
+          }
+          blockData.header.level -> DBIO.sequence(queries).map(_.flatten)
+
       }
-      .map(_.sum)
+      TreeMap(copyDataByLevel: _*)
+    }
+
+    def dedup(contents: List[BigMapContentsRow]) =
+      contents
+        .groupBy(row => (row.bigMapId, row.key))
+        .values
+        .flatMap(_.lastOption)
+
+    val writesByLevel = sortedQueries.values.map(
+      readAction =>
+        readAction.flatMap { updateData =>
+          val rowsToWrite = dedup(updateData.map(BigMapContentsRow.tupled))
+          Tables.BigMapContents.insertOrUpdateAll(rowsToWrite)
+        }
+    )
+
+    DBIO.sequence(writesByLevel).map { upserts =>
+      val all = upserts.fold(Some(0))(_ |+| _)
+      logger.info(
+        "{} big maps will be actually copied in the db.",
+        all.fold("An unspecified number of")(String.valueOf)
+      )
+      all
+    }
 
   }
 
@@ -118,7 +145,6 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
     * @return the count of records added, if available from the underlying db-engine
     */
   def saveMaps(blocks: List[Block]): DBIO[Option[Int]] = {
-    import TezosOptics.Operations.extractAppliedOriginationsResults
 
     val diffsPerBlock = blocks.flatMap(
       b =>
@@ -161,7 +187,6 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
     * @return the count of records added, if available from the underlying db-engine
     */
   def upsertContent(blocks: List[Block]): DBIO[Option[Int]] = {
-    import TezosOptics.Operations.extractAppliedTransactionsResults
 
     val diffsPerBlock = blocks.flatMap(
       b =>
@@ -198,8 +223,8 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
       .foldLeft(Map.empty[(BigDecimal, String), BigMapContentsRow]) {
         case (collected, block) =>
           val seen = collected.keySet
-          val rows = blocks
-            .flatMap(b => rowsPerBlock.getOrElse(b.data.hash, List.empty))
+          val rows = rowsPerBlock
+            .getOrElse(block.data.hash, List.empty)
             .filterNot(row => seen((row.bigMapId, row.key)))
           collected ++ rows.map(row => (row.bigMapId, row.key) -> row)
       }
@@ -219,7 +244,6 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
     * @return the count of records added, if available from the underlying db-engine
     */
   def saveContractOrigin(blocks: List[Block]): DBIO[List[OriginatedAccountMapsRow]] = {
-    import TezosOptics.Operations.extractAppliedOriginationsResults
 
     val diffsPerBlock = blocks.flatMap(
       b =>
@@ -310,7 +334,6 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
       blocks: List[Block]
   )(implicit ec: ExecutionContext, tokenContracts: TokenContracts): DBIO[Option[Int]] = {
     import slickeffect.implicits._
-    import TezosOptics.Operations.extractAppliedTransactions
 
     val toSql = (zdt: java.time.ZonedDateTime) => java.sql.Timestamp.from(zdt.toInstant)
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -10,7 +10,7 @@
     </appender>
 
     <logger name="com.base22" level="TRACE"/>
-    <logger name="tech.cryptonomic.conseil.tezos.BigMapsOperations" level="DEBUG"/>
+    <logger name="tech.cryptonomic.conseil.tezos.bigmaps.BigMapsOperations" level="DEBUG"/>
     <logger name="tech.cryptonomic.conseil.tezos.michelson.contracts.TNSContracts" level="DEBUG"/>
 
     <root level="OFF">

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTestFixtures.scala
@@ -772,7 +772,7 @@ trait TezosDataGeneration extends RandomGenerationKit {
       * In this case the generation needs happen only for Originations
       */
     def updateOperationsWithBigMapAllocation(
-        diffGenerate: PartialFunction[Operation, Contract.BigMapAlloc]
+        diffGenerate: PartialFunction[Operation, List[Contract.BigMapAlloc]]
     ): List[Operation] => List[Operation] = {
       import tech.cryptonomic.conseil.tezos.TezosOptics.Operations._
 
@@ -790,7 +790,7 @@ trait TezosDataGeneration extends RandomGenerationKit {
       * In this case the generation needs happen only for Transacions
       */
     def updateOperationsWithBigMapUpdate(
-        diffGenerate: PartialFunction[Operation, Contract.BigMapUpdate]
+        diffGenerate: PartialFunction[Operation, List[Contract.BigMapUpdate]]
     ): List[Operation] => List[Operation] = {
       import tech.cryptonomic.conseil.tezos.TezosOptics.Operations._
 
@@ -808,7 +808,7 @@ trait TezosDataGeneration extends RandomGenerationKit {
       * In this case the generation needs happen only for Transactions
       */
     def updateOperationsWithBigMapCopy(
-        diffGenerate: PartialFunction[Operation, Contract.BigMapCopy]
+        diffGenerate: PartialFunction[Operation, List[Contract.BigMapCopy]]
     ): List[Operation] => List[Operation] = {
       import tech.cryptonomic.conseil.tezos.TezosOptics.Operations._
 
@@ -826,7 +826,7 @@ trait TezosDataGeneration extends RandomGenerationKit {
       * In this case the generation needs happen only for Transacions
       */
     def updateOperationsWithBigMapRemove(
-        diffGenerate: PartialFunction[Operation, Contract.BigMapRemove]
+        diffGenerate: PartialFunction[Operation, List[Contract.BigMapRemove]]
     ): List[Operation] => List[Operation] = {
       import tech.cryptonomic.conseil.tezos.TezosOptics.Operations._
 
@@ -846,17 +846,17 @@ trait TezosDataGeneration extends RandomGenerationKit {
      * @return the updated operations
      */
     private def updateOperationsToBigMapDiff[Diff <: Contract.BigMapDiff](
-        diffGenerate: PartialFunction[Operation, Diff],
+        diffGenerate: PartialFunction[Operation, List[Diff]],
         diffSetter: Optional[Operation, List[Contract.CompatBigMapDiff]]
     )(operations: List[Operation]): List[Operation] =
       operations.map { op =>
         // applies the function to create a possible value to set on each individual operation
-        val maybeDiff = PartialFunction.condOpt(op)(diffGenerate)
+        val maybeDiffs = PartialFunction.condOpt(op)(diffGenerate)
 
         //sets the diff value list in the optional field of the operation if there's something, or returns the unchanged operation
-        maybeDiff.fold(op) { diff =>
-          val diffFieldValue = Left(diff) //look at how CompatBigMapDiff is defined
-          diffSetter.modify(diffs => diffFieldValue :: diffs)(op)
+        maybeDiffs.fold(op) { diffs =>
+          val diffFieldValues = diffs.map(Left(_)) //look at how CompatBigMapDiff is defined
+          diffSetter.modify(diffs => diffFieldValues ::: diffs)(op)
         }
       }
 


### PR DESCRIPTION
Fix #807 on the release branch before modular redesign.

We essentially take care to preserve ordering of incoming operations when computing big-map-diffs, keeping only the latest data for multiple overlapping keys and/or map ids (depending on whether we're handling map copies or content updates).

The content upsert code in particular suffered from a code error that lead to invalid results of the stored data.

We now have custom-made tests to verify the failures are being corrected.

Attached are the logs before and after the fix, tested against a specific block range of carthage network which showed the issue.
[issue807-carthagetests-400000-400300-afterfix-release-branch.log](https://github.com/Cryptonomic/Conseil/files/4663747/issue807-carthagetests-400000-400300-afterfix-release-branch.log)
[issue807-carthagetests-400000-400300-beforefix-release-branch.log](https://github.com/Cryptonomic/Conseil/files/4663748/issue807-carthagetests-400000-400300-beforefix-release-branch.log)
