### PR TITLE
Update tests to get rid of deprecation warnings

### DIFF
--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/config/ConseilAppConfigTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/config/ConseilAppConfigTest.scala
@@ -1,7 +1,9 @@
 package tech.cryptonomic.conseil.api.config
 
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{EitherValues, Matchers, OptionValues, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{EitherValues, OptionValues}
 import pureconfig.error.ConvertFailure
 import pureconfig.generic.auto._
 import tech.cryptonomic.conseil.api.config.ConseilAppConfig._
@@ -10,7 +12,7 @@ import tech.cryptonomic.conseil.common.config.Platforms
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class ConseilAppConfigTest extends WordSpec with Matchers with EitherValues with OptionValues {
+class ConseilAppConfigTest extends AnyWordSpec with Matchers with EitherValues with OptionValues {
 
   "ConseilAppConfig" should {
       "extract the correct configuration list for Tezos platform's networks using default readers" in {

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/metadata/MetadataServiceTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/metadata/MetadataServiceTest.scala
@@ -3,17 +3,12 @@ package tech.cryptonomic.conseil.api.metadata
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Seconds, Span}
-import org.scalatest.{BeforeAndAfterEach, Matchers, OneInstancePerTest, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{BeforeAndAfterEach, OneInstancePerTest}
 import tech.cryptonomic.conseil.api.routes.platform.discovery.TestPlatformDiscoveryOperations
-import tech.cryptonomic.conseil.common.config.Platforms.{
-  BitcoinBatchFetchConfiguration,
-  BitcoinConfiguration,
-  BitcoinNodeConfiguration,
-  PlatformsConfiguration,
-  TezosConfiguration,
-  TezosNodeConfiguration
-}
+import tech.cryptonomic.conseil.common.config.Platforms.{BitcoinBatchFetchConfiguration, BitcoinConfiguration, BitcoinNodeConfiguration, PlatformsConfiguration, TezosConfiguration, TezosNodeConfiguration}
 import tech.cryptonomic.conseil.common.config.Types.PlatformName
 import tech.cryptonomic.conseil.common.config._
 import tech.cryptonomic.conseil.common.generic.chain.PlatformDiscoveryTypes.DataType.{Hash, Int}
@@ -22,7 +17,7 @@ import tech.cryptonomic.conseil.common.generic.chain.PlatformDiscoveryTypes.{Att
 import tech.cryptonomic.conseil.common.metadata._
 
 class MetadataServiceTest
-    extends WordSpec
+    extends AnyWordSpec
     with Matchers
     with ScalatestRouteTest
     with MockFactory

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/info/AppInfoRouteTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/info/AppInfoRouteTest.scala
@@ -3,10 +3,11 @@ package tech.cryptonomic.conseil.api.routes.info
 import akka.http.scaladsl.model.{ContentTypes, StatusCodes}
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import tech.cryptonomic.conseil.common.util.JsonUtil._
 
-class AppInfoRouteTest extends WordSpec with Matchers with ScalatestRouteTest {
+class AppInfoRouteTest extends AnyWordSpec with Matchers with ScalatestRouteTest {
 
   "The application info route" should {
 

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/openapi/CsvConversionsTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/openapi/CsvConversionsTest.scala
@@ -1,9 +1,10 @@
 package tech.cryptonomic.conseil.api.routes.openapi
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.QueryResponse
 
-class CsvConversionsTest extends WordSpec with Matchers {
+class CsvConversionsTest extends AnyWordSpec with Matchers {
 
   import tech.cryptonomic.conseil.common.util.Conversion.Syntax._
   import tech.cryptonomic.conseil.api.routes.platform.data.CsvConversions._

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/SanitizerTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/SanitizerTest.scala
@@ -1,8 +1,9 @@
 package tech.cryptonomic.conseil.api.routes.platform
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class SanitizerTest extends WordSpec with Matchers {
+class SanitizerTest extends AnyWordSpec with Matchers {
 
   "Sanitizer" should {
       "sanitizeForSql alphanumeric string" in {

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataHelpersTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataHelpersTest.scala
@@ -3,10 +3,11 @@ package tech.cryptonomic.conseil.api.routes.platform.data
 import java.time.Instant
 
 import io.circe.{Encoder, Json}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.{OutputType, QueryResponse, QueryResponseWithOutput}
 
-class ApiDataHelpersTest extends WordSpec with Matchers {
+class ApiDataHelpersTest extends AnyWordSpec with Matchers {
 
   private case class TestEntity(value: String)
 

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataOperationsTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataOperationsTest.scala
@@ -1,9 +1,10 @@
 package tech.cryptonomic.conseil.api.routes.platform.data
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.{OperationType, Predicate}
 
-class ApiDataOperationsTest extends WordSpec with Matchers {
+class ApiDataOperationsTest extends AnyWordSpec with Matchers {
 
   "ApiDataOperations" should {
       "sanitizeFields" in {

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataTypesTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataTypesTest.scala
@@ -3,14 +3,12 @@ package tech.cryptonomic.conseil.api.routes.platform.data
 import java.sql.Timestamp
 
 import org.scalamock.scalatest.MockFactory
+import org.scalatest.{BeforeAndAfterEach, EitherValues, OneInstancePerTest}
 import org.scalatest.LoneElement._
-import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
-import tech.cryptonomic.conseil.api.metadata.{
-  AttributeValuesCacheConfiguration,
-  MetadataService,
-  TransparentUnitTransformation
-}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import tech.cryptonomic.conseil.api.metadata.{AttributeValuesCacheConfiguration, MetadataService, TransparentUnitTransformation}
 import tech.cryptonomic.conseil.api.routes.platform.data.ApiDataTypes.ApiQuery
 import tech.cryptonomic.conseil.api.routes.platform.discovery.TestPlatformDiscoveryOperations
 import tech.cryptonomic.conseil.common.config.MetadataConfiguration
@@ -22,7 +20,7 @@ import tech.cryptonomic.conseil.common.metadata._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class ApiDataTypesTest
-    extends WordSpec
+    extends AnyWordSpec
     with Matchers
     with ScalaFutures
     with EitherValues

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinDataQueriesTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinDataQueriesTest.scala
@@ -5,8 +5,8 @@ import java.sql.Timestamp
 import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.OptionValues
-import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import slick.jdbc.PostgresProfile.api._
 import tech.cryptonomic.conseil.api.BitcoinInMemoryDatabaseSetup
 import tech.cryptonomic.conseil.api.routes.platform.data.ApiDataOperations

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinDataRoutesTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinDataRoutesTest.scala
@@ -3,21 +3,23 @@ package tech.cryptonomic.conseil.api.routes.platform.data.bitcoin
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalamock.scalatest.MockFactory
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import tech.cryptonomic.conseil.api.metadata.{
   AttributeValuesCacheConfiguration,
   MetadataService,
   TransparentUnitTransformation
 }
 import tech.cryptonomic.conseil.api.routes.platform.discovery.TestPlatformDiscoveryOperations
+import tech.cryptonomic.conseil.common.config.MetadataConfiguration
 import tech.cryptonomic.conseil.common.config.Platforms.{
   BitcoinBatchFetchConfiguration,
   BitcoinConfiguration,
   BitcoinNodeConfiguration,
   PlatformsConfiguration
 }
-import tech.cryptonomic.conseil.common.config.MetadataConfiguration
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.{Query, QueryResponse}
 import tech.cryptonomic.conseil.common.generic.chain.PlatformDiscoveryTypes.{Attribute, DataType, Entity, KeyType}
 import tech.cryptonomic.conseil.common.metadata.{EntityPath, NetworkPath, PlatformPath}
@@ -25,7 +27,7 @@ import tech.cryptonomic.conseil.common.metadata.{EntityPath, NetworkPath, Platfo
 import scala.concurrent.{ExecutionContext, Future}
 
 class BitcoinDataRoutesTest
-    extends WordSpec
+    extends AnyWordSpec
     with Matchers
     with ScalatestRouteTest
     with ScalaFutures

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataRoutesTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataRoutesTest.scala
@@ -4,12 +4,10 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
-import tech.cryptonomic.conseil.api.metadata.{
-  AttributeValuesCacheConfiguration,
-  MetadataService,
-  TransparentUnitTransformation
-}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import tech.cryptonomic.conseil.api.metadata.{AttributeValuesCacheConfiguration, MetadataService, TransparentUnitTransformation}
 import tech.cryptonomic.conseil.api.routes.platform.discovery.TestPlatformDiscoveryOperations
 import tech.cryptonomic.conseil.common.config.MetadataConfiguration
 import tech.cryptonomic.conseil.common.config.Platforms._
@@ -20,7 +18,7 @@ import tech.cryptonomic.conseil.common.metadata.{EntityPath, NetworkPath, Platfo
 import scala.concurrent.{ExecutionContext, Future}
 
 class TezosDataRoutesTest
-    extends WordSpec
+    extends AnyWordSpec
     with Matchers
     with ScalatestRouteTest
     with ScalaFutures

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/PlatformDiscoveryTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/PlatformDiscoveryTest.scala
@@ -3,13 +3,10 @@ package tech.cryptonomic.conseil.api.routes.platform.discovery
 import akka.http.scaladsl.model.{ContentTypes, StatusCodes}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import tech.cryptonomic.conseil.api.metadata.{AttributeValuesCacheConfiguration, MetadataService, UnitTransformation}
-import tech.cryptonomic.conseil.common.config.Platforms.{
-  PlatformsConfiguration,
-  TezosConfiguration,
-  TezosNodeConfiguration
-}
+import tech.cryptonomic.conseil.common.config.Platforms.{PlatformsConfiguration, TezosConfiguration, TezosNodeConfiguration}
 import tech.cryptonomic.conseil.common.config.Types.PlatformName
 import tech.cryptonomic.conseil.common.config._
 import tech.cryptonomic.conseil.common.generic.chain.PlatformDiscoveryTypes.DataType.Int
@@ -18,7 +15,7 @@ import tech.cryptonomic.conseil.common.generic.chain.PlatformDiscoveryTypes.{Att
 import tech.cryptonomic.conseil.common.metadata.{EntityPath, NetworkPath, PlatformPath}
 import tech.cryptonomic.conseil.common.util.JsonUtil.toListOfMaps
 
-class PlatformDiscoveryTest extends WordSpec with Matchers with ScalatestRouteTest with MockFactory {
+class PlatformDiscoveryTest extends AnyWordSpec with Matchers with ScalatestRouteTest with MockFactory {
 
   "The platform discovery route" should {
 

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/security/SecurityTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/security/SecurityTest.scala
@@ -2,11 +2,12 @@ package tech.cryptonomic.conseil.api.security
 
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Seconds, Span}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
 import tech.cryptonomic.conseil.api.security.Security.SecurityApi
 
-class SecurityTest extends WordSpec with Matchers with ScalatestRouteTest with ScalaFutures {
+class SecurityTest extends AnyWordSpec with Matchers with ScalatestRouteTest with ScalaFutures {
 
   implicit override val patienceConfig = PatienceConfig(timeout = Span(2, Seconds), interval = Span(20, Millis))
 

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/sql/DefaultDatabaseOperationsTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/sql/DefaultDatabaseOperationsTest.scala
@@ -4,7 +4,8 @@ import java.sql.Timestamp
 import java.time.LocalDateTime
 
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import slick.jdbc.PostgresProfile.api._
 import tech.cryptonomic.conseil.api.TezosInMemoryDatabaseSetup
 import tech.cryptonomic.conseil.api.sql.DefaultDatabaseOperations._
@@ -17,7 +18,7 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 
 class DefaultDatabaseOperationsTest
-    extends WordSpec
+    extends AnyWordSpec
     with Matchers
     with InMemoryDatabase
     with TezosInMemoryDatabaseSetup

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/util/RetryTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/util/RetryTest.scala
@@ -12,17 +12,18 @@ package tech.cryptonomic.conseil.api.util
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 import tech.cryptonomic.conseil.api.util.Retry._
-import org.scalatest.FlatSpec
 import org.scalatest.concurrent.ScalaFutures
 import org.scalamock.scalatest.MockFactory
+
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.{fromNow, Deadline, DurationLong}
+import scala.concurrent.duration.{Deadline, DurationLong, fromNow}
 import scala.concurrent.Future
 import org.scalatest.time.{Seconds, Span}
-import org.scalatest.Matchers
 import org.scalamock.function.StubFunction1
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class RetryTest extends FlatSpec with Matchers with MockFactory with ScalaFutures {
+class RetryTest extends AnyFlatSpec with Matchers with MockFactory with ScalaFutures {
 
   implicit override val patienceConfig = PatienceConfig(timeout = Span(4, Seconds))
   private val waitAtMost: Span = patienceConfig.timeout

--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/bitcoin/BitcoinDbViewsTest.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/bitcoin/BitcoinDbViewsTest.scala
@@ -1,12 +1,10 @@
 package tech.cryptonomic.conseil.common.bitcoin
 
 import scala.concurrent.ExecutionContext
-
 import cats.effect._
-import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import slick.jdbc.PostgresProfile.api._
-
 import tech.cryptonomic.conseil.common.testkit.InMemoryDatabase
 
 class BitcoinDbViewsTest

--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/bitcoin/BitcoinPersistenceTest.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/bitcoin/BitcoinPersistenceTest.scala
@@ -1,17 +1,16 @@
 package tech.cryptonomic.conseil.common.bitcoin
 
 import scala.concurrent.ExecutionContext
-
 import cats.effect._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import slick.jdbc.PostgresProfile.api._
-
 import tech.cryptonomic.conseil.common.testkit.InMemoryDatabase
 import tech.cryptonomic.conseil.common.util.Conversion.Syntax._
 import tech.cryptonomic.conseil.common.bitcoin.BitcoinPersistence._
 
 class BitcoinPersistenceTest
-    extends WordSpec
+    extends AnyWordSpec
     with Matchers
     with InMemoryDatabase
     with BitcoinInMemoryDatabaseSetup

--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/bitcoin/rpc/BitcoinRpcClientTest.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/bitcoin/rpc/BitcoinRpcClientTest.scala
@@ -1,13 +1,12 @@
 package tech.cryptonomic.conseil.common.bitcoin.rpc
 
 import scala.concurrent.ExecutionContext
-
 import cats.effect.{ContextShift, IO}
 import fs2.Stream
-import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
-
-import tech.cryptonomic.conseil.common.bitcoin.{BitcoinFixtures, BitcoinStubs}
+import org.scalatest.wordspec.AnyWordSpec
+import tech.cryptonomic.conseil.common.rpc.RpcClient
+import tech.cryptonomic.conseil.common.bitcoin.BitcoinFixtures
 
 class BitcoinRpcClientTest extends AnyWordSpec with Matchers with BitcoinFixtures with BitcoinStubs {
 

--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/bitcoin/rpc/BitcoinRpcClientTest.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/bitcoin/rpc/BitcoinRpcClientTest.scala
@@ -5,8 +5,7 @@ import cats.effect.{ContextShift, IO}
 import fs2.Stream
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import tech.cryptonomic.conseil.common.rpc.RpcClient
-import tech.cryptonomic.conseil.common.bitcoin.BitcoinFixtures
+import tech.cryptonomic.conseil.common.bitcoin.{BitcoinFixtures, BitcoinStubs}
 
 class BitcoinRpcClientTest extends AnyWordSpec with Matchers with BitcoinFixtures with BitcoinStubs {
 

--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/cache/MetadataCachingTest.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/cache/MetadataCachingTest.scala
@@ -2,13 +2,15 @@ package tech.cryptonomic.conseil.common.cache
 
 import cats.effect._
 import com.rklaehn.radixtree.RadixTree
-import org.scalatest.{Matchers, OneInstancePerTest, OptionValues, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{OneInstancePerTest, OptionValues}
 import tech.cryptonomic.conseil.common.cache.MetadataCaching._
 import tech.cryptonomic.conseil.common.generic.chain.PlatformDiscoveryTypes.{Attribute, DataType, Entity, KeyType}
 
 import scala.concurrent.ExecutionContext
 
-class MetadataCachingTest extends WordSpec with Matchers with OneInstancePerTest with OptionValues {
+class MetadataCachingTest extends AnyWordSpec with Matchers with OneInstancePerTest with OptionValues {
 
   implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 

--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/config/PlatformsTest.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/config/PlatformsTest.scala
@@ -1,17 +1,11 @@
 package tech.cryptonomic.conseil.common.config
 
-import org.scalatest.{Matchers, WordSpec}
-import tech.cryptonomic.conseil.common.config.Platforms.{
-  BitcoinBatchFetchConfiguration,
-  BitcoinConfiguration,
-  BitcoinNodeConfiguration,
-  PlatformsConfiguration,
-  TezosConfiguration,
-  TezosNodeConfiguration
-}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import tech.cryptonomic.conseil.common.config.Platforms.{BitcoinBatchFetchConfiguration, BitcoinConfiguration, BitcoinNodeConfiguration, PlatformsConfiguration, TezosConfiguration, TezosNodeConfiguration}
 import tech.cryptonomic.conseil.common.generic.chain.PlatformDiscoveryTypes
 
-class PlatformsTest extends WordSpec with Matchers {
+class PlatformsTest extends AnyWordSpec with Matchers {
 
   private val configTezosNode = TezosNodeConfiguration("host", 0, "protocol")
   private val configTezos = TezosConfiguration("mainnet", enabled = true, configTezosNode, None)

--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/rpc/RpcClientTest.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/rpc/RpcClientTest.scala
@@ -1,7 +1,6 @@
 package tech.cryptonomic.conseil.common.rpc
 
 import scala.concurrent.ExecutionContext
-
 import cats.effect._
 import org.http4s._
 import org.http4s.client.Client
@@ -9,11 +8,11 @@ import fs2.Stream
 import io.circe.generic.auto._
 import org.http4s.circe.CirceEntityDecoder._
 import org.http4s.circe.CirceEntityEncoder._
-import org.scalatest.{Matchers, WordSpec}
-
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import tech.cryptonomic.conseil.common.rpc.RpcClient._
 
-class RpcClientTest extends WordSpec with Matchers {
+class RpcClientTest extends AnyWordSpec with Matchers {
 
   implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 

--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/tezos/TezosTypesTest.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/tezos/TezosTypesTest.scala
@@ -2,10 +2,12 @@ package tech.cryptonomic.conseil.common.tezos
 
 import java.time.Instant
 
-import org.scalatest.{EitherValues, Matchers, OptionValues, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{EitherValues, OptionValues}
 import tech.cryptonomic.conseil.common.tezos.TezosTypes._
 
-class TezosTypesTest extends WordSpec with Matchers with OptionValues with EitherValues {
+class TezosTypesTest extends AnyWordSpec with Matchers with OptionValues with EitherValues {
 
   val sut = TezosTypes
 

--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/util/CollectionOpsTest.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/util/CollectionOpsTest.scala
@@ -1,9 +1,10 @@
 package tech.cryptonomic.conseil.common.util
 
-import org.scalatest.{Matchers, WordSpec}
 import CollectionOps._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class CollectionOpsTest extends WordSpec with Matchers {
+class CollectionOpsTest extends AnyWordSpec with Matchers {
 
   "Collection operations" should {
 

--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/util/ConfigUtilTest.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/util/ConfigUtilTest.scala
@@ -1,9 +1,11 @@
 package tech.cryptonomic.conseil.common.util
 
-import org.scalatest.{EitherValues, Matchers, OptionValues, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{EitherValues, OptionValues}
 import tech.cryptonomic.conseil.common.tezos.Tables
 
-class ConfigUtilTest extends WordSpec with Matchers with EitherValues with OptionValues {
+class ConfigUtilTest extends AnyWordSpec with Matchers with EitherValues with OptionValues {
 
   "ConfigUtil.Csv" should {
       import kantan.csv.generic._

--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/util/CryptoUtilTest.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/util/CryptoUtilTest.scala
@@ -1,9 +1,10 @@
 package tech.cryptonomic.conseil.common.util
 
-import org.scalatest.{FlatSpec, Matchers}
 import cats.implicits._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CryptoUtilTest extends FlatSpec with Matchers {
+class CryptoUtilTest extends AnyFlatSpec with Matchers {
 
   "CryptoUtil" should "correctly decode and encode a Tezos account ID as bytes" in {
       val accountID = "tz1Z5pFi5Sy99Kcz36XA5WtKW7Z6NVG9LdA4"

--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/util/DatabaseUtilTest.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/util/DatabaseUtilTest.scala
@@ -1,10 +1,11 @@
 package tech.cryptonomic.conseil.common.util
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.Predicate
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.OperationType
 
-class DatabaseUtilTest extends WordSpec with Matchers {
+class DatabaseUtilTest extends AnyWordSpec with Matchers {
 
   "Database utils query builder" should {
       val sut = DatabaseUtil.QueryBuilder

--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/util/JsonUtilTest.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/util/JsonUtilTest.scala
@@ -1,13 +1,14 @@
 package tech.cryptonomic.conseil.common.util
 
-import org.scalatest.{Matchers, WordSpec}
 import org.scalatest.Inspectors._
 import JsonUtil._
 import com.stephenn.scalatest.jsonassert.JsonMatchers
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 case class TestObject(field: String = "")
 
-class JsonUtilTest extends WordSpec with Matchers with JsonMatchers {
+class JsonUtilTest extends AnyWordSpec with Matchers with JsonMatchers {
 
   "JsonUtil" should {
 

--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/util/MathUtilTest.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/util/MathUtilTest.scala
@@ -1,8 +1,9 @@
 package tech.cryptonomic.conseil.common.util
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class MathUtilTest extends FlatSpec with Matchers {
+class MathUtilTest extends AnyFlatSpec with Matchers {
 
   "MathUtilTest" should "correctly calculate the mean of a sequence" in {
       val dataset = List(1d, 2d, 3d, 4d, 5d, 6d, 7d, 8d, 9d, 10d)

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/bitcoin/BitcoinOperationsTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/bitcoin/BitcoinOperationsTest.scala
@@ -3,14 +3,12 @@ package tech.cryptonomic.conseil.indexer.bitcoin
 import java.sql.Timestamp
 
 import scala.concurrent.ExecutionContext
-
 import cats.effect.{ContextShift, IO}
 import fs2.Stream
 import slickeffect.Transactor
-import org.scalatest.wordspec.AnyWordSpec
-import org.scalatest.matchers.should.Matchers
 import org.scalamock.scalatest.MockFactory
-
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import tech.cryptonomic.conseil.common.config.Platforms.BitcoinBatchFetchConfiguration
 import tech.cryptonomic.conseil.common.rpc.RpcClient
 import tech.cryptonomic.conseil.common.bitcoin.{BitcoinPersistence, Tables}

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/config/LorreAppConfigTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/config/LorreAppConfigTest.scala
@@ -1,12 +1,14 @@
 package tech.cryptonomic.conseil.indexer.config
 
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{EitherValues, Matchers, WordSpec}
+import org.scalatest.EitherValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import tech.cryptonomic.conseil.common.config.Platforms.{TezosConfiguration, TezosNodeConfiguration}
 import tech.cryptonomic.conseil.indexer.config.LorreAppConfig.Loaders._
 import tech.cryptonomic.conseil.indexer.config.LorreAppConfig.Natural
 
-class LorreAppConfigTest extends WordSpec with Matchers with EitherValues {
+class LorreAppConfigTest extends AnyWordSpec with Matchers with EitherValues {
 
   "LorreAppConfig.Natural" should {
       "match a valid positive integer string" in {

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseConversionsTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseConversionsTest.scala
@@ -3,15 +3,17 @@ package tech.cryptonomic.conseil.indexer.tezos
 import java.sql.Timestamp
 
 import org.scalatest.Inspectors._
-import org.scalatest.{EitherValues, Matchers, OptionValues, WordSpec}
+import org.scalatest.{EitherValues, OptionValues}
 import tech.cryptonomic.conseil.common.testkit.util.RandomSeed
 import tech.cryptonomic.conseil.common.tezos.TezosTypes._
 import tech.cryptonomic.conseil.common.tezos.Tables
 import TezosDatabaseConversions._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import tech.cryptonomic.conseil.common.util.Conversion.Syntax._
 
 class TezosDatabaseConversionsTest
-    extends WordSpec
+    extends AnyWordSpec
     with Matchers
     with OptionValues
     with EitherValues

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosIndexedDataOperationsTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosIndexedDataOperationsTest.scala
@@ -2,7 +2,9 @@ package tech.cryptonomic.conseil.indexer.tezos
 
 import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.{Matchers, OptionValues, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
 import tech.cryptonomic.conseil.common.testkit.InMemoryDatabase
 import tech.cryptonomic.conseil.common.testkit.util.RandomSeed
 import tech.cryptonomic.conseil.indexer.tezos.michelson.contracts.{TNSContract, TokenContracts}
@@ -11,7 +13,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class TezosIndexedDataOperationsTest
-    extends WordSpec
+    extends AnyWordSpec
     with Matchers
     with InMemoryDatabase
     with TezosInMemoryDatabaseSetup

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosJsonDecodersTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosJsonDecodersTest.scala
@@ -1,12 +1,14 @@
 package tech.cryptonomic.conseil.indexer.tezos
 
 import com.github.ghik.silencer.silent
-import org.scalatest.{EitherValues, Matchers, OptionValues, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{EitherValues, OptionValues}
 import tech.cryptonomic.conseil.common.tezos.TezosTypes._
 import tech.cryptonomic.conseil.common.util.JsonUtil.adaptManagerPubkeyField
 
 @silent("local val derivationConf")
-class TezosJsonDecodersTest extends WordSpec with Matchers with EitherValues with OptionValues {
+class TezosJsonDecodersTest extends AnyWordSpec with Matchers with EitherValues with OptionValues {
 
   import TezosJsonDecoders.Circe.Accounts._
   import TezosJsonDecoders.Circe.Numbers._

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/bigmaps/BigMapsOperationsTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/bigmaps/BigMapsOperationsTest.scala
@@ -2,26 +2,22 @@ package tech.cryptonomic.conseil.indexer.tezos.bigmaps
 
 import java.sql.Timestamp
 
-import org.scalatest.{Matchers, WordSpec}
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import slick.jdbc.PostgresProfile.api._
 import tech.cryptonomic.conseil.common.sql.CustomProfileExtension
 import tech.cryptonomic.conseil.common.testkit.InMemoryDatabase
 import tech.cryptonomic.conseil.common.testkit.util.RandomSeed
-import tech.cryptonomic.conseil.common.tezos.Tables.{
-  BigMapContentsRow,
-  BigMapsRow,
-  OriginatedAccountMapsRow,
-  TokenBalancesRow
-}
+import tech.cryptonomic.conseil.common.tezos.Tables.{BigMapContentsRow, BigMapsRow, OriginatedAccountMapsRow, TokenBalancesRow}
 import tech.cryptonomic.conseil.common.tezos.{Tables, TezosTypes}
 import tech.cryptonomic.conseil.common.tezos.TezosTypes._
 import tech.cryptonomic.conseil.indexer.tezos.michelson.contracts.TokenContracts
 import tech.cryptonomic.conseil.indexer.tezos.{TezosDatabaseOperationsTestFixtures, TezosInMemoryDatabaseSetup}
 import com.softwaremill.diffx.scalatest.DiffMatcher._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 class BigMapsOperationsTest
-    extends WordSpec
+    extends AnyWordSpec
     with TezosDatabaseOperationsTestFixtures
     with InMemoryDatabase
     with TezosInMemoryDatabaseSetup

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/JsonToMichelsonSpec.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/JsonToMichelsonSpec.scala
@@ -1,9 +1,10 @@
 package tech.cryptonomic.conseil.indexer.tezos.michelson
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import tech.cryptonomic.conseil.indexer.tezos.michelson.dto.MichelsonSchema
 
-class JsonToMichelsonSpec extends FlatSpec with Matchers {
+class JsonToMichelsonSpec extends AnyFlatSpec with Matchers {
 
   "A JsonToMichelson" should "convert json to michelson format" in {
       val json =

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/StakerDaoTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/StakerDaoTest.scala
@@ -1,9 +1,11 @@
 package tech.cryptonomic.conseil.indexer.tezos.michelson.contracts
 
-import org.scalatest.{Matchers, OptionValues, WordSpec}
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import tech.cryptonomic.conseil.common.tezos.TezosTypes._
 
-class StakerDaoTest extends WordSpec with Matchers with OptionValues {
+class StakerDaoTest extends AnyWordSpec with Matchers with OptionValues {
 
   "The Token Contracts operations for the StakerDao contract" should {
 

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/TNSContractsTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/TNSContractsTest.scala
@@ -1,12 +1,14 @@
 package tech.cryptonomic.conseil.indexer.tezos.michelson.contracts
 
 import com.softwaremill.diffx.scalatest.DiffMatcher._
-import org.scalatest.{Matchers, OptionValues, WordSpec}
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import tech.cryptonomic.conseil.common.tezos.TezosTypes.Contract.CompatBigMapDiff
 import tech.cryptonomic.conseil.common.tezos.TezosTypes._
 import tech.cryptonomic.conseil.indexer.tezos.michelson.contracts.TNSContract.LookupMapReference
 
-class TNSContractsTest extends WordSpec with Matchers with OptionValues {
+class TNSContractsTest extends AnyWordSpec with Matchers with OptionValues {
 
   "The TNS Contract operations for a known configured contract" should {
 

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/TokenContractsTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/TokenContractsTest.scala
@@ -1,9 +1,11 @@
 package tech.cryptonomic.conseil.indexer.tezos.michelson.contracts
 
-import org.scalatest.{Matchers, OptionValues, WordSpec}
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import tech.cryptonomic.conseil.common.tezos.TezosTypes._
 
-class TokenContractsTest extends WordSpec with Matchers with OptionValues {
+class TokenContractsTest extends AnyWordSpec with Matchers with OptionValues {
 
   "The Token Contracts operations for a known FA1.2 compliant contract" should {
 

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/parser/JsonParserSpec.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/parser/JsonParserSpec.scala
@@ -1,10 +1,11 @@
 package tech.cryptonomic.conseil.indexer.tezos.michelson.parser
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import tech.cryptonomic.conseil.indexer.tezos.michelson.dto._
-import tech.cryptonomic.conseil.indexer.tezos.michelson.parser.JsonParser.{parse, ParserError}
+import tech.cryptonomic.conseil.indexer.tezos.michelson.parser.JsonParser.{ParserError, parse}
 
-class JsonParserSpec extends FlatSpec with Matchers {
+class JsonParserSpec extends AnyFlatSpec with Matchers {
 
   it should "parse one-argument MichelsonType" in {
       val json = """{"prim": "contract"}"""

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/renderer/MichelsonRendererSpec.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/renderer/MichelsonRendererSpec.scala
@@ -1,10 +1,11 @@
 package tech.cryptonomic.conseil.indexer.tezos.michelson.renderer
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import tech.cryptonomic.conseil.indexer.tezos.michelson.dto._
 import tech.cryptonomic.conseil.indexer.tezos.michelson.renderer.MichelsonRenderer._
 
-class MichelsonRendererSpec extends FlatSpec with Matchers {
+class MichelsonRendererSpec extends AnyFlatSpec with Matchers {
 
   it should "render single MichelsonType" in {
       MichelsonType("contract").render() shouldBe "contract"


### PR DESCRIPTION
This pull requests addresses a lot of warnings raised due to usage of deprecated classes from ScalaTest library