### PR TITLE
Track in comments the source of each implicit data fetcher

### DIFF
--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
@@ -686,11 +686,11 @@ object TezosDatabaseOperations extends LazyLogging {
     * @return inactive baker accounts
     * */
   def getInactiveBakersFromAccounts(
-      activeBakers: List[String]
+      activeBakers: List[AccountId]
   )(implicit ec: ExecutionContext): DBIO[List[Tables.AccountsRow]] =
     Tables.Accounts
       .filter(_.isBaker === true)
-      .filterNot(_.accountId inSet activeBakers)
+      .filterNot(_.accountId inSet activeBakers.map(_.id))
       .result
       .map(_.toList)
 

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosNodeFetchers.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosNodeFetchers.scala
@@ -752,9 +752,11 @@ trait AccountsDataFetchers {
   }
 
   implicit val activeDelegateFetcher = new FutureFetcher {
+    import TezosJsonDecoders.Circe._
+
     type Encoded = String
     type In = BlockHash
-    type Out = List[String]
+    type Out = List[AccountId]
 
     private val makeUrl = (blockHash: BlockHash) => s"blocks/${blockHash.value}/context/delegates?active"
 


### PR DESCRIPTION
Documentation: now we have explicit hints - as code comments - on which specific DataFetcher is being used on the node operator when calling `fetch` to get node data.
There are comment at all call sites.

Additional refactor:
Add a typed wrapper to the output of active bakers fetcher, to have a specific implicit resolution and avoid any future conflict.
The fetcher returned strings for a block hash: using such a common type like string for implicit search is generally avoided.
Now the returned types are AccountIds which are more semantically relevant at the domain level too.