### PR TITLE
Improve logging and do not pre-cache while all networks are disabled

### DIFF
--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/ConseilApi.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/ConseilApi.scala
@@ -201,11 +201,13 @@ class ConseilApi(config: CombinedConfiguration)(implicit system: ActorSystem)
         case Success(_) => logger.info("Pre-caching attributes successful!")
       }
     } else {
-      throw NoNetworkEnabledError("""
-        |Pre-catching could not be done, because all of the block-chains are disabled!
-        | It means that application is NOT configured properly.
-        | Please double check configuration file and start API again.
-        |""".stripMargin)
+      throw NoNetworkEnabledError(
+        """|Pre-caching can't be done, because there is no enabled block-chain defined.
+           | This probably means the application is NOT properly configured.
+           | The API needs a platform section to be defined, which lists at least one enabled chain and network.
+           | Please double-check the configuration file and start the API service again.
+           |""".stripMargin
+      )
     }
   }
 

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/ConseilApi.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/ConseilApi.scala
@@ -155,6 +155,7 @@ class ConseilApi(config: CombinedConfiguration)(implicit system: ActorSystem)
 
     /**
       * Map, that contains list of available `ApiDataRoutes` accessed by platform name.
+      *
       * @see `tech.cryptonomic.conseil.common.config.Platforms` to get list of possible platforms.
       */
     lazy val cachedDataEndpoints: Map[String, ApiDataRoutes] =
@@ -183,15 +184,17 @@ class ConseilApi(config: CombinedConfiguration)(implicit system: ActorSystem)
       network <- transformation.overrideNetworks(platform.path, config.platforms.getNetworks(platform.name))
     } yield platform -> network
 
-    cachedDiscoveryOperations.init(visibleNetworks).onComplete {
-      case Failure(exception) => logger.error("Pre-caching metadata failed", exception)
-      case Success(_) => logger.info("Pre-caching successful!")
-    }
+    if (visibleNetworks.nonEmpty) { // At least one blockchain is enabled
+      cachedDiscoveryOperations.init(visibleNetworks).onComplete {
+        case Failure(exception) => logger.error("Pre-caching metadata failed", exception)
+        case Success(_) => logger.info("Pre-caching successful!")
+      }
 
-    cachedDiscoveryOperations.initAttributesCache(visibleNetworks).onComplete {
-      case Failure(exception) => logger.error("Pre-caching attributes failed", exception)
-      case Success(_) => logger.info("Pre-caching attributes successful!")
-    }
+      cachedDiscoveryOperations.initAttributesCache(visibleNetworks).onComplete {
+        case Failure(exception) => logger.error("Pre-caching attributes failed", exception)
+        case Success(_) => logger.info("Pre-caching attributes successful!")
+      }
+    } else logger.warn("Pre-catching could not be done, because all of the block-chains are disabled!")
   }
 
 }

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/ConseilApi.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/ConseilApi.scala
@@ -194,7 +194,15 @@ class ConseilApi(config: CombinedConfiguration)(implicit system: ActorSystem)
         case Failure(exception) => logger.error("Pre-caching attributes failed", exception)
         case Success(_) => logger.info("Pre-caching attributes successful!")
       }
-    } else logger.warn("Pre-catching could not be done, because all of the block-chains are disabled!")
+    } else {
+      logger.error(
+        """
+          |Pre-catching could not be done, because all of the block-chains are disabled! 
+          | Application is probably misconfigured. Please double check configuration files and start application again.
+          |""".stripMargin
+      )
+      sys.exit(1)
+    }
   }
 
 }

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/ConseilMainOutput.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/ConseilMainOutput.scala
@@ -56,7 +56,8 @@ trait ConseilMainOutput {
       .groupBy(_.platform)
       .map {
         case (platform, configuration) =>
-          val networks = configuration.map(_.network).mkString("\n  - ", "\n  - ", "\n")
+          val networks =
+            configuration.map(c => s"${c.network} (enabled: ${c.enabled})").mkString("\n  - ", "\n  - ", "\n")
           s"  Platform: ${platform.name}$networks"
       }
       .mkString("\n")

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/ConseilMainOutput.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/ConseilMainOutput.scala
@@ -3,7 +3,7 @@ package tech.cryptonomic.conseil.api
 import com.typesafe.scalalogging.Logger
 import tech.cryptonomic.conseil.BuildInfo
 import tech.cryptonomic.conseil.api.config.ConseilConfiguration
-import tech.cryptonomic.conseil.common.config.Platforms.PlatformsConfiguration
+import tech.cryptonomic.conseil.common.config.Platforms.{PlatformConfiguration, PlatformsConfiguration}
 import tech.cryptonomic.conseil.common.io.MainOutputs._
 
 /** Defines what to print when starting Conseil */
@@ -56,10 +56,16 @@ trait ConseilMainOutput {
       .groupBy(_.platform)
       .map {
         case (platform, configuration) =>
-          val networks =
-            configuration.map(c => s"${c.network} (enabled: ${c.enabled})").mkString("\n  - ", "\n  - ", "\n")
+          val networks = showAvailableNetworks(configuration)
           s"  Platform: ${platform.name}$networks"
       }
       .mkString("\n")
+
+  /* prepare output to display existing networks */
+  private def showAvailableNetworks(configuration: List[PlatformConfiguration]): String =
+    configuration.map { c =>
+      val disabled = if (!c.enabled) " (disabled)" else ""
+      s"${c.network}$disabled"
+    }.mkString("\n  - ", "\n  - ", "\n")
 
 }

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/util/RetryStrategy.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/util/RetryStrategy.scala
@@ -1,0 +1,17 @@
+package tech.cryptonomic.conseil.api.util
+
+import tech.cryptonomic.conseil.api.ConseilApi.NoNetworkEnabledError
+
+object RetryStrategy {
+
+  /** Method which defines custom strategy, when retry mechanism should not continue
+    *
+    * Currently retry stops when:
+    * - there is no network enabled in the configuration
+    * */
+  val retryGiveUpStrategy: Throwable => Boolean = {
+    case _: NoNetworkEnabledError => true
+    case _ => false
+  }
+
+}


### PR DESCRIPTION
In a situation, when all of the networks are disabled (and by default they are), application did not initialized cache properly, which caused following stack trace to be displayed:
```
10:43:05.607 [conseil-system-akka.http.dispatcher-7] ERROR         t.cryptonomic.conseil.api.ConseilApi - Pre-caching metadata failed
java.lang.UnsupportedOperationException: empty.reduceLeft
	at scala.collection.LinearSeqOptimized.reduceLeft(LinearSeqOptimized.scala:139)
	at scala.collection.LinearSeqOptimized.reduceLeft$(LinearSeqOptimized.scala:138)
  | => aat scala.collection.immutable.List.reduceLeft(List.scala:89)
	at scala.collection.TraversableOnce.reduce(TraversableOnce.scala:213)
	at scala.collection.TraversableOnce.reduce$(TraversableOnce.scala:213)
	at scala.collection.AbstractTraversable.reduce(Traversable.scala:108)
	at tech.cryptonomic.conseil.api.routes.platform.discovery.GenericPlatformDiscoveryOperations.$anonfun$preCacheEntities$2(GenericPlatformDiscoveryOperations.scala:211)
```

Additionally, in some cases it could fall into infinite loop, causing computer to be not responding.

This pull-requests adds additional logging information as well as prevents caching from being done, when there is no network enabled in configuration.