### PR TITLE
818 - Update the travis conf to test in the relevant build phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: scala
 jdk:
   - openjdk8
 scala:
-   - 2.12.10
-script: "sbt ++$TRAVIS_SCALA_VERSION test:compile"
-after_success: "sbt coverage test coverageReport coverageAggregate coveralls"
+  - 2.12.10
+script: sbt clean coverage test coverageAggregate
+after_success: sbt coveralls

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("io.get-coursier"        % "sbt-coursier"         % "1.1.0-M9")
 addSbtPlugin("com.eed3si9n"           % "sbt-assembly"         % "0.14.5")
 addSbtPlugin("com.eed3si9n"           % "sbt-buildinfo"        % "0.9.0")
-addSbtPlugin("org.scoverage"          % "sbt-scoverage"        % "1.5.1")
+addSbtPlugin("org.scoverage"          % "sbt-scoverage"        % "1.6.1")
 addSbtPlugin("org.scoverage"          % "sbt-coveralls"        % "1.2.7")
 addSbtPlugin("net.virtual-void"       % "sbt-dependency-graph" % "0.9.0")
 addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat"       % "1.0.9")


### PR DESCRIPTION
Closes #818 

Define the build as outlined in the [sbt-coveralls](https://github.com/scoverage/sbt-coveralls) documentation.

The sbt-scoverage plugin was upgraded to get aggregateReports for all modules, with no need to run the individual reports, as per [1.6.0 release notes](https://github.com/scoverage/sbt-scoverage#notes-on-upgrading-to-version-160) 