### PR TITLE
843 - 844 - Missing proposals data from governance and fix incorrect rolls counts per level

### DIFF
--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseConversions.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseConversions.scala
@@ -13,7 +13,7 @@ import tech.cryptonomic.conseil.common.tezos.TezosTypes.Fee.AverageFees
 import tech.cryptonomic.conseil.common.tezos.TezosTypes.Voting.Vote
 import tech.cryptonomic.conseil.common.tezos.TezosTypes.{BakingRights, EndorsingRights, FetchRights, _}
 import tech.cryptonomic.conseil.indexer.tezos.michelson.contracts.TNSContract
-import tech.cryptonomic.conseil.common.tezos.{Tables, TezosOptics, TezosTypes}
+import tech.cryptonomic.conseil.common.tezos.{Tables, TezosOptics}
 import tech.cryptonomic.conseil.common.util.Conversion
 
 import scala.util.Try
@@ -881,19 +881,6 @@ private[tezos] object TezosDatabaseConversions extends LazyLogging {
 
       }
 
-      def countRolls(listings: List[Voting.BakerRolls], ballots: List[Voting.Ballot]): (Int, Int, Int) =
-        ballots.foldLeft((0, 0, 0)) {
-          case ((yays, nays, passes), votingBallot) =>
-            val rolls = listings.find(_.pkh == votingBallot.pkh).map(_.rolls).getOrElse(0)
-            votingBallot.ballot match {
-              case Vote("yay") => (yays + rolls, nays, passes)
-              case Vote("nay") => (yays, nays + rolls, passes)
-              case Vote("pass") => (yays, nays, passes + rolls)
-              case Vote(notSupported) =>
-                logger.error("Not supported vote type {}", notSupported)
-                (yays, nays, passes)
-            }
-        }
     }
 
   implicit val tnsNameRecordToRow =

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
@@ -523,8 +523,16 @@ object TezosDatabaseOperations extends LazyLogging {
   ): DBIO[Seq[Tables.EndorsingRightsRow]] =
     Tables.EndorsingRights.filter(_.level === blockLevel).result
 
