### PR TITLE
843 - Correct rolls counts for governance [release merge] take 2

### DIFF
--- a/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
+++ b/src/main/scala/tech/cryptonomic/conseil/tezos/TezosDatabaseOperations.scala
@@ -521,6 +521,9 @@ object TezosDatabaseOperations extends LazyLogging {
     Tables.EndorsingRights ++= endorsingRights.flatMap(_.convertToA[List, Tables.EndorsingRightsRow])
   }
 
+  def getGovernancePerLevel(level: Int): DBIO[Seq[GovernanceRow]] =
+    Tables.Governance.filter(_.level === level).result
+
   def insertGovernance(governance: List[GovernanceRow]): DBIO[Option[Int]] = {
     logger.info("Writing {} governance rows into database...", governance.size)
     Tables.Governance ++= governance


### PR DESCRIPTION
Fixes #843 

Use stored data for rolls from the previous batch to account for  the missing entry to compute per-level rolls counts.