### PR TITLE
809 - Avoid runtime failure of metadata check for genesis block crashing Lorre

### DIFF
--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosIndexer.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosIndexer.scala
@@ -384,8 +384,8 @@ class TezosIndexer(
       import tech.cryptonomic.conseil.common.util.Conversion.Syntax._
 
       //DANGER Will Robinson! we assume in the rest of the code that we're not handling the genesis block
-      val safeBlocks = blocks.filterNot(block => TezosNodeOperator.isGenesis(block.data))
-      val safeListings = listings.filterNot { case (block, rolls) => TezosNodeOperator.isGenesis(block.data) }
+      val safeBlocks = blocks.filterNot(block => block.data.metadata == GenesisMetadata)
+      val safeListings = listings.filterNot { case (block, rolls) => block.data.metadata == GenesisMetadata }
 
       for {
         proposals <- nodeOperator.getProposals(safeBlocks.map(_.data))


### PR DESCRIPTION
Fixes #809 

The "unsafe" check was made on faulty assumptions about the genesis identification.

Now the check is made directly to guarantee that failing data won't be used in the type-unsafe `.get` call from the optional value.

Attached logs show the behaviour before and after the changes.

[issue809-beforefix-carthagetests.log](https://github.com/Cryptonomic/Conseil/files/4664405/issue809-beforefix-carthagetests.log)
[issue809-afterfix-carthagetests.log](https://github.com/Cryptonomic/Conseil/files/4664406/issue809-afterfix-carthagetests.log)
