### PR TITLE
920 - compute and store the hash of smart contracts code when available

### DIFF
--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/GenericPlatformDiscoveryOperationsTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/GenericPlatformDiscoveryOperationsTest.scala
@@ -220,7 +220,8 @@ class GenericPlatformDiscoveryOperationsTest
             Attribute("is_baker", "Is baker", DataType.Boolean, None, KeyType.NonKey, "accounts"),
             Attribute("is_activated", "Is activated", DataType.Boolean, None, KeyType.UniqueKey, "accounts"),
             Attribute("invalidated_asof", "Invalidated asof", DataType.DateTime, None, KeyType.NonKey, "accounts"),
-            Attribute("fork_id", "Fork id", DataType.String, None, KeyType.UniqueKey, "accounts")
+            Attribute("fork_id", "Fork id", DataType.String, None, KeyType.UniqueKey, "accounts"),
+            Attribute("script_hash", "Script hash", DataType.String, None, KeyType.NonKey, "accounts")
           )
         )
       }
@@ -393,7 +394,7 @@ class GenericPlatformDiscoveryOperationsTest
         )
       }
 
-      "return list of attributes of delegates" in {
+      "return list of attributes of bakers" in {
 
         sut.getTableAttributes(EntityPath("bakers", networkPath)).futureValue.value.toSet should matchTo(
           Set(

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/Tables.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/Tables.scala
@@ -325,7 +325,8 @@ trait Tables {
     *  @param isActivated Database column is_activated SqlType(bool), Default(false)
     *  @param isActiveBaker Database column is_active_baker SqlType(bool), Default(None)
     *  @param invalidatedAsof Database column invalidated_asof SqlType(timestamp), Default(None)
-    *  @param forkId Database column fork_id SqlType(varchar) */
+    *  @param forkId Database column fork_id SqlType(varchar)
+    *  @param scriptHash Database column script_hash SqlType(varchar), Default(None) */
   case class AccountsHistoryRow(
       accountId: String,
       blockId: String,
@@ -340,7 +341,8 @@ trait Tables {
       isActivated: Boolean = false,
       isActiveBaker: Option[Boolean] = None,
       invalidatedAsof: Option[java.sql.Timestamp] = None,
-      forkId: String
+      forkId: String,
+      scriptHash: Option[String] = None
   )
 
   /** GetResult implicit for fetching AccountsHistoryRow objects using plain SQL queries */
@@ -371,7 +373,8 @@ trait Tables {
         <<[Boolean],
         <<?[Boolean],
         <<?[java.sql.Timestamp],
-        <<[String]
+        <<[String],
+        <<?[String]
       )
     )
   }
@@ -394,7 +397,8 @@ trait Tables {
         isActivated,
         isActiveBaker,
         invalidatedAsof,
-        forkId
+        forkId,
+        scriptHash
       ) <> (AccountsHistoryRow.tupled, AccountsHistoryRow.unapply)
 
     /** Maps whole row to an option. Useful for outer joins. */
@@ -414,15 +418,17 @@ trait Tables {
           Rep.Some(isActivated),
           isActiveBaker,
           invalidatedAsof,
-          Rep.Some(forkId)
+          Rep.Some(forkId),
+          scriptHash
         )
       ).shaped.<>(
         { r =>
           import r._;
           _1.map(
             _ =>
-              AccountsHistoryRow
-                .tupled((_1.get, _2.get, _3, _4, _5.get, _6.get, _7, _8.get, _9.get, _10, _11.get, _12, _13, _14.get))
+              AccountsHistoryRow.tupled(
+                (_1.get, _2.get, _3, _4, _5.get, _6.get, _7, _8.get, _9.get, _10, _11.get, _12, _13, _14.get, _15)
+              )
           )
         },
         (_: Any) => throw new Exception("Inserting into ? projection not supported.")
@@ -470,6 +476,9 @@ trait Tables {
 
     /** Database column fork_id SqlType(varchar) */
     val forkId: Rep[String] = column[String]("fork_id")
+
+    /** Database column script_hash SqlType(varchar), Default(None) */
+    val scriptHash: Rep[Option[String]] = column[Option[String]]("script_hash", O.Default(None))
 
     /** Index over (accountId) (database name ix_account_id) */
     val index1 = index("ix_account_id", accountId)

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/Tables.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/Tables.scala
@@ -60,7 +60,8 @@ trait Tables {
     *  @param isBaker Database column is_baker SqlType(bool), Default(false)
     *  @param isActivated Database column is_activated SqlType(bool), Default(false)
     *  @param invalidatedAsof Database column invalidated_asof SqlType(timestamp), Default(None)
-    *  @param forkId Database column fork_id SqlType(varchar) */
+    *  @param forkId Database column fork_id SqlType(varchar)
+    *  @param scriptHash Database column script_hash SqlType(varchar), Default(None) */
   case class AccountsRow(
       accountId: String,
       blockId: String,
@@ -76,7 +77,8 @@ trait Tables {
       isBaker: Boolean = false,
       isActivated: Boolean = false,
       invalidatedAsof: Option[java.sql.Timestamp] = None,
-      forkId: String
+      forkId: String,
+      scriptHash: Option[String] = None
   )
 
   /** GetResult implicit for fetching AccountsRow objects using plain SQL queries */
@@ -107,7 +109,8 @@ trait Tables {
         <<[Boolean],
         <<[Boolean],
         <<?[java.sql.Timestamp],
-        <<[String]
+        <<[String],
+        <<?[String]
       )
     )
   }
@@ -130,7 +133,8 @@ trait Tables {
         isBaker,
         isActivated,
         invalidatedAsof,
-        forkId
+        forkId,
+        scriptHash
       ) <> (AccountsRow.tupled, AccountsRow.unapply)
 
     /** Maps whole row to an option. Useful for outer joins. */
@@ -151,15 +155,17 @@ trait Tables {
           Rep.Some(isBaker),
           Rep.Some(isActivated),
           invalidatedAsof,
-          Rep.Some(forkId)
+          Rep.Some(forkId),
+          scriptHash
         )
       ).shaped.<>(
         { r =>
           import r._;
           _1.map(
             _ =>
-              AccountsRow
-                .tupled((_1.get, _2.get, _3, _4, _5, _6.get, _7.get, _8, _9, _10, _11, _12.get, _13.get, _14, _15.get))
+              AccountsRow.tupled(
+                (_1.get, _2.get, _3, _4, _5, _6.get, _7.get, _8, _9, _10, _11, _12.get, _13.get, _14, _15.get, _16)
+              )
           )
         },
         (_: Any) => throw new Exception("Inserting into ? projection not supported.")
@@ -210,6 +216,9 @@ trait Tables {
 
     /** Database column fork_id SqlType(varchar) */
     val forkId: Rep[String] = column[String]("fork_id")
+
+    /** Database column script_hash SqlType(varchar), Default(None) */
+    val scriptHash: Rep[Option[String]] = column[Option[String]]("script_hash", O.Default(None))
 
     /** Primary key of Accounts (database name accounts_pkey) */
     val pk = primaryKey("accounts_pkey", (accountId, forkId))

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseConversions.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseConversions.scala
@@ -16,6 +16,7 @@ import tech.cryptonomic.conseil.common.tezos.{Fork, Tables, TezosOptics}
 import tech.cryptonomic.conseil.common.util.Conversion
 
 import scala.util.Try
+import tech.cryptonomic.conseil.indexer.tezos.michelson.contracts.SmartContracts
 
 private[tezos] object TezosDatabaseConversions extends LazyLogging {
 
@@ -119,7 +120,8 @@ private[tezos] object TezosDatabaseConversions extends LazyLogging {
               delegateValue = toDelegateValue(delegate),
               isBaker = isBaker.getOrElse(false),
               isActivated = isActivated.getOrElse(false),
-              forkId = Fork.mainForkId
+              forkId = Fork.mainForkId,
+              scriptHash = script.map(it => SmartContracts.hashMichelsonScript(it.code.expression))
             )
         }.toList
       }

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
@@ -175,7 +175,7 @@ object TezosDatabaseOperations extends LazyLogging {
 
     /* The interleaving of these operations would actually need a more sophisticated handling to be robust:
      * we're processing collections of blocks, therefore some operations handled "after" might be
-     * referring to something "happening before" or viceversa.
+     * referring to something "happening before" or viceversa. It's some form of dependency-graph problem.
      * E.g. you could find that a new origination creates a map with the same identifier of another previously
      * removed (is this allowed?).
      * Therefore the insert might fail on finding the old record id being there already, whereas the real sequence

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/SmartContracts.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/SmartContracts.scala
@@ -1,0 +1,91 @@
+package tech.cryptonomic.conseil.indexer.tezos.michelson.contracts
+
+import java.nio.charset.StandardCharsets
+import scorex.util.encode.{Base16 => Hex}
+import org.bouncycastle.jcajce.provider.digest.Blake2s.Blake2s128
+import cats.data.Chain
+import cats.implicits._
+
+/** Generic utilities related to smart contracts on tezos */
+object SmartContracts {
+
+  val keywords = Set('parameter, 'storage, 'code)
+
+  /** Takes the content of a smart contract script and creates
+    * hex string via consistent hashing of the content.
+    *
+    * Allows to easily identify the contract type for different accounts,
+    * especially for the most common and standardized ones.
+    *
+    * @param script contained in the contract account, should be in michelson format
+    * @return the hash value as an hex-string
+    */
+  def hashMichelsonScript(script: String): String = {
+    /* 1. pre-process and get the three parts
+     * 2. join the parts with newline char and blake2s encode
+     * 3. hex-encode the result
+     */
+
+    val preProcessed = preProcessScript(script)
+    val sortedParts = preProcessed.getOrElse('parameter, "") ::
+          preProcessed.getOrElse('storage, "") ::
+          preProcessed.getOrElse('code, "") :: Nil
+    hashOf(sortedParts.mkString("\n"))
+  }
+
+  /** The actual hash encoder */
+  private val hashOf: String => String = in => {
+    val blake2s = new Blake2s128()
+    blake2s.update(in.getBytes(StandardCharsets.UTF_8))
+    Hex.encode(blake2s.digest())
+  }
+
+  /** Remove unwanted characters and create a uniform layout for the contract parts,
+    * i.e. code, parameters, storage.
+    * Makes sure that contract hashing is consistent.
+    *
+    * @param code the michelson code as a raw string
+    * @return the individual pieces, indexed by a symbol
+    */
+  private def preProcessScript(script: String): Map[Symbol, String] = {
+    /* We clean up whitespaces and comments, and index lines progressively by matching leading keywords.
+     * We fold over the lines, keeping track of state with a partial result map and the current keyword.
+     * As we fold the keyword to line pair is added to the map using cats apis.
+     * The monoidal operator |+| appends together entries under the same key of two maps, and returns
+     * the resulting combined map, which is quite useful for our case.
+     */
+
+    /* checks for a keyword */
+    def startingKeyword(line: String) = keywords.find(sym => line.startsWith(sym.name))
+
+    def stripTralingComments(line: String) = line.replaceFirst("""\#[\s\S]+$""", "").trim()
+
+    //clean up
+    val lines = script.linesIterator
+      .map(stripTralingComments)
+      .filter(_.nonEmpty)
+      .dropWhile(
+        startingKeyword(_).isEmpty
+      )
+
+    if (lines.isEmpty) Map.empty
+    else {
+      //the iterator can only be consumed once, so we sequence it into a lazy stream
+      val stream = lines.toStream
+      /* we prepare the initial state and then fold */
+      val keyword = startingKeyword(stream.head).getOrElse('impossible)
+      val initialState = keyword -> Map(keyword -> Chain.one(stream.head))
+      val (_, collected) =
+        stream.tail
+          .foldLeft(initialState) {
+            case ((kw, collector), line) =>
+              val nextKeyword = startingKeyword(line).getOrElse(kw)
+              val updated = collector |+| Map(nextKeyword -> Chain.one(line))
+              nextKeyword -> updated
+          }
+
+      collected.mapValues(_.mkString_(" "))
+    }
+  }
+
+}

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/SmartContracts.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/SmartContracts.scala
@@ -44,7 +44,7 @@ object SmartContracts {
     * i.e. code, parameters, storage.
     * Makes sure that contract hashing is consistent.
     *
-    * @param code the michelson code as a raw string
+    * @param script the michelson code as a raw string
     * @return the individual pieces, indexed by a symbol
     */
   private def preProcessScript(script: String): Map[Symbol, String] = {

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/TokenContracts.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/TokenContracts.scala
@@ -33,6 +33,7 @@ class TokenContracts(private val registry: Set[TokenContracts.TokenToolbox]) {
     *
     * @param token the id for a smart contract
     * @param diff the big map changes found in a transaction
+    * @param params the optional parameters passed in the transaction
     * @return a possible pair of an account and its new balance for a token associated to the passed-in contract
     */
   def readBalance(token: ContractId)(

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/SmartContractsTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/contracts/SmartContractsTest.scala
@@ -1,0 +1,77 @@
+package tech.cryptonomic.conseil.indexer.tezos.michelson.contracts
+
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
+
+/** Verifies general handling functions on micheline/michelson scripts */
+class SmartContractsTest extends AnyWordSpec with Matchers {
+
+  "The smart contract module" should {
+
+      "correctly hash a delegation contract script" in {
+        SmartContracts.hashMichelsonScript(babylonDelegation) shouldBe "a585489ffaee60d07077059539d5bfc8"
+      }
+
+      "generate a consistent hash independently of how the contract's parts are layed out" in {
+
+        val version1 =
+          """parameter (int :p) ;
+        |storage int ;
+        |code { UNPAIR ; SWAP ; DROP ; NIL operation ; PAIR }""".stripMargin
+
+        val version2 =
+          """storage int ;
+        |parameter (int :p) ;
+        |code { UNPAIR ; SWAP ; DROP ; NIL operation ; PAIR }""".stripMargin
+
+        val version3 =
+          """code { UNPAIR ; SWAP ; DROP ; NIL operation ; PAIR }
+        |parameter (int :p) ;
+        |storage int ;""".stripMargin
+
+        val hash1 = SmartContracts.hashMichelsonScript(version1)
+        val hash2 = SmartContracts.hashMichelsonScript(version2)
+        val hash3 = SmartContracts.hashMichelsonScript(version3)
+
+        hash1 shouldBe hash2
+        hash1 shouldBe hash3
+
+      }
+
+      "ignore script comments when generating a contract script hash" in {
+        val uncommented =
+          """parameter (int :p) ;
+        |storage int ;
+        |code { UNPAIR ; SWAP ; DROP ; NIL operation ; PAIR }""".stripMargin
+
+        val commented =
+          """parameter (int :p) ; # takes an int
+        |storage int ;            # defines an int storage
+        |code { UNPAIR ; SWAP ; DROP ; NIL operation ; PAIR } # puts the value in storage""".stripMargin
+
+        val uncommentedHash = SmartContracts.hashMichelsonScript(uncommented)
+        val commentedHash = SmartContracts.hashMichelsonScript(commented)
+
+        uncommentedHash shouldBe commentedHash
+      }
+    }
+
+  private val babylonDelegation =
+    """parameter (or (lambda %do unit (list operation)) (unit %default));
+storage key_hash;
+code { { { DUP ; CAR ; DIP { CDR } } } ;
+       IF_LEFT { PUSH mutez 0 ;
+                 AMOUNT ;
+                 { { COMPARE ; EQ } ; IF {} { { UNIT ; FAILWITH } } } ;
+                 { DIP { DUP } ; SWAP } ;
+                 IMPLICIT_ACCOUNT ;
+                 ADDRESS ;
+                 SENDER ;
+                 { { COMPARE ; EQ } ; IF {} { { UNIT ; FAILWITH } } } ;
+                 UNIT ;
+                 EXEC ;
+                 PAIR }
+               { DROP ;
+                 NIL operation ;
+                 PAIR } }"""
+}

--- a/sql/conseil.sql
+++ b/sql/conseil.sql
@@ -194,7 +194,8 @@ CREATE TABLE tezos.accounts_history (
     is_activated boolean NOT NULL DEFAULT false,
     is_active_baker boolean,
     invalidated_asof timestamp,
-    fork_id character varying NOT NULL
+    fork_id character varying NOT NULL,
+    script_hash character varying
 );
 
 CREATE INDEX ix_account_id ON tezos.accounts_history USING btree (account_id);

--- a/sql/conseil.sql
+++ b/sql/conseil.sql
@@ -175,6 +175,7 @@ CREATE TABLE tezos.accounts (
     is_activated boolean NOT NULL DEFAULT false,
     invalidated_asof timestamp,
     fork_id character varying NOT NULL,
+    script_hash character varying,
     PRIMARY KEY (account_id, fork_id)
 );
 


### PR DESCRIPTION
closes #920 


## required schema changes

We require to add an additional column to the `accounts` table, namely

```
    script_hash character varying
```