### PR TITLE
Turn the AccountId type to an alias for Public Key Hash

### DIFF
--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataOperations.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataOperations.scala
@@ -128,7 +128,7 @@ class TezosDataOperations extends ApiDataOperations {
   def fetchAccount(account_id: AccountId)(implicit ec: ExecutionContext): Future[Option[AccountResult]] = {
     val fetchOperation =
       Tables.Accounts
-        .filter(row => row.accountId === account_id.id && row.invalidatedAsof.isEmpty)
+        .filter(row => row.accountId === account_id.value && row.invalidatedAsof.isEmpty)
         .take(1)
         .result
 

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataRoutes.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataRoutes.scala
@@ -9,7 +9,7 @@ import tech.cryptonomic.conseil.common.config.MetadataConfiguration
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.QueryResponseWithOutput
 import tech.cryptonomic.conseil.common.metadata
 import tech.cryptonomic.conseil.common.metadata.{EntityPath, NetworkPath, PlatformPath}
-import tech.cryptonomic.conseil.common.tezos.TezosTypes.{AccountId, TezosBlockHash}
+import tech.cryptonomic.conseil.common.tezos.TezosTypes.{makeAccountId, TezosBlockHash}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -94,7 +94,7 @@ case class TezosDataRoutes(
   private val accountByIdRoute: Route = tezosAccountByIdEndpoint.implementedByAsync {
     case ((network, accountId), _) =>
       platformNetworkValidation(network) {
-        operations.fetchAccount(AccountId(accountId))
+        operations.fetchAccount(makeAccountId(accountId))
       }
   }
 

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataOperationsTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataOperationsTest.scala
@@ -21,7 +21,7 @@ import tech.cryptonomic.conseil.common.tezos.Tables.{
   OperationsRow
 }
 import tech.cryptonomic.conseil.common.tezos.{Fork, Tables}
-import tech.cryptonomic.conseil.common.tezos.TezosTypes.{AccountId, TezosBlockHash}
+import tech.cryptonomic.conseil.common.tezos.TezosTypes.{makeAccountId, TezosBlockHash}
 
 import scala.concurrent.duration._
 
@@ -254,7 +254,7 @@ class TezosDataOperationsTest
 
       "fetchAccount is empty" in {
         // given
-        val input = AccountId("xyz")
+        val input = makeAccountId("xyz")
 
         // when
         val result = sut.fetchAccount(input).futureValue
@@ -267,13 +267,13 @@ class TezosDataOperationsTest
         // given
         dbHandler.run(Tables.Blocks ++= blocksTmp).isReadyWithin(5.seconds) shouldBe true
         dbHandler.run(Tables.Accounts ++= accountsTmp).isReadyWithin(5.seconds) shouldBe true
-        val input = AccountId(accountsTmp.head.accountId)
+        val input = makeAccountId(accountsTmp.head.accountId)
 
         // when
         val result = sut.fetchAccount(input).futureValue.value
 
         // then
-        result.account.accountId shouldBe input.id
+        result.account.accountId shouldBe input.value
       }
 
       "fetchLatestBlock when DB is empty" in {

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosForkDataOperationsTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosForkDataOperationsTest.scala
@@ -10,18 +10,11 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 import slick.jdbc.PostgresProfile.api._
 import tech.cryptonomic.conseil.api.TezosInMemoryDatabaseSetup
-import tech.cryptonomic.conseil.common.generic.chain.DataTypes.{Query, _}
+import tech.cryptonomic.conseil.common.generic.chain.DataTypes._
 import tech.cryptonomic.conseil.common.testkit.InMemoryDatabase
-import tech.cryptonomic.conseil.common.tezos.Tables.{
-  AccountsHistoryRow,
-  AccountsRow,
-  BlocksRow,
-  FeesRow,
-  OperationGroupsRow,
-  OperationsRow
-}
+import tech.cryptonomic.conseil.common.tezos.Tables.{AccountsRow, BlocksRow, OperationGroupsRow, OperationsRow}
 import tech.cryptonomic.conseil.common.tezos.{Fork, Tables}
-import tech.cryptonomic.conseil.common.tezos.TezosTypes.{AccountId, TezosBlockHash}
+import tech.cryptonomic.conseil.common.tezos.TezosTypes.{makeAccountId, TezosBlockHash}
 
 import scala.concurrent.duration._
 import java.time.Instant
@@ -278,7 +271,7 @@ class TezosForkDataOperationsTest
         // given
         dbHandler.run(Tables.Blocks ++= forkInvalidBlocks).isReadyWithin(5.seconds) shouldBe true
         dbHandler.run(Tables.Accounts ++= forkInvalidAccounts).isReadyWithin(5.seconds) shouldBe true
-        val input = AccountId(forkInvalidAccounts.head.accountId)
+        val input = makeAccountId(forkInvalidAccounts.head.accountId)
 
         // when
         val result = sut.fetchAccount(input).futureValue

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosOptics.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosOptics.scala
@@ -367,7 +367,7 @@ object TezosOptics {
     val extractAddressesFromExpression = (micheline: Micheline) => {
       micheline.expression match {
         case JsonUtil.AccountIds(id, ids @ _*) =>
-          (id :: ids.toList).distinct.map(AccountId)
+          (id :: ids.toList).distinct.map(makeAccountId)
         case _ =>
           List.empty[AccountId]
       }

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosTypes.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosTypes.scala
@@ -36,13 +36,17 @@ object TezosTypes {
 
   final case class PublicKeyHash(value: String) extends AnyVal
 
+  /** we use this alias to highlight the semantic of use, but it's another PKH */
+  type AccountId = PublicKeyHash
+
+  /** Wraps a string into an account id value, i.e. a public key hash */
+  val makeAccountId = PublicKeyHash(_)
+
   final case class Signature(value: String) extends AnyVal
 
   final case class OperationHash(value: String) extends AnyVal
 
   final case class ContractId(id: String) extends AnyVal
-
-  final case class AccountId(id: String) extends AnyVal
 
   final case class ChainId(id: String) extends AnyVal
 

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseConversions.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseConversions.scala
@@ -106,7 +106,7 @@ private[tezos] object TezosDatabaseConversions extends LazyLogging {
         accounts.map {
           case (id, Account(balance, delegate, script, counter, manager, spendable, isBaker, isActivated)) =>
             Tables.AccountsRow(
-              accountId = id.id,
+              accountId = id.value,
               blockId = hash.value,
               counter = counter,
               script = script.map(_.code.expression),
@@ -737,7 +737,7 @@ private[tezos] object TezosDatabaseConversions extends LazyLogging {
         ids.map(
           accountId =>
             Tables.AccountsCheckpointRow(
-              accountId = accountId.id,
+              accountId = accountId.value,
               blockId = blockHash.value,
               blockLevel = blockLevel,
               asof = Timestamp.from(timestamp.getOrElse(Instant.ofEpochMilli(0))),

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
@@ -15,7 +15,7 @@ import tech.cryptonomic.conseil.common.sql.CustomProfileExtension
 import tech.cryptonomic.conseil.common.tezos.Tables.{GovernanceRow, OriginatedAccountMapsRow}
 import tech.cryptonomic.conseil.common.tezos.TezosTypes.Fee.AverageFees
 import tech.cryptonomic.conseil.common.tezos.TezosTypes.Voting.BakerRolls
-import tech.cryptonomic.conseil.common.tezos.TezosTypes.{FetchRights, _}
+import tech.cryptonomic.conseil.common.tezos.TezosTypes._
 import tech.cryptonomic.conseil.indexer.tezos.bigmaps.BigMapsOperations
 import tech.cryptonomic.conseil.indexer.tezos.michelson.contracts.{TNSContract, TokenContracts}
 import tech.cryptonomic.conseil.common.tezos.Tables
@@ -238,7 +238,7 @@ object TezosDatabaseOperations extends LazyLogging {
       selection = ids,
       tableQuery = Tables.AccountsCheckpoint,
       tableTotal = getAccountsCheckpointSize(),
-      applySelection = (checkpoint, keySet) => checkpoint.filter(_.accountId inSet keySet.map(_.id))
+      applySelection = (checkpoint, keySet) => checkpoint.filter(_.accountId inSet keySet.map(_.value))
     )
   }
 
@@ -348,7 +348,7 @@ object TezosDatabaseOperations extends LazyLogging {
         ids =>
           writeAccountsCheckpoint(
             List(
-              (hash, level, Some(timestamp), cycle, None, ids.map(AccountId(_)).toList)
+              (hash, level, Some(timestamp), cycle, None, ids.map(makeAccountId).toList)
             )
           )
       )
@@ -373,7 +373,7 @@ object TezosDatabaseOperations extends LazyLogging {
      */
     def keepLatestAccountIds(checkpoints: Seq[Tables.AccountsCheckpointRow]): Map[AccountId, BlockReference] =
       checkpoints.foldLeft(Map.empty[AccountId, BlockReference]) { (collected, row) =>
-        val key = AccountId(row.accountId)
+        val key = makeAccountId(row.accountId)
         val time = row.asof.toInstant
         if (collected.contains(key)) collected
         else
@@ -674,7 +674,7 @@ object TezosDatabaseOperations extends LazyLogging {
     Tables.Accounts
       .filter(_.invalidatedAsof.isEmpty)
       .map(table => (table.accountId, table.blockLevel))
-      .filter(_._1 inSet ids.map(_.id))
+      .filter(_._1 inSet ids.map(_.value))
       .result
 
   /** Fetch the latest block level available for each delegate pkh stored */
@@ -695,7 +695,7 @@ object TezosDatabaseOperations extends LazyLogging {
     Tables.Accounts
       .filter(_.isBaker === true)
       .filter(_.invalidatedAsof.isEmpty)
-      .filterNot(_.accountId inSet exclude.map(_.id))
+      .filterNot(_.accountId inSet exclude.map(_.value))
       .result
       .map(_.toList)
 

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosJsonDecoders.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosJsonDecoders.scala
@@ -91,7 +91,6 @@ private[tezos] object TezosJsonDecoders {
     implicit val blockHashDecoder: Decoder[TezosBlockHash] = base58CheckDecoder.map(b58 => TezosBlockHash(b58.content))
     implicit val opHashDecoder: Decoder[OperationHash] = base58CheckDecoder.map(b58 => OperationHash(b58.content))
     implicit val contractIdDecoder: Decoder[ContractId] = base58CheckDecoder.map(b58 => ContractId(b58.content))
-    implicit val accountIdDecoder: Decoder[AccountId] = base58CheckDecoder.map(b58 => AccountId(b58.content))
     implicit val chainIdDecoder: Decoder[ChainId] = base58CheckDecoder.map(b58 => ChainId(b58.content))
     implicit val protocolIdDecoder: Decoder[ProtocolId] = base58CheckDecoder.map(b58 => ProtocolId(b58.content))
     implicit val scriptIdDecoder: Decoder[ScriptId] = base58CheckDecoder.map(b58 => ScriptId(b58.content))

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosNamesOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosNamesOperations.scala
@@ -5,7 +5,7 @@ import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 import slick.dbio.DBIO
 import tech.cryptonomic.conseil.common.tezos.TezosOptics.Operations.extractAppliedTransactions
-import tech.cryptonomic.conseil.common.tezos.TezosTypes.{AccountId, Block, ContractId, ScriptId}
+import tech.cryptonomic.conseil.common.tezos.TezosTypes.{AccountId, Block, ContractId, PublicKeyHash, ScriptId}
 import tech.cryptonomic.conseil.indexer.tezos.michelson.contracts.TNSContract
 import tech.cryptonomic.conseil.indexer.tezos.michelson.contracts.TNSContract.{
   BigMapId,
@@ -27,7 +27,7 @@ private[tezos] class TezosNamesOperations(tnsContracts: TNSContract, node: Tezos
     case LookupMapReference(
         ContractId(contractId),
         Name(name),
-        AccountId(accountId),
+        PublicKeyHash(accountId),
         BigMapId(bigMapId),
         ScriptId(keyHash)
         ) =>
@@ -54,7 +54,7 @@ private[tezos] class TezosNamesOperations(tnsContracts: TNSContract, node: Tezos
             .filter(
               nameRecord =>
                 //double-check we're looking at the right data for the call
-                nameRecord.name == lookupRef.lookupName.value && nameRecord.resolver == lookupRef.resolver.id
+                nameRecord.name == lookupRef.lookupName.value && nameRecord.resolver == lookupRef.resolver.value
             )
       }.flattenOption
 

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosNodeFetchers.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosNodeFetchers.scala
@@ -106,7 +106,7 @@ private[tezos] trait TezosBlocksDataFetchers {
   val accountIdsJsonDecode: Kleisli[Id, String, List[AccountId]] =
     Kleisli[Id, String, List[AccountId]] {
       case JsonUtil.AccountIds(id, ids @ _*) =>
-        (id :: ids.toList).distinct.map(AccountId)
+        (id :: ids.toList).distinct.map(makeAccountId)
       case _ =>
         List.empty
     }
@@ -682,7 +682,7 @@ trait AccountsDataFetchers {
     type In = AccountId
     type Out = Option[Account]
 
-    private val makeUrl = (id: AccountId) => s"blocks/${referenceBlock.value}/context/contracts/${id.id}"
+    private val makeUrl = (id: AccountId) => s"blocks/${referenceBlock.value}/context/contracts/${id.value}"
 
     override val fetchData = Kleisli(
       ids => {
@@ -693,7 +693,7 @@ trait AccountsDataFetchers {
               .error(
                 "I encountered problems while fetching account data from {}, for ids {}. The error says {}",
                 network,
-                ids.map(_.id).mkString(", "),
+                ids.map(_.value).mkString(", "),
                 err.getMessage
               )
               .pure[Future]

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/bigmaps/BigMapsOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/bigmaps/BigMapsOperations.scala
@@ -384,7 +384,7 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
             tokenId =>
               Tables.TokenBalancesRow(
                 tokenId,
-                address = tokenUpdate.accountId.id,
+                address = tokenUpdate.accountId.value,
                 balance = BigDecimal(tokenUpdate.balance),
                 blockId = blockData.hash.value,
                 blockLevel = blockData.header.level,

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/TNSContract.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/TNSContract.scala
@@ -4,6 +4,7 @@ import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 import tech.cryptonomic.conseil.common.config.Platforms.TNSContractConfiguration
 import tech.cryptonomic.conseil.common.tezos.TezosTypes.{
+  makeAccountId,
   AccountId,
   Contract,
   ContractId,
@@ -290,7 +291,7 @@ object TNSContract extends LazyLogging {
             _ :: MichelsonType("Pair", MichelsonStringConstant(name) :: MichelsonStringConstant(resolver) :: _, _) :: _,
             _
             ) =>
-          (Name(name), AccountId(resolver))
+          (Name(name), makeAccountId(resolver))
       }
 
     /* Reads paramters for a registerName call, extracting the name mapping */
@@ -306,7 +307,7 @@ object TNSContract extends LazyLogging {
         val extracted = MichelsonParamExpr
           .findFirstIn(michelson)
           .map {
-            case MichelsonParamExpr(name, resolver) => (Name(name), AccountId(resolver))
+            case MichelsonParamExpr(name, resolver) => (Name(name), makeAccountId(resolver))
           }
           .orElse(parseAsMicheline(michelson))
         if (extracted.isEmpty)

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/TokenContracts.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/TokenContracts.scala
@@ -1,6 +1,7 @@
 package tech.cryptonomic.conseil.indexer.tezos.michelson.contracts
 
 import tech.cryptonomic.conseil.common.tezos.TezosTypes.{
+  makeAccountId,
   AccountId,
   Contract,
   ContractId,
@@ -208,7 +209,7 @@ object TokenContracts extends LazyLogging {
         id.toOption
       case packedAddress if packedAddress.startsWith("0") =>
         //this is directly the packed addres
-        val id = CryptoUtil.readAddress(packedAddress).map(AccountId)
+        val id = CryptoUtil.readAddress(packedAddress).map(makeAccountId)
         id.failed.foreach(
           err => logger.error("I failed to match a big map key as a proper account address", err)
         )
@@ -310,7 +311,7 @@ object TokenContracts extends LazyLogging {
         //this is number of bytes, each hex byte will take 2 chars
         length <- Hex.decode(hexLength).map(BigInt(_).toInt)
         accountId <- CryptoUtil.readAddress(hexAccount.take(length * 2))
-      } yield AccountId(accountId)
+      } yield makeAccountId(accountId)
 
     /* Michelson can be binary-encoded, in this case representing the following
      * example expression:

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperationsTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperationsTest.scala
@@ -298,7 +298,7 @@ class TezosDatabaseOperationsTest
 
         forAll(dbAccounts zip accountsInfo.content) {
           case (row, (id, account)) =>
-            row.accountId shouldEqual id.id
+            row.accountId shouldEqual id.value
             row.blockId shouldEqual block.hash
             row.counter shouldEqual account.counter
             row.script shouldEqual account.script.map(_.code.expression)
@@ -343,7 +343,7 @@ class TezosDatabaseOperationsTest
         val accountsInfo = generateAccounts(accountChanges, TezosBlockHash(hashUpdate), levelUpdate)
 
         //double-check for the identifier existence
-        accountsInfo.content.keySet.map(_.id) should contain(account.accountId)
+        accountsInfo.content.keySet.map(_.value) should contain(account.accountId)
 
         //do the updates
         val writeUpdatedAndGetRows = for {
@@ -364,7 +364,7 @@ class TezosDatabaseOperationsTest
         //both rows on db should refer to updated data
         forAll(dbAccounts zip accountsInfo.content) {
           case (row, (id, account)) =>
-            row.accountId shouldEqual id.id
+            row.accountId shouldEqual id.value
             row.blockId shouldEqual hashUpdate
             row.counter shouldEqual account.counter
             row.script shouldEqual account.script.map(_.code.expression)
@@ -396,7 +396,7 @@ class TezosDatabaseOperationsTest
                 Some(time),
                 None,
                 None,
-                List.fill(idPerBlock)(AccountId(generateHash(5)))
+                List.fill(idPerBlock)(makeAccountId(generateHash(5)))
               )
           )
 
@@ -423,7 +423,7 @@ class TezosDatabaseOperationsTest
           case (row, (hash, level, accountId)) =>
             row.blockId shouldEqual hash.value
             row.blockLevel shouldBe level
-            row.accountId shouldEqual accountId.id
+            row.accountId shouldEqual accountId.value
         }
 
       }
@@ -492,7 +492,7 @@ class TezosDatabaseOperationsTest
 
         val inSelection = Set(accountIds(1), accountIds(2), accountIds(3), accountIds(4))
 
-        val selection = inSelection.map(AccountId)
+        val selection = inSelection.map(makeAccountId)
 
         val expected = checkpointRows.filterNot(row => inSelection(row.accountId))
 
@@ -605,7 +605,7 @@ class TezosDatabaseOperationsTest
         val changes = 2
         val (hashUpdate, levelUpdate) = (second.hash, second.level)
         val delegatedKeys =
-          generateAccounts(howMany = changes, TezosBlockHash(hashUpdate), levelUpdate).content.keySet.map(_.id)
+          generateAccounts(howMany = changes, TezosBlockHash(hashUpdate), levelUpdate).content.keySet.map(_.value)
         val delegatesInfo = generateDelegates(
           delegatedHashes = delegatedKeys.toList,
           blockHash = TezosBlockHash(hashUpdate),
@@ -819,7 +819,7 @@ class TezosDatabaseOperationsTest
         )
 
         def entry(accountAtIndex: Int, atLevel: Int, time: Timestamp) =
-          AccountId(accountIds(accountAtIndex)) ->
+          makeAccountId(accountIds(accountAtIndex)) ->
               BlockReference(TezosBlockHash(blockIds(atLevel)), atLevel, Some(time.toInstant), None, None)
 
         //expecting only the following to remain
@@ -1096,13 +1096,13 @@ class TezosDatabaseOperationsTest
         implicit val randomSeed = RandomSeed(testReferenceTimestamp.getTime)
 
         val expectedCount = 3
-        val matchingId = AccountId("tz19alkdjf83aadkcl")
+        val matchingId = makeAccountId("tz19alkdjf83aadkcl")
 
         val block = generateBlockRows(1, testReferenceTimestamp).head
         val BlockTagged(hash, level, ts, cycle, period, accountsContent) =
           generateAccounts(expectedCount, TezosBlockHash(block.hash), block.level)
         val updatedContent = accountsContent.map {
-          case (AccountId(id), account) if id == "1" => (matchingId, account)
+          case (PublicKeyHash(id), account) if id == "1" => (matchingId, account)
           case any => any
         }
 

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperationsTestFixtures.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperationsTestFixtures.scala
@@ -53,7 +53,7 @@ trait TezosDatabaseOperationsTestFixtures extends RandomGenerationKit {
     val rnd = new Random(randomSeed.seed)
 
     val accounts = (1 to howMany).map { currentId =>
-      AccountId(String valueOf currentId) ->
+      makeAccountId(String valueOf currentId) ->
         Account(
           balance = rnd.nextInt,
           counter = Some(currentId),

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosForkDatabaseOperationsTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosForkDatabaseOperationsTest.scala
@@ -4,32 +4,29 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.OptionValues
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalacheck.Gen
 import org.scalacheck.Arbitrary.arbitrary
 import com.typesafe.scalalogging.LazyLogging
 import slick.jdbc.PostgresProfile.api._
 import tech.cryptonomic.conseil.common.testkit.InMemoryDatabase
 import tech.cryptonomic.conseil.common.testkit.util.DBSafe
-import tech.cryptonomic.conseil.common.tezos.TezosTypes.{Block, Voting}
+import tech.cryptonomic.conseil.common.tezos.TezosTypes.{makeAccountId, Block, PublicKeyHash, TezosBlockHash, Voting}
 import tech.cryptonomic.conseil.common.tezos.Tables
 import tech.cryptonomic.conseil.common.tezos.Tables.{
+  AccountsHistoryRow,
   AccountsRow,
+  BakersRow,
   BakingRightsRow,
   BlocksRow,
   EndorsingRightsRow,
   GovernanceRow,
+  OperationGroupsRow,
   OperationsRow
 }
+import TezosDataGenerationKit.ForkValid
+
 import java.{util => ju}
 import java.sql.Timestamp
-
-import TezosDataGenerationKit.ForkValid
-import tech.cryptonomic.conseil.common.tezos.Tables.OperationGroupsRow
-import org.scalacheck.Gen
-import _root_.tech.cryptonomic.conseil.common.tezos.TezosTypes.AccountId
-import tech.cryptonomic.conseil.common.tezos.Tables.BakersRow
-import tech.cryptonomic.conseil.common.tezos.TezosTypes.PublicKeyHash
-import tech.cryptonomic.conseil.common.tezos.Tables.AccountsHistoryRow
-import _root_.tech.cryptonomic.conseil.common.tezos.TezosTypes.TezosBlockHash
 
 /** Here we verify that any ∂ata saved persistently, that is marked as
   * belonging to a forked branch having been invalidated by latest chain
@@ -314,7 +311,7 @@ class TezosForkDatabaseOperationsTest
         val populateAndFetch = for {
           _ <- Tables.Blocks += invalidBlock
           Some(stored) <- Tables.Accounts ++= invalidRows
-          loaded <- sut.getLevelsForAccounts(invalidRows.map(row => AccountId(row.accountId)).toSet)
+          loaded <- sut.getLevelsForAccounts(invalidRows.map(row => makeAccountId(row.accountId)).toSet)
         } yield (stored, loaded)
 
         /* Test the results */

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosJsonDecodersTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosJsonDecodersTest.scala
@@ -93,6 +93,11 @@ class TezosJsonDecodersTest extends AnyWordSpec with Matchers with EitherValues 
         decoded.right.value shouldBe PublicKeyHash(validB58Hash)
       }
 
+      "decode valid json base58check strings into a AccountId" in {
+        val decoded = decode[AccountId](jsonStringOf(validB58Hash))
+        decoded.right.value shouldBe PublicKeyHash(validB58Hash)
+      }
+
       "fail to decode an invalid json base58check strings into a PublicKeyHash" in {
         val decoded = decode[PublicKeyHash](jsonStringOf(invalidB58Hash))
         decoded shouldBe 'left
@@ -126,11 +131,6 @@ class TezosJsonDecodersTest extends AnyWordSpec with Matchers with EitherValues 
       "fail to decode an invalid json base58check strings into a OperationHash" in {
         val decoded = decode[OperationHash](jsonStringOf(invalidB58Hash))
         decoded shouldBe 'left
-      }
-
-      "decode valid json base58check strings into a AccountId" in {
-        val decoded = decode[AccountId](jsonStringOf(validB58Hash))
-        decoded.right.value shouldBe AccountId(validB58Hash)
       }
 
       "fail to decode an invalid json base58check strings into a AccountId" in {

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/StakerDaoTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/StakerDaoTest.scala
@@ -91,8 +91,8 @@ class StakerDaoTest extends AnyWordSpec with Matchers with OptionValues {
 
         //then
         balanceUpdates should contain theSameElementsAs List(
-          AccountId("tz1dcWXLS1UBeGc7EazGvoNE6D8YSzVkAsSa") -> BigInt(1),
-          AccountId("tz1WAVpSaCFtLQKSJkrdVApCQC1TNK8iNxq9") -> BigInt(1499998)
+          makeAccountId("tz1dcWXLS1UBeGc7EazGvoNE6D8YSzVkAsSa") -> BigInt(1),
+          makeAccountId("tz1WAVpSaCFtLQKSJkrdVApCQC1TNK8iNxq9") -> BigInt(1499998)
         )
 
       }

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/TNSContractsTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/TNSContractsTest.scala
@@ -27,7 +27,7 @@ class TNSContractsTest extends AnyWordSpec with Matchers with OptionValues {
           LookupMapReference(
             contractId = tnsContractId,
             lookupName = TNSContract.Name("me want tacos"),
-            resolver = AccountId("tz2TSvNTh2epDMhZHrw73nV9piBX7kLZ9K9m"),
+            resolver = makeAccountId("tz2TSvNTh2epDMhZHrw73nV9piBX7kLZ9K9m"),
             mapId = TNSContract.BigMapId(lookupId),
             mapKeyHash = ScriptId("exprvT4zX5M2nUKv2msyEeRTQx6zYoMh6rpnpWeDJhEranRRt8Hea9")
           )

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/TokenContractsTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/TokenContractsTest.scala
@@ -43,7 +43,7 @@ class TokenContractsTest extends AnyWordSpec with Matchers with OptionValues {
         val balanceUpdate = sut.readBalance(ledgerId)(mapUpdate)
 
         //then
-        val (AccountId(id), balance) = balanceUpdate.value
+        val (PublicKeyHash(id), balance) = balanceUpdate.value
         id shouldEqual "tz1dae51wqhBwC7YdGiJAAU5JYwEvVH3Usf2"
         balance shouldEqual BigInt(10000)
 
@@ -75,7 +75,7 @@ class TokenContractsTest extends AnyWordSpec with Matchers with OptionValues {
         val balanceUpdate = sut.readBalance(ledgerId)(mapUpdate)
 
         //then
-        val (AccountId(id), balance) = balanceUpdate.value
+        val (PublicKeyHash(id), balance) = balanceUpdate.value
         id shouldEqual "tz1YWeZqt67XGHUvPFBmfMfWAoZtXELTWtKh"
         balance shouldEqual BigInt(290502)
 


### PR DESCRIPTION
An account-id is just a specific use of a PKH.
This PR address such fact and changes the, currently distinct, type to an alias and provides an easy way to build one where specific usage is expected.

The `AccountId` type alias is still kept around to highlight its semantic where it's used.
This legacy definition might disappear completely in the future if it creates more confusion instead of reducing it.