### PR TITLE
843 - Correct rolls counts from governance

### DIFF
--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseConversions.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseConversions.scala
@@ -13,7 +13,7 @@ import tech.cryptonomic.conseil.common.tezos.TezosTypes.Fee.AverageFees
 import tech.cryptonomic.conseil.common.tezos.TezosTypes.Voting.Vote
 import tech.cryptonomic.conseil.common.tezos.TezosTypes.{BakingRights, EndorsingRights, FetchRights, _}
 import tech.cryptonomic.conseil.indexer.tezos.michelson.contracts.TNSContract
-import tech.cryptonomic.conseil.common.tezos.{Tables, TezosOptics, TezosTypes}
+import tech.cryptonomic.conseil.common.tezos.{Tables, TezosOptics}
 import tech.cryptonomic.conseil.common.util.Conversion
 
 import scala.util.Try
@@ -881,19 +881,6 @@ private[tezos] object TezosDatabaseConversions extends LazyLogging {
 
       }
 
-      def countRolls(listings: List[Voting.BakerRolls], ballots: List[Voting.Ballot]): (Int, Int, Int) =
-        ballots.foldLeft((0, 0, 0)) {
-          case ((yays, nays, passes), votingBallot) =>
-            val rolls = listings.find(_.pkh == votingBallot.pkh).map(_.rolls).getOrElse(0)
-            votingBallot.ballot match {
-              case Vote("yay") => (yays + rolls, nays, passes)
-              case Vote("nay") => (yays, nays + rolls, passes)
-              case Vote("pass") => (yays, nays, passes + rolls)
-              case Vote(notSupported) =>
-                logger.error("Not supported vote type {}", notSupported)
-                (yays, nays, passes)
-            }
-        }
     }
 
   implicit val tnsNameRecordToRow =

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
@@ -523,8 +523,16 @@ object TezosDatabaseOperations extends LazyLogging {
   ): DBIO[Seq[Tables.EndorsingRightsRow]] =
     Tables.EndorsingRights.filter(_.level === blockLevel).result
 
-  /** Stores the governance statistic aggregates in the database
-    *
+  /**
+    * Fetches all governance entries for a given block level
+    * @param level to identify the relevant block
+    * @return the governance data
+    */
+  def getGovernanceForLevel(level: Int): DBIO[Seq[GovernanceRow]] =
+    Tables.Governance.filter(_.level === level).result
+
+  /**
+    * Stores the governance statistic aggregates in the database
     * @param governance aggregates
     * @return the number of rows added, if available from the driver
     */

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosGovernanceOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosGovernanceOperations.scala
@@ -62,10 +62,10 @@ object TezosGovernanceOperations extends LazyLogging {
       * @return the "zero-min" difference of the counts, element by element
       */
     def subtract(subtrahend: VoteRollsCounts, minuend: VoteRollsCounts): VoteRollsCounts = (subtrahend, minuend) match {
-      case (VoteRollsCounts(i1, j1, k1), VoteRollsCounts(i2, j2, k2)) =>
+      case (VoteRollsCounts(y1, n1, p1), VoteRollsCounts(y2, n2, p2)) =>
         //we use the sum algebra for Ints to sum with the inverse of the minuend values
-        val (i, j, k) = (i1, j1, k1) |+| ((i2, j2, k2).inverse())
-        VoteRollsCounts(max(i, 0), max(j, 0), max(k, 0))
+        val (y, n, p) = (y1, n1, p1) |+| ((y2, n2, p2).inverse())
+        VoteRollsCounts(max(y, 0), max(n, 0), max(p, 0))
     }
 
   }


### PR DESCRIPTION
fixes #843 for the main working branch

**[NOTE this PR depends on a previous one]**
We should first merge #845 and then rebase to master!

Use stored data for rolls from the previous batch to account for the missing entry to compute per-level rolls counts.