### PR TITLE
809 - Avoid runtime failure of metadata check for genesis block crashing Lorre [backport]

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/Lorre.scala
@@ -426,32 +426,38 @@ object Lorre extends App with TezosErrors with LazyLogging with LorreAppConfig w
       import DatabaseConversions._
       import tech.cryptonomic.conseil.util.Conversion.Syntax._
 
+      //DANGER Will Robinson! we assume in the rest of the code that we're not handling the genesis block
+      val safeBlocks = blocks.filterNot(block => block.data.metadata == GenesisMetadata)
+      val safeListings = listings.filterNot { case (block, rolls) => block.data.metadata == GenesisMetadata }
+
       for {
-        proposals <- tezosNodeOperator.getProposals(blocks.map(_.data))
+        proposals <- tezosNodeOperator.getProposals(safeBlocks.map(_.data))
         blockHashesWithProposals = proposals.filter(_._2.isDefined).map(_._1)
-        blocksWithProposals = blocks.filter(blockData => blockHashesWithProposals.contains(blockData.data.hash))
+        blocksWithProposals = safeBlocks.filter(blockData => blockHashesWithProposals.contains(blockData.data.hash))
         ballotCountsPerCycle <- Future.traverse(blocksWithProposals) { block =>
-          db.run(TezosDb.getBallotOperationsForCycle(TezosTypes.discardGenesis(block.data.metadata).level.cycle))
+          db.run(TezosDb.getBallotOperationsForCycle(TezosTypes.discardGenesis(block.data.metadata).get.level.cycle))
             .map(block -> _)
         }
         ballotCountsPerLevel <- Future.traverse(blocksWithProposals) { block =>
           db.run(TezosDb.getBallotOperationsForLevel(block.data.header.level))
             .map(block -> _)
         }
-        proposalHashes <- Future.traverse(blocks) { block =>
-          db.run(TezosDb.getProposalOperationHashesByCycle(TezosTypes.discardGenesis(block.data.metadata).level.cycle))
+        proposalHashes <- Future.traverse(safeBlocks) { block =>
+          db.run(
+              TezosDb.getProposalOperationHashesByCycle(TezosTypes.discardGenesis(block.data.metadata).get.level.cycle)
+            )
             .map(block -> _)
         }
         ballots <- tezosNodeOperator.getVotes(blocksWithProposals)
         governanceRows = groupGovernanceDataByBlock(
           blocksWithProposals,
           proposals.toMap,
-          listings.map { case (block, listing) => block.data.header.level -> listing }.toMap,
+          safeListings.map { case (block, listing) => block.data.header.level -> listing }.toMap,
           ballots.toMap,
           ballotCountsPerCycle.toMap,
           ballotCountsPerLevel.toMap,
           proposalHashes.toMap
-        ).map(_.convertTo[Tables.GovernanceRow])
+        ).flatMap(_.convertToA[Option, Tables.GovernanceRow])
         _ <- db.run(TezosDb.insertGovernance(governanceRows))
       } yield ()
     }

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosNodeOperator.scala
@@ -676,7 +676,7 @@ class TezosNodeOperator(
 
     def extractAccountIds(blockData: BlockData): List[AccountId] =
       for {
-        blockHeaderMetadata <- discardGenesis.lift(blockData.metadata).toList
+        blockHeaderMetadata <- discardGenesis(blockData.metadata).toList
         balanceUpdate <- blockHeaderMetadata.balance_updates
         id <- balanceUpdate.contract.map(_.id).toList ::: balanceUpdate.delegate.map(_.value).toList
       } yield AccountId(id)

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosOptics.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosOptics.scala
@@ -101,26 +101,22 @@ object TezosOptics {
 
     //Note, cycle 0 starts at the level 2 block
     def extractCycle(block: Block): Option[Int] =
-      discardGenesis
-        .lift(block.data.metadata) //this returns an Option[BlockHeaderMetadata]
+      discardGenesis(block.data.metadata) //this returns an Option[BlockHeaderMetadata]
         .map(_.level.cycle) //this is Option[Int]
 
     //Note, cycle 0 starts at the level 2 block
     def extractCycle(block: BlockData): Option[Int] =
-      discardGenesis
-        .lift(block.metadata) //this returns an Option[BlockHeaderMetadata]
+      discardGenesis(block.metadata) //this returns an Option[BlockHeaderMetadata]
         .map(_.level.cycle) //this is Option[Int]
 
     //Note, cycle 0 starts at the level 2 block
     def extractCyclePosition(block: BlockMetadata): Option[Int] =
-      discardGenesis
-        .lift(block) //this returns an Option[BlockHeaderMetadata]
+      discardGenesis(block) //this returns an Option[BlockHeaderMetadata]
         .map(_.level.cycle_position) //this is Option[Int]
 
     //Note, cycle 0 starts at the level 2 block
     def extractPeriod(block: BlockMetadata): Option[Int] =
-      discardGenesis
-        .lift(block)
+      discardGenesis(block)
         .map(_.level.voting_period)
   }
 

--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosTypes.scala
@@ -180,8 +180,11 @@ object TezosTypes {
   )
 
   /** only accepts standard block metadata, discarding the genesis metadata */
-  def discardGenesis: PartialFunction[BlockMetadata, BlockHeaderMetadata] = {
-    case md: BlockHeaderMetadata => md
+  def discardGenesis: BlockMetadata => Option[BlockHeaderMetadata] = {
+    val partialSelector: PartialFunction[BlockMetadata, BlockHeaderMetadata] = {
+      case md: BlockHeaderMetadata => md
+    }
+    partialSelector.lift
   }
 
   /** Naming can be deceiving, we're sticking with the json schema use of `positive_bignumber`

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/DatabaseConversionsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/DatabaseConversionsTest.scala
@@ -96,7 +96,7 @@ class DatabaseConversionsTest
         val converted = block.convertTo[Tables.BlocksRow]
 
         val header = block.data.header
-        val metadata = discardGenesis.lift(block.data.metadata)
+        val metadata = discardGenesis(block.data.metadata)
         val CurrentVotes(expectedQuorum, proposal) = block.votes
 
         converted should have(

--- a/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperationsTest.scala
@@ -119,7 +119,7 @@ class TezosDatabaseOperationsTest
 
           forAll(dbBlocks zip generatedBlocks) {
             case (row, block) =>
-              val metadata = discardGenesis.lift(block.data.metadata)
+              val metadata = discardGenesis(block.data.metadata)
 
               row.level shouldEqual block.data.header.level
               row.proto shouldEqual block.data.header.proto


### PR DESCRIPTION
Hotfix for #809 

Back-ported to the release branch as solved in #815 