-  /** Stores the governance statistic aggregates in the database
-    *
+  /**
+    * Fetches all governance entries for a given block level
+    * @param level to identify the relevant block
+    * @return the governance data
+    */
+  def getGovernanceForLevel(level: Int): DBIO[Seq[GovernanceRow]] =
+    Tables.Governance.filter(_.level === level).result
+
+  /**
+    * Stores the governance statistic aggregates in the database
     * @param governance aggregates
     * @return the number of rows added, if available from the driver
     */

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
@@ -493,7 +493,7 @@ object TezosDatabaseOperations extends LazyLogging {
     * Writes baking rights to the database
     * @param bakingRights mapping of hash to endorsingRights list
     */
-  def insertBakingRights(bakingRights: List[BakingRights]): DBIO[Option[Int]] = {
+  def writeBakingRights(bakingRights: List[BakingRights]): DBIO[Option[Int]] = {
     berLogger.info("Inserting baking rights to the DB...")
     Tables.BakingRights ++= bakingRights.map(_.convertTo[Tables.BakingRightsRow])
   }
@@ -502,7 +502,7 @@ object TezosDatabaseOperations extends LazyLogging {
     * Writes endorsing rights to the database
     * @param endorsingRights mapping of hash to endorsingRights list
     */
-  def insertEndorsingRights(endorsingRights: List[EndorsingRights]): DBIO[Option[Int]] = {
+  def writeEndorsingRights(endorsingRights: List[EndorsingRights]): DBIO[Option[Int]] = {
     berLogger.info("Inserting endorsing rights to the DB...")
     Tables.EndorsingRights ++= endorsingRights.flatMap(_.convertToA[List, Tables.EndorsingRightsRow])
   }

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
@@ -493,7 +493,7 @@ object TezosDatabaseOperations extends LazyLogging {
     * Writes baking rights to the database
     * @param bakingRights mapping of hash to endorsingRights list
     */
-  def writeBakingRights(bakingRights: List[BakingRights]): DBIO[Option[Int]] = {
+  def insertBakingRights(bakingRights: List[BakingRights]): DBIO[Option[Int]] = {
     berLogger.info("Inserting baking rights to the DB...")
     Tables.BakingRights ++= bakingRights.map(_.convertTo[Tables.BakingRightsRow])
   }
@@ -502,7 +502,7 @@ object TezosDatabaseOperations extends LazyLogging {
     * Writes endorsing rights to the database
     * @param endorsingRights mapping of hash to endorsingRights list
     */
-  def writeEndorsingRights(endorsingRights: List[EndorsingRights]): DBIO[Option[Int]] = {
+  def insertEndorsingRights(endorsingRights: List[EndorsingRights]): DBIO[Option[Int]] = {
     berLogger.info("Inserting endorsing rights to the DB...")
     Tables.EndorsingRights ++= endorsingRights.flatMap(_.convertToA[List, Tables.EndorsingRightsRow])
   }

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosGovernanceOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosGovernanceOperations.scala
@@ -3,8 +3,12 @@ package tech.cryptonomic.conseil.indexer.tezos
 import tech.cryptonomic.conseil.common.tezos.TezosTypes._
 import tech.cryptonomic.conseil.common.tezos.VotingOperations._
 import scala.concurrent.{ExecutionContext, Future}
+import scala.math.max
+import scala.util.Try
 import com.typesafe.scalalogging.LazyLogging
+import slick.dbio.DBIO
 import slick.jdbc.PostgresProfile.api.Database
+import cats.implicits._
 
 /** Process blocks and voting data to compute details for
   * the governance-related cycles
@@ -43,6 +47,39 @@ object TezosGovernanceOperations extends LazyLogging {
     * @param pass how many passes
     */
   case class VoteRollsCounts(yay: Int, nay: Int, pass: Int)
+
+  object VoteRollsCounts {
+
+    /** a wrapper with all zeroes */
+    val zero = VoteRollsCounts(0, 0, 0)
+
+    /** defines substraction between counts, with the caveat
+      * that no result of the substraction can have negative counts,
+      * which would have no meaning
+      *
+      * @param subtrahend
+      * @param minuend
+      * @return the "zero-min" difference of the counts, element by element
+      */
+    def subtract(subtrahend: VoteRollsCounts, minuend: VoteRollsCounts): VoteRollsCounts = (subtrahend, minuend) match {
+      case (VoteRollsCounts(y1, n1, p1), VoteRollsCounts(y2, n2, p2)) =>
+        /* We make use of cats implicit instances which defines general operations that applies to Ints too:
+         * - |+| sums two integers
+         * - i.inverse() changes the sign, i.e. i.inverse() === -i
+         * Therefore we do substraction by adding the negated number.
+         *
+         * Cats provides the additional facilities to do that for a whole triplet of Ints
+         * in a single call, such that corresponding elements of the tuple are subtracted
+         * as you might naturally want to do.
+         *
+         * We subtract the three values of the rolls counts each by each as 2 triplets.
+         * Then we make sure to avoid results of negative rolls counts.
+         */
+        val (y, n, p) = (y1, n1, p1) |+| ((y2, n2, p2).inverse())
+        VoteRollsCounts(max(y, 0), max(n, 0), max(p, 0))
+    }
+
+  }
 
   /** Extracts and aggregates the information relative to different
     * governance periods, restricted to a selection of blocks.
@@ -84,7 +121,7 @@ object TezosGovernanceOperations extends LazyLogging {
       proposalsMap = activeProposals.toMap
       //pair blocks and proposals
       blocksAndProposals = blocks.map(block => block -> proposalsMap.getOrElse(block.data.hash, None)).toMap
-      ballots <- nodeOperator.getVotes(blocksAndProposals.keys.toList)
+      ballots <- nodeOperator.getVotes(blocks)
       aggregates <- aggregateData(db)(
         blocksAndProposals,
         ballots.toMap,
@@ -177,10 +214,16 @@ object TezosGovernanceOperations extends LazyLogging {
       db.run(proposalHashesPerCycle(block).map(block -> _))
     }
 
+    val previousRollsResult = db
+      .run(
+        queryPreviousBatchStats(activeProposalsBlocks.keySet)
+      )
+
     for {
       levelCountsMap <- levelBallotCountsResult
       cycleCountsMap <- cycleBallotCountsResult
       proposalCounts <- proposalCountsResult
+      previousBatchRolls <- previousRollsResult
     } yield
       fillAggregates(
         activeProposalsBlocks,
@@ -188,7 +231,8 @@ object TezosGovernanceOperations extends LazyLogging {
         activeProposalsBallots,
         levelCountsMap,
         cycleCountsMap,
-        proposalCounts.toMap
+        proposalCounts.toMap,
+        previousBatchRolls.getOrElse(VoteRollsCounts.zero)
       )
   }
 
@@ -201,23 +245,27 @@ object TezosGovernanceOperations extends LazyLogging {
       ballots: Map[Block, List[Voting.Ballot]],
       ballotCountsPerLevel: Map[Block, BallotsPerLevel],
       ballotCountsPerCycle: Map[Int, BallotsPerCycle],
-      proposalCountsByBlock: Map[Block, Map[ProtocolId, Int]] //comes from individual operations on the block
+      proposalCountsByBlock: Map[Block, Map[ProtocolId, Int]], //comes from individual operations on the block
+      previousBatchRolls: VoteRollsCounts
   ): List[GovernanceAggregate] =
     proposalsBlocks.toList.flatMap {
       case (block, currentProposal) =>
-        val rollsAtLevel = rollsByLevel.getOrElse(block.data.header.level, List.empty)
-        val rollsAtPreviousLevel = rollsByLevel.getOrElse(block.data.header.level - 1, List.empty)
-        val rollsForBlockLevel = rollsAtLevel.diff(rollsAtPreviousLevel)
         val ballot = ballots.getOrElse(block, List.empty)
+        val rollsAtLevel = countRolls(rollsByLevel.getOrElse(block.data.header.level, List.empty), ballot)
+        val rollsAtPreviousLevel = rollsByLevel.get(block.data.header.level - 1) match {
+          case Some(bakerRolls) =>
+            countRolls(bakerRolls, ballot)
+          case None =>
+            //when we have no data here we need to use the counts from previously collected blocks
+            previousBatchRolls
+        }
+        val rollsForBlockLevel = VoteRollsCounts.subtract(rollsAtLevel, rollsAtPreviousLevel)
         val ballotCountPerCycle = block.data.metadata match {
           case md: BlockHeaderMetadata => ballotCountsPerCycle.get(md.level.cycle).map(_.counts)
           case GenesisMetadata => None
         }
         val ballotCountPerLevel = ballotCountsPerLevel.get(block).map(_.counts)
         val proposalCounts = proposalCountsByBlock.getOrElse(block, Map.empty).toList
-
-        val allRolls = countRolls(rollsAtLevel, ballot)
-        val levelRolls = countRolls(rollsForBlockLevel, ballot)
 
         /* Here we collect a row for the block being considered
          * to get voting data for the periods with a specific proposal
@@ -239,8 +287,8 @@ object TezosGovernanceOperations extends LazyLogging {
                   block.data.hash,
                   metadata,
                   Some(proposal),
-                  allRolls,
-                  levelRolls,
+                  rollsAtLevel,
+                  rollsForBlockLevel,
                   ballotCountPerCycle,
                   ballotCountPerLevel
                 )
@@ -258,12 +306,13 @@ object TezosGovernanceOperations extends LazyLogging {
                     block.data.hash,
                     metadata.copy(voting_period_kind = VotingPeriod.proposal), //we know these are from operations
                     Some(proposalProtocol),
-                    allRolls,
-                    levelRolls,
+                    rollsAtLevel,
+                    rollsForBlockLevel,
                     Some(Voting.BallotCounts(count, 0, 0)),
                     ballotCountPerLevel
                   )
               }
+
             activeProposalAggregate.toList ::: proposalOperationsAggregates
           case GenesisMetadata =>
             //case handled to satisfy the compiler, should never run by design
@@ -288,4 +337,57 @@ object TezosGovernanceOperations extends LazyLogging {
     }
     VoteRollsCounts(yays, nays, passes)
   }
+
+  /** We plan to compute rolls counts per each block level, as opposed to
+    * having only the cycle total, up to a given level.
+    * We do this by removing the previous level's counts from those of the
+    * latest one.
+    *
+    * Since we're processing blocks in batches, the main entrypoint in this object
+    * (i.e. [[extractGovernanceAggregations]])
+    * will receive as arguments the batch of blocks, along with the corresponding
+    * baker rolls.
+    * Therefore, as we compute the rolls differences, we have all
+    * the values we need for each block level, apart from the first block.
+    * In such case we miss the cycle total of rolls for the previous level,
+    * which is not included in the arguments. But we have those values stored
+    * locally, because we computed the governance records for the previous
+    * batch already.
+    *
+    * This function queries the existing governance records to find which
+    * were the total rolls per cycle at the level "before" the one corresponding
+    * to the first block in the set passed as argument.
+    *
+    * To give a clarifying example, consider a call to extract the aggregates
+    * for block levels 100-110.
+    * We get the blocks, and the rolls for those levels.
+    * To compute rolls for bakers of level 110, we take the
+    * rolls up to 110 and subtract the rolls up to 109, and so on,
+    * until we bump into the fist block, at level 100.
+    * Here we don't have rolls up to 99, so we need to reach
+    * to the stored governance records and get those counts.
+    */
+  private def queryPreviousBatchStats(
+      blocks: Set[Block]
+  )(implicit ec: ExecutionContext): DBIO[Option[VoteRollsCounts]] = {
+    //adapting database-level formats to the domain-level ones
+    def downCastToInt(bd: BigDecimal) = Try(bd.toIntExact).toOption
+    //should be the level we reached, before the current processing batch
+    val previousBatchHighLevel = blocks.map(_.data.header.level).min - 1
+
+    TezosDatabaseOperations
+      .getGovernanceForLevel(previousBatchHighLevel)
+      .map(
+        govRows =>
+          govRows.headOption.flatMap(
+            stats =>
+              (
+                stats.yayRolls.flatMap(downCastToInt),
+                stats.nayRolls.flatMap(downCastToInt),
+                stats.passRolls.flatMap(downCastToInt)
+              ).mapN(VoteRollsCounts.apply)
+          )
+      )
+  }
+
 }

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosGovernanceOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosGovernanceOperations.scala
@@ -19,7 +19,7 @@ object TezosGovernanceOperations extends LazyLogging {
     * @param proposalId a specific proposal under evaluation
     * @param allRolls ballot rolls up to this block for the proposal
     * @param rollsPerLevel ballot rolls included in this specific block
-    * @param ballotsPerCycle how many baloots for a whole cycle
+    * @param ballotsPerCycle how many ballots for a whole cycle
     * @param ballotsPerLevel how many ballots for the single block level
     */
   case class GovernanceAggregate(

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosGovernanceOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosGovernanceOperations.scala
@@ -251,7 +251,7 @@ object TezosGovernanceOperations extends LazyLogging {
                 /* this should never be the case: the proposal currently under evaluation
                  * should not be proposed in operations of the same block
                  */
-                case (proposal, _) => currentProposal.exists(_ == proposal)
+                case (proposal, _) => currentProposal.contains(proposal)
               }.map {
                 case (proposalProtocol, count) =>
                   GovernanceAggregate(

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosGovernanceOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosGovernanceOperations.scala
@@ -83,7 +83,7 @@ object TezosGovernanceOperations extends LazyLogging {
       activeProposals <- nodeOperator.getActiveProposals(blocksInActiveVotingPeriod)
       proposalsMap = activeProposals.toMap
       //pair blocks and proposals
-      blocksAndProposals = blocks.map(block => block -> proposalsMap.get(block.data.hash).flatten).toMap
+      blocksAndProposals = blocks.map(block => block -> proposalsMap.getOrElse(block.data.hash, None)).toMap
       ballots <- nodeOperator.getVotes(blocksAndProposals.keys.toList)
       aggregates <- aggregateData(db)(
         blocksAndProposals,
@@ -104,20 +104,20 @@ object TezosGovernanceOperations extends LazyLogging {
     *              have a proper metadata value, different from the genesis one
     *
     * @param db needed to fetch previously stored voting data
-    * @param proposalsBlocks blocks we want to have governance data for, associated to the protocol of the proposal
-    * @param proposalsBallots votes cast on the blocks of interest,
-    *                         the keys should be a superset of the `proposalsBlocks` keys,
+    * @param activeProposalsBlocks blocks we want to have governance data for, associated to the protocol of the proposal
+    * @param activeProposalsBallots votes cast on the blocks of interest,
+    *                         the keys should be a superset of the `activeProposalsBlocks` keys,
     *                         so that the value is available for each of those blocks.
-    * @param levelsRolls listings of baker rolls involved, indexed per level, we expect all levels for the
+    * @param rollsByLevel listings of baker rolls involved, indexed per level, we expect all levels for the
     *                         `proposalsBlocks` to be available, plus the level immediately before this batch.
     *                          ideally this would be a `Level => List[Voting.BakerRolls]` (i.e. a total function)
     * @param ec needed to compose concurrent operations
     * @return aggregated data
     */
   def aggregateData(db: Database)(
-      proposalsBlocks: Map[Block, Option[ProtocolId]],
-      proposalsBallots: Map[Block, List[Voting.Ballot]],
-      levelsRolls: Map[Int, List[Voting.BakerRolls]]
+      activeProposalsBlocks: Map[Block, Option[ProtocolId]],
+      activeProposalsBallots: Map[Block, List[Voting.Ballot]],
+      rollsByLevel: Map[Int, List[Voting.BakerRolls]]
   )(
       implicit ec: ExecutionContext
   ): Future[List[GovernanceAggregate]] = {
@@ -138,7 +138,7 @@ object TezosGovernanceOperations extends LazyLogging {
     logger.info("Searching for governance data in voting period...")
 
     //find blocks for a specific proposal under scrutiny, relevant for counting ballots
-    val votingBlocks = proposalsBlocks.collect { case (block, Some(protocol)) => block }.toList
+    val votingBlocks = activeProposalsBlocks.collect { case (block, Some(protocol)) => block }.toList
 
     logger.info(
       "There are {} blocks related to testing vote and proposal vote periods.",
@@ -146,7 +146,7 @@ object TezosGovernanceOperations extends LazyLogging {
     )
 
     //main algorithm
-    val cycles = proposalsBlocks.keys
+    val cycles = activeProposalsBlocks.keys
       .filter(votingPeriodIn(ballotPeriods))
       .map(_.data.metadata)
       .collect {
@@ -165,14 +165,14 @@ object TezosGovernanceOperations extends LazyLogging {
     val levelBallotCountsResult =
       Future
         .traverse(
-          proposalsBlocks.keys.filter(votingPeriodIn(ballotPeriods))
+          activeProposalsBlocks.keys.filter(votingPeriodIn(ballotPeriods))
         ) { block =>
           db.run(countBallotsPerLevel(block)).map(block -> BallotsPerLevel(_))
         }
         .map(_.toMap)
 
     val proposalCountsResult = Future.traverse(
-      proposalsBlocks.keys.filter(votingPeriodIs(VotingPeriod.proposal))
+      activeProposalsBlocks.keys.filter(votingPeriodIs(VotingPeriod.proposal))
     ) { block =>
       db.run(proposalHashesPerCycle(block).map(block -> _))
     }
@@ -183,9 +183,9 @@ object TezosGovernanceOperations extends LazyLogging {
       proposalCounts <- proposalCountsResult
     } yield
       fillAggregates(
-        proposalsBlocks,
-        levelsRolls,
-        proposalsBallots,
+        activeProposalsBlocks,
+        rollsByLevel,
+        activeProposalsBallots,
         levelCountsMap,
         cycleCountsMap,
         proposalCounts.toMap
@@ -197,27 +197,27 @@ object TezosGovernanceOperations extends LazyLogging {
    */
   private def fillAggregates(
       proposalsBlocks: Map[Block, Option[ProtocolId]],
-      listingsPerLevel: Map[Int, List[Voting.BakerRolls]],
+      rollsByLevel: Map[Int, List[Voting.BakerRolls]],
       ballots: Map[Block, List[Voting.Ballot]],
       ballotCountsPerLevel: Map[Block, BallotsPerLevel],
       ballotCountsPerCycle: Map[Int, BallotsPerCycle],
-      proposalProtocolCounts: Map[Block, Map[ProtocolId, Int]] //comes from individual operations on the block
+      proposalCountsByBlock: Map[Block, Map[ProtocolId, Int]] //comes from individual operations on the block
   ): List[GovernanceAggregate] =
     proposalsBlocks.toList.flatMap {
       case (block, currentProposal) =>
-        val listing = listingsPerLevel.getOrElse(block.data.header.level, List.empty)
-        val prevListings = listingsPerLevel.getOrElse(block.data.header.level - 1, List.empty)
-        val listingByBlock = listing.diff(prevListings)
+        val rollsAtLevel = rollsByLevel.getOrElse(block.data.header.level, List.empty)
+        val rollsAtPreviousLevel = rollsByLevel.getOrElse(block.data.header.level - 1, List.empty)
+        val rollsForBlockLevel = rollsAtLevel.diff(rollsAtPreviousLevel)
         val ballot = ballots.getOrElse(block, List.empty)
         val ballotCountPerCycle = block.data.metadata match {
           case md: BlockHeaderMetadata => ballotCountsPerCycle.get(md.level.cycle).map(_.counts)
           case GenesisMetadata => None
         }
         val ballotCountPerLevel = ballotCountsPerLevel.get(block).map(_.counts)
-        val proposalCounts = proposalProtocolCounts.getOrElse(block, Map.empty).toList
+        val proposalCounts = proposalCountsByBlock.getOrElse(block, Map.empty).toList
 
-        val allRolls = countRolls(listing, ballot)
-        val levelRolls = countRolls(listingByBlock, ballot)
+        val allRolls = countRolls(rollsAtLevel, ballot)
+        val levelRolls = countRolls(rollsForBlockLevel, ballot)
 
         /* Here we collect a row for the block being considered
          * to get voting data for the periods with a specific proposal

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosGovernanceOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosGovernanceOperations.scala
@@ -81,16 +81,12 @@ object TezosGovernanceOperations extends LazyLogging {
      */
     for {
       activeProposals <- nodeOperator.getActiveProposals(blocksInActiveVotingPeriod)
-      proposalsMap = activeProposals.collect { case (hash, Some(protocol)) => hash -> protocol }.toMap
-      //collect only those blocks that have a current voting proposal
-      activeProposalsBlocks = blocks.collect {
-        case block if (proposalsMap.contains(block.data.hash)) =>
-          //we know for sure that the value's there: the fallback value is actually never called
-          block -> proposalsMap.getOrElse(block.data.hash, ProtocolId(""))
-      }.toMap
-      ballots <- nodeOperator.getVotes(activeProposalsBlocks.keys.toList)
+      proposalsMap = activeProposals.toMap
+      //pair blocks and proposals
+      blocksAndProposals = blocks.map(block => block -> proposalsMap.get(block.data.hash).flatten).toMap
+      ballots <- nodeOperator.getVotes(blocksAndProposals.keys.toList)
       aggregates <- aggregateData(db)(
-        activeProposalsBlocks,
+        blocksAndProposals,
         ballots.toMap,
         bakerRollsByLevel
       )
@@ -118,8 +114,8 @@ object TezosGovernanceOperations extends LazyLogging {
     * @param ec needed to compose concurrent operations
     * @return aggregated data
     */
-  private def aggregateData(db: Database)(
-      proposalsBlocks: Map[Block, ProtocolId],
+  def aggregateData(db: Database)(
+      proposalsBlocks: Map[Block, Option[ProtocolId]],
       proposalsBallots: Map[Block, List[Voting.Ballot]],
       levelsRolls: Map[Int, List[Voting.BakerRolls]]
   )(
@@ -134,12 +130,20 @@ object TezosGovernanceOperations extends LazyLogging {
       TezosDatabaseOperations.getBallotOperationsForCycle(cycle)
 
     // as stated, this is a runtime failure if the block contains the wrong metadata
-    def proposalOperationsHashes(block: Block) = block.data.metadata match {
+    def proposalHashesPerCycle(block: Block) = block.data.metadata match {
       case BlockHeaderMetadata(_, _, _, _, _, level) =>
         TezosDatabaseOperations.getProposalOperationHashesByCycle(level.cycle)
     }
 
     logger.info("Searching for governance data in voting period...")
+
+    //find blocks for a specific proposal under scrutiny, relevant for counting ballots
+    val votingBlocks = proposalsBlocks.collect { case (block, Some(protocol)) => block }.toList
+
+    logger.info(
+      "There are {} blocks related to some voting - excluding proposals.",
+      if (votingBlocks.nonEmpty) String.valueOf(votingBlocks.size) else "no"
+    )
 
     //main algorithm
     val cycles = proposalsBlocks.keys
@@ -170,7 +174,7 @@ object TezosGovernanceOperations extends LazyLogging {
     val proposalCountsResult = Future.traverse(
       proposalsBlocks.keys.filter(votingPeriodIs(VotingPeriod.proposal))
     ) { block =>
-      db.run(proposalOperationsHashes(block).map(block -> _))
+      db.run(proposalHashesPerCycle(block).map(block -> _))
     }
 
     for {
@@ -192,7 +196,7 @@ object TezosGovernanceOperations extends LazyLogging {
    * extract the numbers returning a collector object.
    */
   private def fillAggregates(
-      proposalsBlocks: Map[Block, ProtocolId],
+      proposalsBlocks: Map[Block, Option[ProtocolId]],
       listingsPerLevel: Map[Int, List[Voting.BakerRolls]],
       ballots: Map[Block, List[Voting.Ballot]],
       ballotCountsPerLevel: Map[Block, BallotsPerLevel],
@@ -200,7 +204,7 @@ object TezosGovernanceOperations extends LazyLogging {
       proposalProtocolCounts: Map[Block, Map[ProtocolId, Int]] //comes from individual operations on the block
   ): List[GovernanceAggregate] =
     proposalsBlocks.toList.flatMap {
-      case (block, proposal) =>
+      case (block, currentProposal) =>
         val listing = listingsPerLevel.getOrElse(block.data.header.level, List.empty)
         val prevListings = listingsPerLevel.getOrElse(block.data.header.level - 1, List.empty)
         val listingByBlock = listing.diff(prevListings)
@@ -229,17 +233,26 @@ object TezosGovernanceOperations extends LazyLogging {
          */
         block.data.metadata match {
           case metadata: BlockHeaderMetadata =>
-            val activeProposalAggregate = GovernanceAggregate(
-              block.data.hash,
-              metadata,
-              Some(proposal),
-              allRolls,
-              levelRolls,
-              ballotCountPerCycle,
-              ballotCountPerLevel
+            val activeProposalAggregate = currentProposal.map(
+              proposal =>
+                GovernanceAggregate(
+                  block.data.hash,
+                  metadata,
+                  Some(proposal),
+                  allRolls,
+                  levelRolls,
+                  ballotCountPerCycle,
+                  ballotCountPerLevel
+                )
             )
             val proposalOperationsAggregates =
-              proposalCounts.map { //these come from all individual proposal operations during the proposal period
+              proposalCounts //these come from all individual proposal operations during the proposal period
+              .filterNot {
+                /* this should never be the case: the proposal currently under evaluation
+                 * should not be proposed in operations of the same block
+                 */
+                case (proposal, _) => currentProposal.exists(_ == proposal)
+              }.map {
                 case (proposalProtocol, count) =>
                   GovernanceAggregate(
                     block.data.hash,
@@ -251,7 +264,7 @@ object TezosGovernanceOperations extends LazyLogging {
                     ballotCountPerLevel
                   )
               }
-            activeProposalAggregate :: proposalOperationsAggregates
+            activeProposalAggregate.toList ::: proposalOperationsAggregates
           case GenesisMetadata =>
             //case handled to satisfy the compiler, should never run by design
             List.empty[GovernanceAggregate]

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosGovernanceOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosGovernanceOperations.scala
@@ -141,7 +141,7 @@ object TezosGovernanceOperations extends LazyLogging {
     val votingBlocks = proposalsBlocks.collect { case (block, Some(protocol)) => block }.toList
 
     logger.info(
-      "There are {} blocks related to some voting - excluding proposals.",
+      "There are {} blocks related to testing vote and proposal vote periods.",
       if (votingBlocks.nonEmpty) String.valueOf(votingBlocks.size) else "no"
     )
 

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosGovernanceOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosGovernanceOperations.scala
@@ -54,6 +54,7 @@ object TezosGovernanceOperations extends LazyLogging {
     *
     * @param db the reference database
     * @param nodeOperator the operator to get information from the remore tezos node
+    * @param bakerRollsByBlock blocks of interest, with any rolls data available
     * @return the computed aggregate data
     */
   def extractGovernanceAggregations(

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosIndexer.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosIndexer.scala
@@ -175,12 +175,12 @@ class TezosIndexer(
           nodeOperator.getBatchBakingRightsByLevels(partition.toList).flatMap { bakingRightsResult =>
             val brResults = bakingRightsResult.values.flatten
             berLogger.info(s"Got ${brResults.size} baking rights")
-            db.run(TezosDb.writeBakingRights(brResults.toList))
+            db.run(TezosDb.insertBakingRights(brResults.toList))
           }
           nodeOperator.getBatchEndorsingRightsByLevel(partition.toList).flatMap { endorsingRightsResult =>
             val erResults = endorsingRightsResult.values.flatten
             berLogger.info(s"Got ${erResults.size} endorsing rights")
-            db.run(TezosDb.writeEndorsingRights(erResults.toList))
+            db.run(TezosDb.insertEndorsingRights(erResults.toList))
           }
         }
         .runWith(Sink.ignore)

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosIndexer.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosIndexer.scala
@@ -175,12 +175,12 @@ class TezosIndexer(
           nodeOperator.getBatchBakingRightsByLevels(partition.toList).flatMap { bakingRightsResult =>
             val brResults = bakingRightsResult.values.flatten
             berLogger.info(s"Got ${brResults.size} baking rights")
-            db.run(TezosDb.insertBakingRights(brResults.toList))
+            db.run(TezosDb.writeBakingRights(brResults.toList))
           }
           nodeOperator.getBatchEndorsingRightsByLevel(partition.toList).flatMap { endorsingRightsResult =>
             val erResults = endorsingRightsResult.values.flatten
             berLogger.info(s"Got ${erResults.size} endorsing rights")
-            db.run(TezosDb.insertEndorsingRights(erResults.toList))
+            db.run(TezosDb.writeEndorsingRights(erResults.toList))
           }
         }
         .runWith(Sink.ignore)


### PR DESCRIPTION
Fixes #843 and #844 

The code to extract governance rows now takes all blocks into considerations, and differentiates between those that have a current proposal or not.
Hence we now have also proposals data that was not collected before.

Use stored data for rolls from the previous batch to account for the missing entry to compute per-level rolls counts.