### PR TITLE
791 - make the token handling compatible with tzBTC format [backport]

### DIFF
--- a/src/main/resources/metadata/tezos.mainnet.conf
+++ b/src/main/resources/metadata/tezos.mainnet.conf
@@ -33,6 +33,7 @@
             "tz1Z9MxKUBcbA6SKyKu9VLif8PeiQ5fkpCeo": "@tezosnoob"
             "tz1djRgXXWWJiY1rpMECCxr5d9ZBqWewuiU1": "Galleon Support"
             "KT1ChNsEFxwyCbJyWGSL3KdjeXE28AY1Kaog": "TCF Baker Registry"
+            "KT1GfAzvH7aUtVPbqRw6WbYMbd77dFPErQUg": "Staker Dao Manager"
             "tz1RaGb8tWxUh194btmAiXT9Tkk6pGBMZVL8": "USDtz Mother"
             "KT1LN4LPSqTMS7Sd2CJw4bbDGRkMv2t68Fy9": "USDtz Token"
 

--- a/src/main/resources/registered_tokens/mainnet.csv
+++ b/src/main/resources/registered_tokens/mainnet.csv
@@ -1,3 +1,4 @@
 id, name      , contract_type  , account_id
 1 , Staker DAO, FA1.2-StakerDao, KT1EctCuorV2NfVb1XTQgvzJ88MQtWP8cMMv
 2 , USDtz     , FA1.2          , KT1LN4LPSqTMS7Sd2CJw4bbDGRkMv2t68Fy9
+3 , tzBTC     , FA1.2          , KT1PWx2mnDueood7fEmfbBDKx1D9BAnnXitn

--- a/src/main/scala/tech/cryptonomic/conseil/util/CryptoUtil.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/util/CryptoUtil.scala
@@ -70,7 +70,8 @@ object CryptoUtil {
         case "kt1" => "01" + hexString + "00"
       }
 
-    //what if the wrapped length is odd?
+    //what if the wrapped length is odd? Technically it shouldn't be possible since
+    //bytes are always made of 2 chars and we only pad them with other bytes
     base58CheckDecode(b58Address, b58Address.take(3).toLowerCase).map { bytes =>
       val wrapped = wrap(Hex.encode(bytes.toArray))
       s"050a${dataLength(wrapped.length / 2)}$wrapped"
@@ -116,4 +117,51 @@ object CryptoUtil {
       }
     } yield address
   }
+
+  /** When encoding numbers as bytes in michelson/micheline they use
+    * an unusual form, it's little endian base-128 but use the full bytes
+    * to keep additional info.
+    *
+    * Please refer to the last paragraph of
+    * https://medium.com/the-cryptonomic-aperiodical/the-magic-and-mystery-of-the-micheline-binary-format-33bf85699bef
+    * or to the original implementation: https://github.com/ocaml/Zarith
+    *
+    * @param hexEncoded ZArith encoding as hex string
+    * @return a possibly valid signed integer of arbitrary magnitude
+    */
+  def decodeZarithNumber(hexEncoded: String): Try[BigInt] = {
+    import scorex.util.encode.{Base16 => Hex}
+
+    //the sign is defined by the second bit in the hex-string
+    val signMask: Byte = 0x40
+
+    /* base128 little-endian decoding with special treat for the lower byte */
+    def readSigned(bytes: Array[Byte]): BigInt = {
+      val positive = (bytes.head & signMask) == 0
+      val masked = ((bytes.head & 0x3F) +: bytes.tail.map(_ & 0x7F)).map(_.toByte)
+
+      val result = masked.zipWithIndex.foldRight(BigInt(0)) {
+        case ((byte, 0), bigInt) =>
+          bigInt | BigInt(byte)
+        case ((byte, index), bigInt) =>
+          val intBits = BigInt(byte) << (7 * index - 1)
+          bigInt | intBits
+      }
+
+      if (positive) result else -result
+    }
+
+    Hex
+      .decode(hexEncoded)
+      .map { bytes =>
+        /* the first bit signals that there's more to read
+         * we keep all those, and add the one following
+         */
+        val highBitSet = bytes.takeWhile(_ < 0)
+        highBitSet :+ bytes(highBitSet.size)
+      }
+      .map(readSigned)
+
+  }
+
 }

--- a/src/test/scala/tech/cryptonomic/conseil/util/CryptoUtilTest.scala
+++ b/src/test/scala/tech/cryptonomic/conseil/util/CryptoUtilTest.scala
@@ -1,6 +1,7 @@
 package tech.cryptonomic.conseil.util
 
 import org.scalatest.{FlatSpec, Matchers}
+import cats.implicits._
 
 class CryptoUtilTest extends FlatSpec with Matchers {
 
@@ -31,4 +32,27 @@ class CryptoUtilTest extends FlatSpec with Matchers {
       address shouldBe "tz1b2icJC4E7Y2ED1xsZXuqYpF7cxHDtduuP"
     }
 
+  it should "decode a zarith signed number" in {
+      val hex = List(
+        "86bb230200000000",
+        "b8c6ce95020200000000",
+        "ac9a010200000000",
+        "840e0200000000",
+        "a88c010200000000",
+        "090200000000",
+        "490200000000"
+      )
+
+      val nums = hex.traverse(CryptoUtil.decodeZarithNumber).get
+
+      nums should contain theSameElementsInOrderAs List(
+        BigInt(290502),
+        BigInt(291099064),
+        BigInt(9900),
+        BigInt(900),
+        BigInt(9000),
+        BigInt(9),
+        BigInt(-9)
+      )
+    }
 }


### PR DESCRIPTION
Fix #791 for the release branch

This changes handles in a uniform way multiple token formats to read both addresses and balances from the big-map diffs for three common formats: USDtz, StakerDAO, tzBTC

It includes additional efforts to document the logic used to decode the specific formats of data included in those contracts

I slipped in known mainnet account alias for "Staker Dao Manager", too
@anonymoussprocket please confirm if it's fine ☝️ 

@vishakh @anonymoussprocket 👇 
I can't find a note with the addresses to fill the token-registries (mainnet, carthagenet) for tzBTC.

Could you kindly tell me how to fill the entry to put in this very PR to handle it?

### details of the changes

The first release of the token-handling code would make simple assumptions on the format of balance results found in the big-map diffs.

From additional information collected on different FA1.2 token actual implementations, we now handle more formats to express the same balance changes in diffs, given that they can be

 - an explicit numeric value that defines the new token balance for the address identified by the map key (e.g. StakerDao)
 - a micheline instruction encoding a numeric int value of the token balance for the address identified by the map key (e.g. USDtz)
 - a byte-encoded micheline instruction that, once decoded, defines a pair holding a ZArith-encoded token balance for the address identified by the map key (e.g. tzBTC)

In addition to that, the key used to identify the balance owner in the big map can have different encodings, depending on the contract implementation, and now we handle

 - binary packed addresses (StakerDao and USDtz)
 - micheline binary encoded to an instruction that provides a "ledger" value as a packed address (tzBTC)
 - total supply reference for the tzBTC tokens, which is ignored by the indexer

All in all the information is essentially the same but can be stored in different formats.