### PR TITLE
Define block-tags in terms of block-references

### DIFF
--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/tezos/TezosTypesTest.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/tezos/TezosTypesTest.scala
@@ -55,14 +55,10 @@ class TezosTypesTest extends AnyWordSpec with Matchers with OptionValues with Ei
         val content = "A content string"
         val (hash, level) = (TezosBlockHash("hash"), 1)
 
-        content.taggedWithBlock(hash, level, someTime, None, None) shouldEqual BlockTagged(
-          hash,
-          level,
-          someTime,
-          None,
-          None,
-          content
-        )
+        val ref = BlockReference(hash, level, someTime, None, None)
+
+        content.taggedWithBlock(ref) shouldEqual BlockTagged(ref, content)
+
       }
     }
 
@@ -72,7 +68,7 @@ class TezosTypesTest extends AnyWordSpec with Matchers with OptionValues with Ei
         val content = "A content string"
         val (hash, level) = (TezosBlockHash("hash"), 1)
 
-        BlockTagged(hash, level, someTime, None, None, content).asTuple shouldEqual (hash, level, someTime, None, None, content)
+        BlockTagged(BlockReference(hash, level, someTime, None, None), content).asTuple shouldEqual (hash, level, someTime, None, None, content)
       }
     }
 

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosNodeOperator.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosNodeOperator.scala
@@ -265,8 +265,8 @@ private[tezos] class TezosNodeOperator(
       data.groupBy {
         case (id, _) => accountsBlocksIndex(id)
       }.map {
-        case (BlockReference(hash, level, timestamp, cycle, period), accounts) =>
-          accounts.taggedWithBlock(hash, level, timestamp, cycle, period)
+        case (blockReference, accounts) =>
+          accounts.taggedWithBlock(blockReference)
       }.toList
 
     //fetch accounts by requested ids and group them together with corresponding blocks
@@ -455,8 +455,8 @@ private[tezos] class TezosNodeOperator(
       data.groupBy {
         case (pkh, _) => keysBlocksIndex(pkh)
       }.map {
-        case (BlockReference(hash, level, timestamp, cycle, period), delegates) =>
-          delegates.taggedWithBlock(hash, level, timestamp, cycle, period)
+        case (blockReference, delegates) =>
+          delegates.taggedWithBlock(blockReference)
       }.toList
 
     //fetch delegates by requested pkh and group them together with corresponding blocks

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/processing/BakersProcessor.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/processing/BakersProcessor.scala
@@ -120,7 +120,7 @@ class BakersProcessor(
         .mapConcat(identity) //concatenates the list of values as single-valued elements in the stream
         .grouped(batchingConf.blockPageSize) //re-arranges the process batching
         .mapAsync(1)(taggedBakers => {
-          val hashes = taggedBakers.map(_.blockHash).toList
+          val hashes = taggedBakers.map(_.ref.hash).toList
           nodeOperator
             .getBakerRollsForBlockHashes(hashes)
             .map { hashKeyedRolls =>
@@ -166,8 +166,8 @@ class BakersProcessor(
       }
 
     val sorted = updates.flatMap {
-      case BlockTagged(hash, level, timestamp, cycle, period, ids) =>
-        ids.map(_ -> BlockReference(hash, level, timestamp, cycle, period))
+      case BlockTagged(ref, ids) =>
+        ids.map(_ -> ref)
     }.sortBy {
       case (id, ref) => ref.level
     }(Ordering[Long].reverse)

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseConversionsTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseConversionsTest.scala
@@ -163,10 +163,10 @@ class TezosDatabaseConversionsTest
             change = BigDecimal(up1.change),
             level = up1.level,
             category = up1.category,
-            blockId = tag.blockHash.value,
-            blockLevel = tag.blockLevel,
-            cycle = tag.cycle,
-            period = tag.period,
+            blockId = tag.ref.hash.value,
+            blockLevel = tag.ref.level,
+            cycle = tag.ref.cycle,
+            period = tag.ref.period,
             forkId = Fork.mainForkId
           ),
           Tables.BalanceUpdatesRow(
@@ -179,10 +179,10 @@ class TezosDatabaseConversionsTest
             change = BigDecimal(up2.change),
             level = up2.level,
             category = up2.category,
-            blockId = tag.blockHash.value,
-            blockLevel = tag.blockLevel,
-            cycle = tag.cycle,
-            period = tag.period,
+            blockId = tag.ref.hash.value,
+            blockLevel = tag.ref.level,
+            cycle = tag.ref.cycle,
+            period = tag.ref.period,
             forkId = Fork.mainForkId
           ),
           Tables.BalanceUpdatesRow(
@@ -195,10 +195,10 @@ class TezosDatabaseConversionsTest
             change = BigDecimal(up3.change),
             level = up3.level,
             category = up3.category,
-            blockId = tag.blockHash.value,
-            blockLevel = tag.blockLevel,
-            cycle = tag.cycle,
-            period = tag.period,
+            blockId = tag.ref.hash.value,
+            blockLevel = tag.ref.level,
+            cycle = tag.ref.cycle,
+            period = tag.ref.period,
             forkId = Fork.mainForkId
           )
         )
@@ -208,7 +208,7 @@ class TezosDatabaseConversionsTest
         import OperationBalances._
         import SymbolSourceLabels.Show._
 
-        BlockTagged(TezosBlockHash("sampleHash"), 123, None, None, None, sampleReveal)
+        BlockTagged(BlockReference(TezosBlockHash("sampleHash"), 123, None, None, None), sampleReveal)
           .convertToA[List, Tables.BalanceUpdatesRow] should contain only (
           Tables.BalanceUpdatesRow(
             id = 0,
@@ -245,7 +245,7 @@ class TezosDatabaseConversionsTest
         import OperationBalances._
         import SymbolSourceLabels.Show._
 
-        BlockTagged(TezosBlockHash("sampleHash"), 123, None, None, None, sampleOrigination)
+        BlockTagged(BlockReference(TezosBlockHash("sampleHash"), 123, None, None, None), sampleOrigination)
           .convertToA[List, Tables.BalanceUpdatesRow] should contain only (
           Tables.BalanceUpdatesRow(
             id = 0,

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperationsTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperationsTest.scala
@@ -1099,14 +1099,14 @@ class TezosDatabaseOperationsTest
         val matchingId = AccountId("tz19alkdjf83aadkcl")
 
         val block = generateBlockRows(1, testReferenceTimestamp).head
-        val BlockTagged(hash, level, ts, cycle, period, accountsContent) =
+        val BlockTagged(ref, accountsContent) =
           generateAccounts(expectedCount, TezosBlockHash(block.hash), block.level)
         val updatedContent = accountsContent.map {
           case (AccountId(id), account) if id == "1" => (matchingId, account)
           case any => any
         }
 
-        val accountsInfo = BlockTagged(hash, level, ts, cycle, period, updatedContent)
+        val accountsInfo = BlockTagged(ref, updatedContent)
 
         val populate =
           (Tables.Blocks += block) >>

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperationsTestFixtures.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperationsTestFixtures.scala
@@ -66,7 +66,7 @@ trait TezosDatabaseOperationsTestFixtures extends RandomGenerationKit {
         )
     }.toMap
 
-    accounts.taggedWithBlock(blockHash, blockLevel, Some(time), None, None)
+    accounts.taggedWithBlock(BlockReference(blockHash, blockLevel, Some(time), None, None))
   }
 
   /* randomly generates a number of delegates with associated block data */
@@ -99,7 +99,7 @@ trait TezosDatabaseOperationsTestFixtures extends RandomGenerationKit {
             )
     }.toMap
 
-    delegates.taggedWithBlock(blockHash, blockLevel, Some(Instant.ofEpochSecond(0)), None, None)
+    delegates.taggedWithBlock(BlockReference(blockHash, blockLevel, Some(Instant.ofEpochSecond(0)), None, None))
   }
 
   /* randomly populate a number of blocks based on a level range */


### PR DESCRIPTION
BlockReference is used to collect [not so few] attributes to identify a block and to re-use such data as a reference alongside other entities.
E.g. when extracting account or bakers we need to record the provenance of those to the block.

We also have a similar concept of "tagging" content with additional reference data to some block.

The concept is so similar that this PR connects the two abstractions and defines the block-tagged-data in terms of block-reference.

This simplifies the codebase wherever the block-reference can be passed along untouched.
This goes so far as to be able to define a functor instance that leaves untouched the block reference and only changes the content, further simplifying the code where this happens.