### PR TITLE
922 - missing rolls and bakers during test period

### DIFF
--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/ConseilApi.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/ConseilApi.scala
@@ -29,7 +29,7 @@ import tech.cryptonomic.conseil.api.security.Security
 import tech.cryptonomic.conseil.common.cache.MetadataCaching
 import tech.cryptonomic.conseil.common.config.Platforms
 import tech.cryptonomic.conseil.common.config.Platforms.BlockchainPlatform
-import tech.cryptonomic.conseil.common.sql.DatabaseMetadataOperations
+import tech.cryptonomic.conseil.common.sql.DatabaseRunner
 import tech.cryptonomic.conseil.common.util.DatabaseUtil
 
 import scala.concurrent.ExecutionContext
@@ -157,7 +157,7 @@ class ConseilApi(config: CombinedConfiguration)(implicit system: ActorSystem)
 
     private val cacheOverrides = new AttributeValuesCacheConfiguration(config.metadata)
     private val metadataCaching = MetadataCaching.empty[IO].unsafeRunSync()
-    private val metadataOperations: DatabaseMetadataOperations = new DatabaseMetadataOperations {
+    private val metadataOperations: DatabaseRunner = new DatabaseRunner {
       override lazy val dbReadHandle = DatabaseUtil.conseilDb
     }
 

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataOperations.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataOperations.scala
@@ -5,7 +5,7 @@ import tech.cryptonomic.conseil.common.generic.chain.DataOperations
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.OutputType.OutputType
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.{Field, Predicate, Query, QueryResponse, _}
 import tech.cryptonomic.conseil.api.routes.platform.Sanitizer._
-import tech.cryptonomic.conseil.common.sql.DatabaseMetadataOperations
+import tech.cryptonomic.conseil.common.sql.DatabaseRunner
 import tech.cryptonomic.conseil.common.util.DatabaseUtil.QueryBuilder._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -28,7 +28,7 @@ object ApiDataOperations {
 }
 
 /** Provides the implementation for `DataOperations` trait */
-trait ApiDataOperations extends DatabaseMetadataOperations with DataOperations {
+trait ApiDataOperations extends DatabaseRunner with DataOperations {
   import ApiDataOperations._
 
   /** Executes the query with given predicates

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/GenericPlatformDiscoveryOperations.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/GenericPlatformDiscoveryOperations.scala
@@ -16,7 +16,7 @@ import tech.cryptonomic.conseil.common.generic.chain.DataTypes.{
 }
 import tech.cryptonomic.conseil.common.generic.chain.PlatformDiscoveryTypes.DataType.DataType
 import tech.cryptonomic.conseil.common.generic.chain.PlatformDiscoveryTypes._
-import tech.cryptonomic.conseil.common.generic.chain.{MetadataOperations, PlatformDiscoveryOperations}
+import tech.cryptonomic.conseil.common.generic.chain.{DBIORunner, PlatformDiscoveryOperations}
 import tech.cryptonomic.conseil.common.metadata._
 
 import scala.concurrent.duration.FiniteDuration
@@ -26,7 +26,7 @@ import scala.concurrent.{ExecutionContext, Future}
 object GenericPlatformDiscoveryOperations {
 
   def apply(
-      metadataOperations: MetadataOperations,
+      metadataOperations: DBIORunner,
       caching: MetadataCaching[IO],
       cacheOverrides: AttributeValuesCacheConfiguration,
       cacheTTL: FiniteDuration,
@@ -37,7 +37,7 @@ object GenericPlatformDiscoveryOperations {
 
 /** Class providing the implementation of the metadata calls with caching */
 class GenericPlatformDiscoveryOperations(
-    metadataOperations: MetadataOperations,
+    metadataOperations: DBIORunner,
     caching: MetadataCaching[IO],
     cacheOverrides: AttributeValuesCacheConfiguration,
     cacheTTL: FiniteDuration,

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/GenericPlatformDiscoveryOperationsTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/GenericPlatformDiscoveryOperationsTest.scala
@@ -21,7 +21,7 @@ import tech.cryptonomic.conseil.common.generic.chain.DataTypes.{
   InvalidAttributeDataType,
   InvalidAttributeFilterLength
 }
-import tech.cryptonomic.conseil.common.generic.chain.MetadataOperations
+import tech.cryptonomic.conseil.common.generic.chain.DBIORunner
 import tech.cryptonomic.conseil.common.generic.chain.PlatformDiscoveryTypes.{Attribute, _}
 import tech.cryptonomic.conseil.common.metadata._
 import tech.cryptonomic.conseil.common.testkit.InMemoryDatabase
@@ -49,7 +49,7 @@ class GenericPlatformDiscoveryOperationsTest
 
   import scala.concurrent.ExecutionContext.Implicits.global
 
-  val metadataOperations: MetadataOperations = new MetadataOperations {
+  val metadataOperations: DBIORunner = new DBIORunner {
     override def runQuery[A](action: dbio.DBIO[A]): Future[A] = dbHandler.run(action)
   }
   implicit val contextShift: ContextShift[IO] = IO.contextShift(implicitly[ExecutionContext])

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/generic/chain/DBIORunner.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/generic/chain/DBIORunner.scala
@@ -4,7 +4,7 @@ import slick.dbio.DBIO
 
 import scala.concurrent.Future
 
-trait MetadataOperations {
+trait DBIORunner {
 
   /**
     * Runs DBIO action for reading purposes

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/sql/DatabaseRunner.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/sql/DatabaseRunner.scala
@@ -1,12 +1,12 @@
 package tech.cryptonomic.conseil.common.sql
 
 import slick.jdbc.PostgresProfile.api._
-import tech.cryptonomic.conseil.common.generic.chain.MetadataOperations
+import tech.cryptonomic.conseil.common.generic.chain.DBIORunner
 
 import scala.concurrent.Future
 
 /** Provides the implementation for `MetadataOperations` trait from database */
-trait DatabaseMetadataOperations extends MetadataOperations {
+trait DatabaseRunner extends DBIORunner {
   def dbReadHandle: Database
 
   /**

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosTypes.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosTypes.scala
@@ -522,12 +522,8 @@ object TezosTypes {
   ) {
 
     /** Compute rolls based on staked balance */
-    def rolls: Option[Int] = staking_balance match {
-      case PositiveDecimal(value) =>
-        Some((value quot Voting.BakerRollsSize).toIntExact)
-      case InvalidPositiveDecimal(jsonString) =>
-        None
-    }
+    def rolls: Option[Int] = Baking.computeRollsFromStakes(staking_balance)
+
   }
 
   final case class CycleBalance(
@@ -603,14 +599,28 @@ object TezosTypes {
 
   object Voting {
 
-    /** how big is a baker roll */
-    final val BakerRollsSize = BigDecimal.decimal(8000)
-
     final case class Vote(value: String) extends AnyVal
     final case class Proposal(protocols: List[(ProtocolId, ProposalSupporters)], block: Block)
     final case class BakerRolls(pkh: PublicKeyHash, rolls: Int)
     final case class Ballot(pkh: PublicKeyHash, ballot: Vote)
     final case class BallotCounts(yay: Int, nay: Int, pass: Int)
+  }
+
+  /** Utilities related to the baking process */
+  object Baking {
+
+    //we'll move this to a proper chain configuration value later on
+    /** how big is a baker roll */
+    final val BakerRollsSize = BigDecimal.decimal(8000)
+
+    def computeRollsFromStakes(stakingBalance: PositiveBigNumber): Option[Int] =
+      stakingBalance match {
+        case PositiveDecimal(value) =>
+          Some((value quot BakerRollsSize).toIntExact)
+        case InvalidPositiveDecimal(jsonString) =>
+          None
+      }
+
   }
 
   object Syntax {

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosTypes.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosTypes.scala
@@ -517,11 +517,17 @@ object TezosTypes {
       staking_balance: PositiveBigNumber,
       delegated_contracts: List[ContractId],
       delegated_balance: PositiveBigNumber,
-      rolls: Option[Int] = None,
       deactivated: Boolean,
       grace_period: Int
   ) {
-    def updateRolls(rolls: Int): Delegate = this.copy(rolls = Some(rolls))
+
+    /** Compute rolls based on staked balance */
+    def rolls: Option[Int] = staking_balance match {
+      case PositiveDecimal(value) =>
+        Some((value quot Voting.BakerRollsSize).toIntExact)
+      case InvalidPositiveDecimal(jsonString) =>
+        None
+    }
   }
 
   final case class CycleBalance(
@@ -596,6 +602,9 @@ object TezosTypes {
   final case class MichelsonExpression(prim: String, args: List[String])
 
   object Voting {
+
+    /** how big is a baker roll */
+    final val BakerRollsSize = BigDecimal.decimal(8000)
 
     final case class Vote(value: String) extends AnyVal
     final case class Proposal(protocols: List[(ProtocolId, ProposalSupporters)], block: Block)

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
@@ -362,34 +362,6 @@ object TezosDatabaseOperations extends LazyLogging {
     Tables.BakersCheckpoint.distinctOn(_.delegatePkh).length.result
 
   /**
-    * Reads the account ids in the checkpoint table,
-    * sorted by decreasing block-level
-    * @return a database action that loads the list of relevant rows
-    */
-  def getLatestAccountsFromCheckpoint(implicit ec: ExecutionContext): DBIO[Map[AccountId, BlockReference]] = {
-    /* Given a sorted sequence of checkpoint rows whose reference level is decreasing,
-     * collects them in a map, skipping keys already added
-     * This prevents duplicate entry keys and keeps the highest level referenced, using an in-memory algorithm
-     * We can think of optimizing this later, we're now optimizing on db queries
-     */
-    def keepLatestAccountIds(checkpoints: Seq[Tables.AccountsCheckpointRow]): Map[AccountId, BlockReference] =
-      checkpoints.foldLeft(Map.empty[AccountId, BlockReference]) { (collected, row) =>
-        val key = makeAccountId(row.accountId)
-        val time = row.asof.toInstant
-        if (collected.contains(key)) collected
-        else
-          collected + (key -> BlockReference(TezosBlockHash(row.blockId), row.blockLevel, Some(time), row.cycle, None))
-      }
-
-    logger.info("Getting the latest accounts from checkpoints in the DB...")
-
-    Tables.AccountsCheckpoint
-      .sortBy(_.blockLevel.desc)
-      .result
-      .map(keepLatestAccountIds)
-  }
-
-  /**
     * Reads the delegate key hashes in the checkpoint table,
     * sorted by decreasing block-level
     * @return a database action that loads the list of relevant rows
@@ -671,14 +643,6 @@ object TezosDatabaseOperations extends LazyLogging {
   private def expandStringArray(arr: String): List[ProtocolId] =
     arr.trim.stripPrefix("[").stripSuffix("]").split(',').map(ProtocolId).toList
 
-  /** Fetch the latest block level available for each account id stored */
-  def getLevelsForAccounts(ids: Set[AccountId]): DBIO[Seq[(String, BlockLevel)]] =
-    Tables.Accounts
-      .filter(_.invalidatedAsof.isEmpty)
-      .map(table => (table.accountId, table.blockLevel))
-      .filter(_._1 inSet ids.map(_.value))
-      .result
-
   /** Fetch the latest block level available for each delegate pkh stored */
   def getLevelsForBakers(ids: Set[PublicKeyHash]): DBIO[Seq[(String, BlockLevel)]] =
     Tables.Bakers
@@ -686,20 +650,6 @@ object TezosDatabaseOperations extends LazyLogging {
       .map(table => (table.pkh, table.blockLevel))
       .filter(_._1 inSet ids.map(_.value))
       .result
-
-  /** Gets only bakers from the accounts, excluding those for the input ids.
-    *
-    * @param exclude defines which bakers should be filtered out
-    */
-  def getFilteredBakerAccounts(
-      exclude: Set[AccountId]
-  )(implicit ec: ExecutionContext): DBIO[List[Tables.AccountsRow]] =
-    Tables.Accounts
-      .filter(_.isBaker === true)
-      .filter(_.invalidatedAsof.isEmpty)
-      .filterNot(_.accountId inSet exclude.map(_.value))
-      .result
-      .map(_.toList)
 
   /** Updates accounts history with bakers */
   def updateAccountsHistoryWithBakers(bakers: List[Voting.BakerRolls], block: Block): DBIO[Int] = {
@@ -732,25 +682,6 @@ object TezosDatabaseOperations extends LazyLogging {
       .map(_.isBaker)
       .update(true)
   }
-
-  /**
-    * Gets all bakers for given block hash
-    * @param hashes
-    * @param ec
-    * @return
-    */
-  def getBakersForBlocks(
-      hashes: List[TezosBlockHash]
-  )(implicit ec: ExecutionContext): DBIO[List[(TezosBlockHash, List[BakerRolls])]] =
-    DBIO.sequence {
-      hashes.map { hash =>
-        Tables.Bakers
-          .filter(_.blockId === hash.value)
-          .filter(_.invalidatedAsof.isEmpty)
-          .result
-          .map(hash -> _.map(baker => BakerRolls(PublicKeyHash(baker.pkh), baker.rolls)).toList)
-      }
-    }
 
   /**
     * Gets all bakers from the DB
@@ -814,36 +745,6 @@ object TezosDatabaseOperations extends LazyLogging {
       }
     }
   }
-
-  /** Finds activated accounts - useful when updating accounts history
-    * @return sequence of activated account ids
-    */
-  def findActivatedAccountIds: DBIO[Seq[String]] =
-    Tables.Accounts
-      .filter(acc => acc.isActivated && acc.invalidatedAsof.isEmpty)
-      .map(_.accountId)
-      .result
-
-  /** Load all operations referenced from a block level and higher, that are of a specific kind.
-    * @param ofKind a set of kinds to filter operations, if empty there will be no result
-    * @param fromLevel the lowest block-level to start from, zero by default
-    * @return the matching operations pkh, sorted by ascending block-level
-    */
-  def fetchRecentOperationsHashByKind(
-      ofKind: Set[String],
-      fromLevel: BlockLevel = 0
-  ): DBIO[Seq[String]] =
-    Tables.Operations
-      .filter(
-        row =>
-          (row.kind inSet ofKind)
-            && (row.blockLevel >= fromLevel)
-            && (row.pkh.isDefined)
-            && row.invalidatedAsof.isEmpty
-      )
-      .sortBy(_.blockLevel.asc)
-      .map(_.pkh.get) //this is allowed only because we filtered by non-empty pkh
-      .result
 
   /** Returns all levels that have seen a custom event processing, e.g.
     * - auto-refresh of all accounts after the babylon protocol amendment

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosIndexedDataOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosIndexedDataOperations.scala
@@ -1,17 +1,25 @@
 package tech.cryptonomic.conseil.indexer.tezos
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import slick.jdbc.PostgresProfile.api._
-import tech.cryptonomic.conseil.common.sql.DatabaseMetadataOperations
-import tech.cryptonomic.conseil.common.tezos.TezosTypes.BlockLevel
+import tech.cryptonomic.conseil.common.sql.DatabaseRunner
+import tech.cryptonomic.conseil.common.tezos.TezosTypes.{
+  makeAccountId,
+  AccountId,
+  BlockLevel,
+  BlockReference,
+  PublicKeyHash,
+  TezosBlockHash
+}
+import tech.cryptonomic.conseil.common.tezos.TezosTypes.Voting.BakerRolls
 import tech.cryptonomic.conseil.common.tezos.Tables
-import tech.cryptonomic.conseil.common.util.DatabaseUtil
 
 /**
   * Functionality for fetching data from the Conseil database specific only for conseil-lorre module.
   */
-private[tezos] class TezosIndexedDataOperations extends DatabaseMetadataOperations {
-  override lazy val dbReadHandle: Database = DatabaseUtil.lorreDb
+private[tezos] class TezosIndexedDataOperations(
+    override val dbReadHandle: Database
+) extends DatabaseRunner {
 
   /**
     * Fetches the level of the most recent block stored in the database.
@@ -69,5 +77,112 @@ private[tezos] class TezosIndexedDataOperations extends DatabaseMetadataOperatio
     */
   def fetchBlockAtLevel(level: BlockLevel): Future[Option[Tables.BlocksRow]] =
     runQuery(Tables.Blocks.filter(row => row.level === level && row.invalidatedAsof.isEmpty).result.headOption)
+
+  /** Finds activated accounts - useful when updating accounts history
+    * @return sequence of activated account ids
+    */
+  def findActivatedAccountIds: Future[Seq[String]] =
+    runQuery(
+      Tables.Accounts
+        .filter(acc => acc.isActivated && acc.invalidatedAsof.isEmpty)
+        .map(_.accountId)
+        .result
+    )
+
+  /** Gets only bakers from the accounts, excluding those for the input ids.
+    *
+    * @param exclude defines which bakers should be filtered out
+    */
+  def getFilteredBakerAccounts(
+      exclude: Set[AccountId]
+  )(implicit ec: ExecutionContext): Future[List[Tables.AccountsRow]] =
+    runQuery(
+      Tables.Accounts
+        .filter(_.isBaker === true)
+        .filter(_.invalidatedAsof.isEmpty)
+        .filterNot(_.accountId inSet exclude.map(_.value))
+        .result
+        .map(_.toList)
+    )
+
+  /**
+    * Gets all bakers for given block hash
+    * @param hashes
+    * @param ec
+    * @return
+    */
+  def getBakersForBlocks(
+      hashes: List[TezosBlockHash]
+  )(implicit ec: ExecutionContext): Future[List[(TezosBlockHash, List[BakerRolls])]] =
+    runQuery(DBIO.sequence {
+      hashes.map { hash =>
+        Tables.Bakers
+          .filter(_.blockId === hash.value)
+          .filter(_.invalidatedAsof.isEmpty)
+          .result
+          .map(hash -> _.map(baker => BakerRolls(PublicKeyHash(baker.pkh), baker.rolls)).toList)
+      }
+    })
+
+  /** Fetch the latest block level available for each account id stored */
+  def getLevelsForAccounts(ids: Set[AccountId]): Future[Seq[(String, BlockLevel)]] =
+    runQuery(
+      Tables.Accounts
+        .filter(_.invalidatedAsof.isEmpty)
+        .map(table => (table.accountId, table.blockLevel))
+        .filter(_._1 inSet ids.map(_.value))
+        .result
+    )
+
+  /** Load all operations referenced from a block level and higher, that are of a specific kind.
+    * @param ofKind a set of kinds to filter operations, if empty there will be no result
+    * @param fromLevel the lowest block-level to start from, zero by default
+    * @return the matching operations pkh, sorted by ascending block-level
+    */
+  def fetchRecentOperationsHashByKind(
+      ofKind: Set[String],
+      fromLevel: BlockLevel = 0
+  ): Future[Seq[String]] =
+    runQuery(
+      Tables.Operations
+        .filter(
+          row =>
+            (row.kind inSet ofKind)
+              && (row.blockLevel >= fromLevel)
+              && (row.pkh.isDefined)
+              && row.invalidatedAsof.isEmpty
+        )
+        .sortBy(_.blockLevel.asc)
+        .map(_.pkh.get) //this is allowed only because we filtered by non-empty pkh
+        .result
+    )
+
+  /**
+    * Reads the account ids in the checkpoint table,
+    * sorted by decreasing block-level
+    * @return a database action that loads the list of relevant rows
+    */
+  def getLatestAccountsFromCheckpoint(implicit ec: ExecutionContext): Future[Map[AccountId, BlockReference]] = {
+    /* Given a sorted sequence of checkpoint rows whose reference level is decreasing,
+     * collects them in a map, skipping keys already added
+     * This prevents duplicate entry keys and keeps the highest level referenced, using an in-memory algorithm
+     * We can think of optimizing this later, we're now optimizing on db queries
+     */
+    def keepLatestAccountIds(checkpoints: Seq[Tables.AccountsCheckpointRow]): Map[AccountId, BlockReference] =
+      checkpoints.foldLeft(Map.empty[AccountId, BlockReference]) { (collected, row) =>
+        val key = makeAccountId(row.accountId)
+        val time = row.asof.toInstant
+        if (collected.contains(key)) collected
+        else
+          collected + (key -> BlockReference(TezosBlockHash(row.blockId), row.blockLevel, Some(time), row.cycle, None))
+      }
+
+    runQuery(
+      Tables.AccountsCheckpoint
+        .sortBy(_.blockLevel.desc)
+        .result
+        .map(keepLatestAccountIds)
+    )
+  }
 
 }

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosIndexedDataOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosIndexedDataOperations.scala
@@ -13,6 +13,7 @@ import tech.cryptonomic.conseil.common.tezos.TezosTypes.{
 }
 import tech.cryptonomic.conseil.common.tezos.TezosTypes.Voting.BakerRolls
 import tech.cryptonomic.conseil.common.tezos.Tables
+import tech.cryptonomic.conseil.common.tezos.Tables.BakersRow
 
 /**
   * Functionality for fetching data from the Conseil database specific only for conseil-lorre module.
@@ -123,6 +124,21 @@ private[tezos] class TezosIndexedDataOperations(
           .map(hash -> _.map(baker => BakerRolls(PublicKeyHash(baker.pkh), baker.rolls)).toList)
       }
     })
+
+  /** Gets baker rows for any matching id in the input.
+    * Useful to verify which account corresponds to a baker.
+    *
+    * @param include the account ids to match on
+    */
+  def getBakersSelection(
+      include: Set[AccountId]
+  )(implicit ec: ExecutionContext): Future[List[BakersRow]] =
+    runQuery(
+      Tables.Bakers
+        .filter(_.pkh inSet include.map(_.value))
+        .result
+        .map(_.toList)
+    )
 
   /** Fetch the latest block level available for each account id stored */
   def getLevelsForAccounts(ids: Set[AccountId]): Future[Seq[(String, BlockLevel)]] =

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosIndexer.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosIndexer.scala
@@ -256,7 +256,7 @@ object TezosIndexer extends LazyLogging {
 
     /* Here we collect all internal service operations and resources, needed to run the indexer */
     val db = DatabaseUtil.lorreDb
-    val indexedData = new TezosIndexedDataOperations
+    val indexedData = new TezosIndexedDataOperations(db)
 
     /* collects data from the remote tezos node */
     val nodeOperator = new TezosNodeOperator(
@@ -274,7 +274,8 @@ object TezosIndexer extends LazyLogging {
     )
 
     /* handles standard accounts data */
-    val accountsProcessor = new AccountsProcessor(nodeOperator, db, batchingConf, lorreConf.blockRightsFetching)
+    val accountsProcessor =
+      new AccountsProcessor(nodeOperator, indexedData, batchingConf, lorreConf.blockRightsFetching)
 
     /* handles wide-range accounts refresh due to occasional special events */
     val accountsResetHandler = new AccountsResetHandler(db, indexedData)

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/processing/AccountsProcessor.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/processing/AccountsProcessor.scala
@@ -8,7 +8,11 @@ import akka.stream.scaladsl.Source
 import cats._
 import cats.implicits._
 import tech.cryptonomic.conseil.indexer.config.{BakingAndEndorsingRights, BatchFetchConfiguration}
-import tech.cryptonomic.conseil.indexer.tezos.{TezosNodeOperator, TezosDatabaseOperations => TezosDb}
+import tech.cryptonomic.conseil.indexer.tezos.{
+  TezosIndexedDataOperations,
+  TezosNodeOperator,
+  TezosDatabaseOperations => TezosDb
+}
 import tech.cryptonomic.conseil.indexer.tezos.TezosNodeOperator.LazyPages
 import tech.cryptonomic.conseil.common.tezos.Tables
 import tech.cryptonomic.conseil.common.tezos.TezosTypes.{
@@ -23,23 +27,20 @@ import tech.cryptonomic.conseil.common.tezos.TezosTypes.{
   Voting
 }
 import tech.cryptonomic.conseil.indexer.tezos.TezosErrors.AccountsProcessingFailed
-import tech.cryptonomic.conseil.common.tezos.TezosTypes.Syntax._
 import com.typesafe.scalalogging.LazyLogging
-import slick.jdbc.PostgresProfile.api._
-import tech.cryptonomic.conseil.common.util.JsonUtil.AccountIds
 
 /** Collects operations related to handling accounts from
   * the tezos node.
   *
   * @param nodeOperator connects to tezos
-  * @param db raw access to the slick database
+  * @param indexedData access to the chain data already in the indexer
   * @param batchingConf used to access configuration on batch fetching
   * @param rightsConf used to access configuration for baking/endorsing rights processing
   * @param mat implicitly required materializer of akka streams, used by internal streaming processing
   */
 class AccountsProcessor(
     nodeOperator: TezosNodeOperator,
-    db: Database,
+    indexedData: TezosIndexedDataOperations,
     batchingConf: BatchFetchConfiguration,
     rightsConf: BakingAndEndorsingRights
 )(
@@ -126,7 +127,7 @@ class AccountsProcessor(
       // (there is no operation like bakers deactivation)
       val accountsWithHistoryFut = for {
         activatedOperations <- fetchActivationOperationsByLevel(taggedAccounts.map(_.ref.level).distinct)
-        activatedAccounts <- db.run(TezosDb.findActivatedAccountIds)
+        activatedAccounts <- indexedData.findActivatedAccountIds
         updatedTaggedAccounts = updateTaggedAccountsWithIsActivated(
           taggedAccounts,
           activatedOperations.mapValues(_.toSet),
@@ -136,7 +137,8 @@ class AccountsProcessor(
       } yield inactiveBakerAccounts
 
       accountsWithHistoryFut.flatMap { accountsWithHistory =>
-        db.run(TezosDb.writeAccountsAndCheckpointBakers(accountsWithHistory, taggedBakerKeys))
+        indexedData
+          .runQuery(TezosDb.writeAccountsAndCheckpointBakers(accountsWithHistory, taggedBakerKeys))
           .map {
             case (accountWrites, accountHistoryWrites, bakerCheckpoints) =>
               (accountWrites, bakerCheckpoints, taggedBakerKeys)
@@ -155,11 +157,7 @@ class AccountsProcessor(
             //the returned ids also reference the input hash, but we can discard it
             //we only want the active ids to fetch the inactive by difference from the database
             val activeIds = activeBakers.map(_._2.toSet).getOrElse(Set.empty)
-            db.run {
-              TezosDb
-                .getFilteredBakerAccounts(exclude = activeIds)
-                .map(accountsPerLevel -> _)
-            }
+            indexedData.getFilteredBakerAccounts(exclude = activeIds).map(accountsPerLevel -> _)
           }
         } else {
           Future.successful(accountsPerLevel -> List.empty)
@@ -193,34 +191,31 @@ class AccountsProcessor(
       }
 
     /** Get all pkh for each level in input, belonging to any activate-account operation */
-    def fetchActivationOperationsByLevel(levels: List[BlockLevel]): Future[Map[BlockLevel, List[PublicKeyHash]]] = {
-      import slick.jdbc.PostgresProfile.api._
-      db.run {
-        DBIO.sequence {
-          levels.map { level =>
-            TezosDb
-              .fetchRecentOperationsHashByKind(Set("activate_account"), level)
-              .map(
-                optionalOperationHashes => level -> optionalOperationHashes.toList.map(PublicKeyHash(_))
-              )
-          }
-        }.map(_.toMap)
-      }
-    }
+    def fetchActivationOperationsByLevel(levels: List[BlockLevel]): Future[Map[BlockLevel, List[PublicKeyHash]]] =
+      Future
+        .traverse(levels) { level =>
+          indexedData
+            .fetchRecentOperationsHashByKind(Set("activate_account"), level)
+            .map(
+              optionalOperationHashes => level -> optionalOperationHashes.toList.map(PublicKeyHash(_))
+            )
+        }
+        .map(_.toMap)
 
     /** remove from the checkpoints any processed id */
     def cleanup = {
       //can fail with no real downsides
       val processed = Some(ids.keySet)
       logger.info("Cleaning {} processed accounts from the checkpoint...", ids.size)
-      db.run(TezosDb.cleanAccountsCheckpoint(processed))
+      indexedData
+        .runQuery(TezosDb.cleanAccountsCheckpoint(processed))
         .map(cleaned => logger.info("Done cleaning {} accounts checkpoint rows.", cleaned))
     }
 
     //if needed, we get the stored levels and only keep updates that are more recent
     def prunedUpdates(): Future[Map[AccountId, BlockReference]] =
-      if (onlyProcessLatest) db.run {
-        TezosDb.getLevelsForAccounts(ids.keySet).map { currentlyStored =>
+      if (onlyProcessLatest) {
+        indexedData.getLevelsForAccounts(ids.keySet).map { currentlyStored =>
           ids.filterNot {
             case (PublicKeyHash(accountId), BlockReference(_, updateLevel, _, _, _)) =>
               currentlyStored.exists {
@@ -233,24 +228,29 @@ class AccountsProcessor(
     logger.info("Ready to fetch updated accounts information from the chain")
 
     // updates account pages with baker information
-    def updateAccountPages(pages: LazyPages[nodeOperator.AccountFetchingResults]) = pages.map { pageFut =>
-      pageFut.map { accounts =>
-        accounts.map { taggedAccounts =>
-          votingData
-            .get(taggedAccounts.ref.hash)
-            .map { rolls =>
-              val affectedAccounts = rolls.map(_.pkh.value)
-              val accUp = taggedAccounts.content.map {
-                case (accId, acc) if affectedAccounts.contains(accId.value) =>
-                  accId -> acc.copy(isBaker = Some(true))
-                case x => x
+    def updateAccountPages(
+        pages: LazyPages[nodeOperator.AccountFetchingResults]
+    ): LazyPages[nodeOperator.AccountFetchingResults] =
+      pages.map { pageFut =>
+        pageFut.map { accounts =>
+          accounts.map { taggedAccounts =>
+            votingData
+              .get(taggedAccounts.ref.hash)
+              .map { rolls =>
+                //TODO this map should be read from the indexed bakers
+                //essentially read the bakers list from the previous blocks
+                val affectedAccounts = rolls.map(_.pkh.value)
+                val accUp = taggedAccounts.content.map {
+                  case (accId, acc) if affectedAccounts.contains(accId.value) =>
+                    accId -> acc.copy(isBaker = Some(true))
+                  case x => x
+                }
+                taggedAccounts.copy(content = accUp)
               }
-              taggedAccounts.copy(content = accUp)
-            }
-            .getOrElse(taggedAccounts)
+              .getOrElse(taggedAccounts)
+          }
         }
       }
-    }
 
     /* Streams the (unevaluated) incoming data, actually fetching the results.
      * We use combinators to keep the ongoing requests' flow under control, taking advantage of
@@ -321,14 +321,15 @@ class AccountsProcessor(
   private[tezos] def processTezosAccountsCheckpoint()(implicit ec: ExecutionContext): Future[Done] = {
 
     logger.info("Selecting all accounts left in the checkpoint table...")
-    db.run(TezosDb.getLatestAccountsFromCheckpoint) flatMap { checkpoints =>
+
+    indexedData.getLatestAccountsFromCheckpoint flatMap { checkpoints =>
       if (checkpoints.nonEmpty) {
         logger.info(
           "I loaded all of {} checkpointed ids from the DB and will proceed to fetch updated accounts information from the chain",
           checkpoints.size
         )
         // here we need to get missing bakers for the given block
-        db.run(TezosDb.getBakersForBlocks(checkpoints.values.map(_.hash).toList)).flatMap { bakers =>
+        indexedData.getBakersForBlocks(checkpoints.values.map(_.hash).toList).flatMap { bakers =>
           process(checkpoints, bakers.toMap, onlyProcessLatest = true).map(_ => Done)
         }
 

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/processing/BakersProcessor.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/processing/BakersProcessor.scala
@@ -14,8 +14,7 @@ import tech.cryptonomic.conseil.common.tezos.TezosTypes.{
   InvalidPositiveDecimal,
   PositiveBigNumber,
   PositiveDecimal,
-  PublicKeyHash,
-  Voting
+  PublicKeyHash
 }
 import tech.cryptonomic.conseil.indexer.tezos.{TezosNodeOperator, TezosDatabaseOperations => TezosDb}
 import tech.cryptonomic.conseil.indexer.tezos.TezosNodeOperator.LazyPages
@@ -205,14 +204,6 @@ class BakersProcessor(
       case InvalidPositiveDecimal(_) => None
     }
 
-    /** Computes updated rolls from the stake balance being updated */
-    def rollsFromStakes(balance: PositiveBigNumber): Int = balance match {
-      case PositiveDecimal(value) =>
-        (value quot Voting.BakerRollsSize).toIntExact
-      case InvalidPositiveDecimal(jsonString) =>
-        0
-    }
-
     def findUpdateDelegate(baker: Tables.BakersRow) = delegates.get(PublicKeyHash(baker.pkh))
 
     bakers.map(baker => baker -> findUpdateDelegate(baker)).collect {
@@ -221,7 +212,7 @@ class BakersProcessor(
           balance = extractBalance(delegate.balance),
           frozenBalance = extractBalance(delegate.frozen_balance),
           stakingBalance = extractBalance(delegate.staking_balance),
-          rolls = rollsFromStakes(delegate.staking_balance),
+          rolls = delegate.rolls.getOrElse(0),
           delegatedBalance = extractBalance(delegate.delegated_balance),
           deactivated = delegate.deactivated
         )

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/processing/BakersProcessor.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/processing/BakersProcessor.scala
@@ -64,25 +64,6 @@ class BakersProcessor(
         logger.info("{} baker history rows were added to the database.", historyRows.fold("The")(String.valueOf))
     }
 
-    def processBakersPage(
-        taggedBakers: Seq[BlockTagged[Map[PublicKeyHash, Delegate]]],
-        rolls: List[Voting.BakerRolls]
-    ): Future[(Option[Int], Option[Int])] = {
-
-      val enrichedBakers = taggedBakers
-        .map(
-          blockTagged =>
-            blockTagged.copy(content = blockTagged.content.map {
-              case (key, baker) =>
-                val rollsSum = rolls.filter(_.pkh.value == key.value).map(_.rolls).sum
-                (key, baker.updateRolls(rollsSum))
-            })
-        )
-
-      db.run(TezosDb.writeBakersAndCopyContracts(enrichedBakers.toList))
-        .andThen(logWriteFailure)
-    }
-
     def cleanup = {
       //can fail with no real downsides
       val processed = Some(ids.keySet)
@@ -119,18 +100,11 @@ class BakersProcessor(
         .mapAsync(1)(identity) //extracts the future value as an element of the stream
         .mapConcat(identity) //concatenates the list of values as single-valued elements in the stream
         .grouped(batchingConf.blockPageSize) //re-arranges the process batching
-        .mapAsync(1)(taggedBakers => {
-          val hashes = taggedBakers.map(_.ref.hash).toList
-          nodeOperator
-            .getBakerRollsForBlockHashes(hashes)
-            .map { hashKeyedRolls =>
-              val rolls = hashKeyedRolls.flatMap { case (hash, rolls) => rolls }
-              taggedBakers -> rolls
-            }
-        })
-        .mapAsync(1) {
-          case (bakers, rolls) => processBakersPage(bakers, rolls)
-        }
+        .mapAsync(1)(
+          taggedBakers =>
+            db.run(TezosDb.writeBakersAndCopyContracts(taggedBakers.toList))
+              .andThen(logWriteFailure)
+        )
         .runFold((Monoid[Option[Int]].empty, Monoid[Option[Int]].empty)) {
           case ((processedRows, processedHistoryRows), (justDone, justDoneHistory)) =>
             (processedRows |+| justDone) -> (processedHistoryRows |+| justDoneHistory)
@@ -231,6 +205,14 @@ class BakersProcessor(
       case InvalidPositiveDecimal(_) => None
     }
 
+    /** Computes updated rolls from the stake balance being updated */
+    def rollsFromStakes(balance: PositiveBigNumber): Int = balance match {
+      case PositiveDecimal(value) =>
+        (value quot Voting.BakerRollsSize).toIntExact
+      case InvalidPositiveDecimal(jsonString) =>
+        0
+    }
+
     def findUpdateDelegate(baker: Tables.BakersRow) = delegates.get(PublicKeyHash(baker.pkh))
 
     bakers.map(baker => baker -> findUpdateDelegate(baker)).collect {
@@ -239,6 +221,7 @@ class BakersProcessor(
           balance = extractBalance(delegate.balance),
           frozenBalance = extractBalance(delegate.frozen_balance),
           stakingBalance = extractBalance(delegate.staking_balance),
+          rolls = rollsFromStakes(delegate.staking_balance),
           delegatedBalance = extractBalance(delegate.delegated_balance),
           deactivated = delegate.deactivated
         )

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/JsonDecodersTestFixtures.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/JsonDecodersTestFixtures.scala
@@ -186,7 +186,6 @@ trait DelegatesJsonData {
         ContractId("KT19RhkHK8ssqXX1VxSSpyuyMXHK6V9RHizs"),
         ContractId("KT18bmcAvpLZPv6BF79RqTmZLZQSjodr3f2S")
       ),
-      rolls = None,
       delegated_balance = PositiveDecimal(13935725110L),
       deactivated = false,
       grace_period = 181

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperationsTestFixtures.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperationsTestFixtures.scala
@@ -94,8 +94,7 @@ trait TezosDatabaseOperationsTestFixtures extends RandomGenerationKit {
               delegated_contracts = List(ContractId(accountPkh)),
               delegated_balance = PositiveDecimal(rnd.nextInt()),
               deactivated = false,
-              grace_period = rnd.nextInt(),
-              rolls = None
+              grace_period = rnd.nextInt()
             )
     }.toMap
 

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosIndexedDataOperationsTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosIndexedDataOperationsTest.scala
@@ -7,24 +7,44 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.OptionValues
 import org.scalatest.matchers.should.Matchers
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalacheck.Gen
+import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.ScalacheckShapeless._
 import slick.jdbc.PostgresProfile.api._
 import tech.cryptonomic.conseil.common.testkit.InMemoryDatabase
-import tech.cryptonomic.conseil.common.testkit.util.DBSafe
-import tech.cryptonomic.conseil.common.tezos.TezosTypes.{BakingRights, Block, EndorsingRights, FetchRights}
-import tech.cryptonomic.conseil.common.tezos.TezosOptics
+import tech.cryptonomic.conseil.common.testkit.util.{DBSafe, RandomSeed}
+import tech.cryptonomic.conseil.common.tezos.TezosTypes.{
+  makeAccountId,
+  BakingRights,
+  Block,
+  BlockReference,
+  EndorsingRights,
+  FetchRights,
+  TezosBlockHash,
+  Voting
+}
+import tech.cryptonomic.conseil.common.tezos.{Fork, TezosOptics}
 import tech.cryptonomic.conseil.common.tezos.Tables
-import tech.cryptonomic.conseil.common.tezos.Tables.BlocksRow
+import tech.cryptonomic.conseil.common.tezos.Tables.{
+  AccountsHistoryRow,
+  AccountsRow,
+  BakersHistoryRow,
+  BakersRow,
+  BakingRightsRow,
+  BlocksRow,
+  EndorsingRightsRow,
+  GovernanceRow,
+  OperationGroupsRow,
+  OperationsRow,
+  TokenBalancesRow
+}
 import tech.cryptonomic.conseil.indexer.tezos.TezosDataGenerationKit.ForkValid
 import tech.cryptonomic.conseil.indexer.tezos.michelson.contracts.{TNSContract, TokenContracts}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import java.{util => ju}
+import java.time.Instant
 import java.sql.Timestamp
-import tech.cryptonomic.conseil.common.tezos.Tables.EndorsingRightsRow
-import tech.cryptonomic.conseil.common.tezos.Tables.BakingRightsRow
 
 class TezosIndexedDataOperationsTest
     extends AnyWordSpec
@@ -40,14 +60,13 @@ class TezosIndexedDataOperationsTest
   import scala.concurrent.ExecutionContext.Implicits.global
   import TezosDataGenerationKit.DomainModelGeneration._
   import TezosDataGenerationKit.DataModelGeneration._
+  import LocalGenerationUtils._
 
   "TezosIndexedDataOperations" should {
       implicit val noTokenContracts: TokenContracts = TokenContracts.fromConfig(List.empty)
       implicit val noTNSContracts: TNSContract = TNSContract.noContract
 
-      val sut = new TezosIndexedDataOperations {
-        override lazy val dbReadHandle = dbHandler
-      }
+      val sut = new TezosIndexedDataOperations(dbHandler)
 
       "fetchBlockAtLevel for missing entry" in {
         //when
@@ -88,6 +107,59 @@ class TezosIndexedDataOperationsTest
 
         // then
         result.level shouldBe pickLevel
+      }
+
+      "read latest account ids from checkpoint" in {
+        implicit val randomSeed = RandomSeed(testReferenceTimestamp.getTime)
+
+        //generate data
+        val blocks = generateBlockRows(toLevel = 5, testReferenceTimestamp)
+
+        //store required blocks for FK
+        val accountIds = Array("a0", "a1", "a2", "a3", "a4", "a5", "a6")
+        val blockIds = blocks.map(_.hash)
+
+        //create test data:
+        val checkpointRows = Array(
+          Tables.AccountsCheckpointRow(accountIds(1), blockIds(1), blockLevel = 1, testReferenceTimestamp),
+          Tables.AccountsCheckpointRow(accountIds(2), blockIds(1), blockLevel = 1, testReferenceTimestamp),
+          Tables.AccountsCheckpointRow(accountIds(3), blockIds(1), blockLevel = 1, testReferenceTimestamp),
+          Tables.AccountsCheckpointRow(accountIds(4), blockIds(2), blockLevel = 2, testReferenceTimestamp),
+          Tables.AccountsCheckpointRow(accountIds(5), blockIds(2), blockLevel = 2, testReferenceTimestamp),
+          Tables.AccountsCheckpointRow(accountIds(2), blockIds(3), blockLevel = 3, testReferenceTimestamp),
+          Tables.AccountsCheckpointRow(accountIds(3), blockIds(4), blockLevel = 4, testReferenceTimestamp),
+          Tables.AccountsCheckpointRow(accountIds(5), blockIds(4), blockLevel = 4, testReferenceTimestamp),
+          Tables.AccountsCheckpointRow(accountIds(6), blockIds(5), blockLevel = 5, testReferenceTimestamp)
+        )
+
+        def entry(accountAtIndex: Int, atLevel: Int, time: Timestamp) =
+          makeAccountId(accountIds(accountAtIndex)) ->
+              BlockReference(TezosBlockHash(blockIds(atLevel)), atLevel, Some(time.toInstant), None, None)
+
+        //expecting only the following to remain
+        val expected =
+          Map(
+            entry(accountAtIndex = 1, atLevel = 1, time = testReferenceTimestamp),
+            entry(accountAtIndex = 2, atLevel = 3, time = testReferenceTimestamp),
+            entry(accountAtIndex = 3, atLevel = 4, time = testReferenceTimestamp),
+            entry(accountAtIndex = 4, atLevel = 2, time = testReferenceTimestamp),
+            entry(accountAtIndex = 5, atLevel = 4, time = testReferenceTimestamp),
+            entry(accountAtIndex = 6, atLevel = 5, time = testReferenceTimestamp)
+          )
+
+        val populate = for {
+          blockCounts <- Tables.Blocks ++= blocks
+          checkpoint <- Tables.AccountsCheckpoint ++= checkpointRows
+        } yield (blockCounts, checkpoint)
+
+        val (storedBlocks, initialCount) = dbHandler.run(populate.transactionally).futureValue
+        val latest = sut.getLatestAccountsFromCheckpoint.futureValue
+
+        storedBlocks.value shouldBe blocks.size
+        initialCount.value shouldBe checkpointRows.size
+
+        latest.toSeq should contain theSameElementsAs expected.toSeq
+
       }
 
       "ignore forked data on fetchBlockAtLevel" in {
@@ -321,6 +393,337 @@ class TezosIndexedDataOperationsTest
 
       }
 
+      "ignore fork-invalidated data for latest operation hashes by kind" in {
+        /* Generate the data random sample */
+        val (validRows, validReferencedGroup, validReferencedBlock, invalidation, fork) =
+          Gen
+            .zip(
+              nonConflictingArbitrary[ForkValid[OperationsRow]](
+                //add a bit more realism
+                satisfying = (row: ForkValid[OperationsRow]) => row.data.blockLevel > 0
+              ),
+              arbitrary[ForkValid[OperationGroupsRow]],
+              arbitrary[ForkValid[BlocksRow]],
+              arbitrary[Timestamp],
+              arbitrary[ju.UUID]
+            )
+            .sample
+            .value
+
+        val invalidBlock = validReferencedBlock.data.copy(invalidatedAsof = Some(invalidation), forkId = fork.toString)
+        val invalidGroup = validReferencedGroup.data.copy(
+          blockId = invalidBlock.hash,
+          blockLevel = invalidBlock.level,
+          invalidatedAsof = Some(invalidation),
+          forkId = fork.toString
+        )
+        /* take heed that we keep the levels random */
+        val invalidRows = validRows.map(
+          _.data.copy(
+            blockHash = invalidBlock.hash,
+            operationGroupHash = invalidGroup.hash,
+            invalidatedAsof = Some(invalidation),
+            forkId = fork.toString
+          )
+        )
+
+        /* take note of relevant params */
+        val minRecordedLevel = invalidRows.map(_.blockLevel).min
+        val operationKinds = invalidRows.map(_.kind).toSet
+        //double-check
+        minRecordedLevel shouldBe >(0L)
+        operationKinds should not be empty
+
+        /* Store everything on db */
+        val populate = for {
+          _ <- Tables.Blocks += invalidBlock
+          _ <- Tables.OperationGroups += invalidGroup
+          Some(stored) <- Tables.Operations ++= invalidRows
+        } yield stored
+
+        /* Test the results */
+        val stored = dbHandler.run(populate).futureValue
+        val loaded = sut
+          .fetchRecentOperationsHashByKind(
+            ofKind = operationKinds,
+            fromLevel = minRecordedLevel
+          )
+          .futureValue
+
+        stored shouldBe >(0)
+        loaded shouldBe empty
+      }
+
+      "ignore fork-invalidated data for account levels" in {
+
+        /* Generate the data random sample */
+        val (validRows, validReferencedBlock, invalidation, fork) =
+          Gen
+            .zip(
+              //duplicate ids will fail to save on the db for violation of the PK uniqueness
+              nonConflictingArbitrary[ForkValid[AccountsRow]],
+              arbitrary[ForkValid[BlocksRow]],
+              arbitrary[Timestamp],
+              arbitrary[ju.UUID]
+            )
+            .sample
+            .value
+
+        val invalidBlock = validReferencedBlock.data.copy(invalidatedAsof = Some(invalidation), forkId = fork.toString)
+        val invalidRows = validRows.map(
+          _.data.copy(
+            blockId = invalidBlock.hash,
+            blockLevel = invalidBlock.level,
+            invalidatedAsof = Some(invalidation),
+            forkId = fork.toString
+          )
+        )
+
+        /* Store everything on db */
+        val populate = for {
+          _ <- Tables.Blocks += invalidBlock
+          Some(stored) <- Tables.Accounts ++= invalidRows
+        } yield stored
+
+        /* Test the results */
+        val stored = dbHandler.run(populate).futureValue
+        val loaded = sut.getLevelsForAccounts(invalidRows.map(row => makeAccountId(row.accountId)).toSet).futureValue
+
+        stored shouldBe >(0)
+        loaded shouldBe empty
+
+      }
+
+      "ignore fork-invalidated data for filteres bakers" in {
+
+        /* Generate the data random sample */
+        val (validRows, validReferencedBlock, invalidation, fork) =
+          Gen
+            .zip(
+              //duplicate ids will fail to save on the db for violation of the PK uniqueness
+              nonConflictingArbitrary[ForkValid[AccountsRow]],
+              arbitrary[ForkValid[BlocksRow]],
+              arbitrary[Timestamp],
+              arbitrary[ju.UUID]
+            )
+            .sample
+            .value
+
+        val invalidBlock = validReferencedBlock.data.copy(invalidatedAsof = Some(invalidation), forkId = fork.toString)
+        val invalidRows = validRows.map(
+          _.data.copy(
+            blockId = invalidBlock.hash,
+            blockLevel = invalidBlock.level,
+            invalidatedAsof = Some(invalidation),
+            forkId = fork.toString
+          )
+        )
+
+        /* Store everything on db */
+        val populate = for {
+          _ <- Tables.Blocks += invalidBlock
+          Some(stored) <- Tables.Accounts ++= invalidRows
+        } yield stored
+
+        /* Test the results */
+        val stored = dbHandler.run(populate).futureValue
+        val loaded = sut.getFilteredBakerAccounts(exclude = Set.empty).futureValue
+
+        stored shouldBe >(0)
+        loaded shouldBe empty
+
+      }
+
+      "ignore fork-invalidated data for bakers by block-hash" in {
+
+        val (validRow, validReferencedBlock, invalidation, fork) =
+          arbitrary[
+            (
+                ForkValid[BakersRow],
+                ForkValid[BlocksRow],
+                Timestamp,
+                ju.UUID
+            )
+          ].sample.value
+
+        val invalidBlock = validReferencedBlock.data.copy(invalidatedAsof = Some(invalidation), forkId = fork.toString)
+        val invalidRow = validRow.data.copy(
+          blockId = invalidBlock.hash,
+          blockLevel = invalidBlock.level,
+          invalidatedAsof = Some(invalidation),
+          forkId = fork.toString
+        )
+
+        val populate = for {
+          _ <- Tables.Blocks += invalidBlock
+          stored <- Tables.Bakers += invalidRow
+        } yield stored
+
+        val stored = dbHandler.run(populate).futureValue
+        val loaded = sut.getBakersForBlocks(List(TezosBlockHash(invalidRow.blockId))).futureValue
+
+        stored shouldBe >(0)
+        //get all rolls for any requested hash and concat them together
+        loaded.foldLeft(List.empty[Voting.BakerRolls]) {
+          case (allRolls, (hash, rolls)) => allRolls ++ rolls
+        } shouldBe empty
+
+      }
+
+      "ignore fork-invalidated data for activated accounts" in {
+
+        val (validRow, validReferencedBlock, invalidation, fork) =
+          arbitrary[
+            (
+                ForkValid[AccountsRow],
+                ForkValid[BlocksRow],
+                Timestamp,
+                ju.UUID
+            )
+          ].sample.value
+
+        val invalidBlock = validReferencedBlock.data.copy(invalidatedAsof = Some(invalidation), forkId = fork.toString)
+        val invalidRow = validRow.data.copy(
+          isActivated = true,
+          blockLevel = invalidBlock.level,
+          blockId = invalidBlock.hash,
+          invalidatedAsof = Some(invalidation),
+          forkId = fork.toString
+        )
+
+        val populate = for {
+          _ <- Tables.Blocks += invalidBlock
+          stored <- Tables.Accounts += invalidRow
+        } yield stored
+
+        val stored = dbHandler.run(populate).futureValue
+        val loaded = sut.findActivatedAccountIds.futureValue
+
+        stored shouldBe >(0)
+        loaded shouldBe empty
+
+      }
+
     }
 
+  private object LocalGenerationUtils {
+
+    /* Common generators should reduce clutter
+     * We have common patterns of dependencies and constraints for
+     * data that needs to be saved on db.
+     * Those are generally FK to block keys, or uniqueness checks on PK.
+     */
+    import Gen.{listOfN, nonEmptyListOf}
+
+    /* Denotes a type that is uniquely identified by a key type PK */
+    trait HasKey[Entity, PK] {
+
+      /** retrieves the unique key value from the entity instance */
+      def getKey(entity: Entity): PK
+
+    }
+
+    /* Here we provide all instances we need in the test cases */
+    object HasKey {
+
+      /* will provide an implicit HasKey for an entity wrapped by ForkValid
+       * we make use of java8 functional interfaces and define the instance as a lambda, which
+       * corresponds to the single method of HasKey, i.e. getKey
+       */
+      implicit def forkValidWithKey[PK, E](implicit hasKey: HasKey[E, PK]): HasKey[ForkValid[E], PK] = {
+        case ForkValid(entity) => implicitly[HasKey[E, PK]].getKey(entity)
+      }
+
+      /* There we provide all the key extractors for known db entites, again using functional interfaces shortcut */
+      implicit val blocksRowHasKey: HasKey[BlocksRow, String] = _.hash
+      implicit val accountsRowHasKey: HasKey[AccountsRow, String] = _.accountId
+      implicit val accountsHistoryRowHasKey: HasKey[AccountsHistoryRow, String] = _.accountId
+      implicit val bakersRowHasKey: HasKey[BakersRow, String] = _.pkh
+      implicit val bakersHistoryRowHasKey: HasKey[BakersHistoryRow, String] = _.pkh
+      implicit val operationGroupsRowHasKey: HasKey[OperationGroupsRow, String] = _.hash
+      implicit val operationsRowHasKey: HasKey[OperationsRow, Int] = _.operationId
+      implicit val bakingRightsRowHasKey: HasKey[BakingRightsRow, String] = _.delegate
+      implicit val endorsingRightsRowHasKey: HasKey[EndorsingRightsRow, String] = _.delegate
+      implicit val tokenBalancesRowHasKey: HasKey[TokenBalancesRow, String] = _.address
+      implicit val governanceRowHasKey: HasKey[GovernanceRow, (String, String, String)] =
+        gov => (gov.blockHash, gov.proposalHash, gov.votingPeriodKind)
+
+    }
+
+    /** Generates a list (non-empty) of Ts with no PK conflict.
+      * The key is provided implicitly by an instance of [[HasKey]] for the
+      * entity T we're trying to generate.
+      */
+    def nonConflictingArbitrary[T: Arbitrary](implicit hasKey: HasKey[T, _]): Gen[List[T]] =
+      nonEmptyListOf(arbitrary[T]).retryUntil(noDuplicates(forKey = hasKey.getKey))
+
+    /** Generates a list (non-empty) of pairs with T1 and T2s, with no PK conflict for the same type.
+      * The key is provided implicitly by an instance of [[HasKey]] for the
+      * entities we're trying to generate.
+      */
+    def nonConflictingArbitrary[T1: Arbitrary, T2: Arbitrary](
+        implicit
+        hasKey1: HasKey[T1, _],
+        hasKey2: HasKey[T2, _]
+    ): Gen[List[(T1, T2)]] =
+      nonEmptyListOf(arbitrary[(T1, T2)])
+        .retryUntil(noDuplicates(forKey = hasKey1.getKey, andKey = hasKey2.getKey))
+
+    /** generates a list (non-empty) of Ts with no PK conflict and at most n elements.
+      * The key is provided implicitly by an instance of [[HasKey]] for the
+      * entity T we're trying to generate.
+      */
+    def nonConflictingArbitrary[T: Arbitrary](atMost: Int)(implicit hasKey: HasKey[T, _]): Gen[List[T]] =
+      listOfN(atMost, arbitrary[T])
+        .suchThat(_.nonEmpty)
+        .retryUntil(noDuplicates(forKey = hasKey.getKey))
+
+    /** generates a list (non-empty) of Ts with no PK conflict.
+      * Additionally, each element should satisfy a specific property.
+      * The key is provided implicitly by an instance of [[HasKey]] for the
+      * entity T we're trying to generate.
+      */
+    def nonConflictingArbitrary[T: Arbitrary](satisfying: T => Boolean)(implicit hasKey: HasKey[T, _]): Gen[List[T]] =
+      nonEmptyListOf(arbitrary[T].retryUntil(satisfying)).retryUntil(noDuplicates(forKey = hasKey.getKey))
+
+    /** True if all entities have a distinct key, where the key is
+      * computed by the passed-in extraction function
+      */
+    private def noDuplicates[T, K](forKey: T => K)(entities: List[T]): Boolean =
+      !entities.groupBy(forKey).exists { case (key, rows) => rows.size > 1 }
+
+    /** True if all entities have a distinct key in each list, where the keys are
+      * separately computed by the passed-in extraction functions
+      */
+    private def noDuplicates[T, T2, K, K2](forKey: T => K, andKey: T2 => K2)(entities: List[(T, T2)]): Boolean = {
+      val (lefties, righties) = entities.unzip
+      noDuplicates(forKey)(lefties) && noDuplicates(andKey)(righties)
+    }
+
+    /* This is a "structural" type which collects what is necessary to be considered a data type
+     * which might be invalidated.
+     * This kind of definitions incurs runtime checks and as such tends to be avoided in production
+     * code, and its usage is enabled only behind a specific language import.
+     * We restrict its use to tests for this very reason.
+     */
+    type CanBeInvalidated = { def invalidatedAsof: Option[Timestamp]; def forkId: String }
+
+    /* import flag used to enable reflection calls for the following verification methods */
+    import language.reflectiveCalls
+
+    /** return true if all the entities in the sequence have not been invalidated by a fork */
+    def allValid[T <: CanBeInvalidated](valid: Seq[T]): Boolean =
+      valid.forall(it => it.invalidatedAsof.isEmpty && it.forkId == Fork.mainForkId)
+
+    /** return true if all the entities in the sequence result in having been invalidated by a fork
+      * with the given id and at the specific time
+      */
+    def allInvalidated[T <: CanBeInvalidated](asof: Instant, forkId: String)(invalidated: Seq[T]): Boolean =
+      invalidated.forall(
+        it =>
+          it.invalidatedAsof == Some(Timestamp.from(asof)) &&
+            it.forkId == forkId
+      )
+
+  }
 }


### PR DESCRIPTION
This interim solution closes #922 

It doesn't use rolls to identify bakers, but reads existing bakers from the corresponding database table.
It also simplifies rolls computation with a simple rule based on staking balances.

There are also a few refactors useful to better separate dependencies between the processor component for accounts and the database instance.
This is done by re-use of the indexed-data operations component, which collects read operations on data already stored in the indexer. Eventually I might try to re-use this separation for other entity processors too.
Finally the metadata operations related traits where renamed to better reflect the actual api exposed, which is related to running slick-db actions through a database instance. Hence the rename and reuse of such interface.