### PR TITLE
922-2 mark bakers after delegates are fetched

### DIFF
--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosTypes.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosTypes.scala
@@ -610,13 +610,14 @@ object TezosTypes {
   object Baking {
 
     //we'll move this to a proper chain configuration value later on
-    /** how big is a baker roll */
+    /** how big is a baker roll in tez */
     final val BakerRollsSize = BigDecimal.decimal(8000)
 
+    /** Starting from the staking balance, infers number of rolls for a given baker. */
     def computeRollsFromStakes(stakingBalance: PositiveBigNumber): Option[Int] =
       stakingBalance match {
         case PositiveDecimal(value) =>
-          Some((value quot BakerRollsSize).toIntExact)
+          Some((value quot (BakerRollsSize * BigDecimal(1000))).toIntExact)
         case InvalidPositiveDecimal(jsonString) =>
           None
       }

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosTypes.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosTypes.scala
@@ -617,7 +617,7 @@ object TezosTypes {
     def computeRollsFromStakes(stakingBalance: PositiveBigNumber): Option[Int] =
       stakingBalance match {
         case PositiveDecimal(value) =>
-          Some((value quot (BakerRollsSize * BigDecimal(1000))).toIntExact)
+          Some((value quot (BakerRollsSize * BigDecimal(1e6))).toIntExact) // taking scale of mutez into account
         case InvalidPositiveDecimal(jsonString) =>
           None
       }

--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/tezos/TezosTypesTest.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/tezos/TezosTypesTest.scala
@@ -72,4 +72,18 @@ class TezosTypesTest extends AnyWordSpec with Matchers with OptionValues with Ei
       }
     }
 
+  "The Baking object" should {
+      "compute rolls from staking balances" in {
+        val stakes = PositiveDecimal(BigDecimal.exact(21126133085692L))
+
+        Baking.computeRollsFromStakes(stakes).value shouldBe 2640
+      }
+
+      "compute no rolls if there's not enough staking balance" in {
+
+        val stakes = PositiveDecimal((Baking.BakerRollsSize * 1e6) - 1)
+
+        Baking.computeRollsFromStakes(stakes).value shouldBe 0
+      }
+    }
 }

--- a/conseil-lorre/src/main/resources/application.conf
+++ b/conseil-lorre/src/main/resources/application.conf
@@ -93,6 +93,8 @@ lorre {
     cycle-size: 4096 # size of the cycle, by default 4096
     fetch-size: 200 # amount of rights we fetch at once
     update-size: 16 # amount of rights we update after Lorre syncs
+    enabled: true # set to false to turn this feature off
+    enabled: ${?CONSEIL_LORRE_BLOCK_RIGHTS_FETCHING_ENABLED}
   }
 
 }

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/config/LorreConfiguration.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/config/LorreConfiguration.scala
@@ -31,7 +31,8 @@ final case class BakingAndEndorsingRights(
     cyclesToFetch: Int,
     cycleSize: Int,
     fetchSize: Int,
-    updateSize: Int
+    updateSize: Int,
+    enabled: Boolean
 )
 
 final case class BatchFetchConfiguration(

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
@@ -14,7 +14,6 @@ import tech.cryptonomic.conseil.common.generic.chain.DataTypes.{Query => _}
 import tech.cryptonomic.conseil.common.sql.CustomProfileExtension
 import tech.cryptonomic.conseil.common.tezos.Tables.{GovernanceRow, OriginatedAccountMapsRow}
 import tech.cryptonomic.conseil.common.tezos.TezosTypes.Fee.AverageFees
-import tech.cryptonomic.conseil.common.tezos.TezosTypes.Voting.BakerRolls
 import tech.cryptonomic.conseil.common.tezos.TezosTypes._
 import tech.cryptonomic.conseil.indexer.tezos.bigmaps.BigMapsOperations
 import tech.cryptonomic.conseil.indexer.tezos.michelson.contracts.{TNSContract, TokenContracts}
@@ -700,13 +699,11 @@ object TezosDatabaseOperations extends LazyLogging {
 
     val bakersIds =
       Tables.AccountsHistory
-        .filter(
-          account =>
-            account.invalidatedAsof.isEmpty
-              && account.isBaker === false
-              && (account.blockId inSet blockHashes.map(_.value))
+        .filter(account => account.invalidatedAsof.isEmpty && account.isBaker === false)
+        .join(
+          Tables.Bakers
+            .filter(baker => baker.invalidatedAsof.isEmpty && (baker.blockId inSet blockHashes.map(_.value)))
         )
-        .join(Tables.Bakers.filter(_.invalidatedAsof.isEmpty))
         .on(_.accountId === _.pkh)
         .map { case (accounts, bakers) => accounts.accountId }
 
@@ -724,13 +721,11 @@ object TezosDatabaseOperations extends LazyLogging {
 
     val bakersIds =
       Tables.Accounts
-        .filter(
-          account =>
-            account.invalidatedAsof.isEmpty
-              && account.isBaker === false
-              && (account.blockId inSet blockHashes.map(_.value))
+        .filter(account => account.invalidatedAsof.isEmpty && account.isBaker === false)
+        .join(
+          Tables.Bakers
+            .filter(baker => baker.invalidatedAsof.isEmpty && (baker.blockId inSet blockHashes.map(_.value)))
         )
-        .join(Tables.Bakers.filter(_.invalidatedAsof.isEmpty))
         .on(_.accountId === _.pkh)
         .map { case (accounts, bakers) => accounts.accountId }
 

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
@@ -711,8 +711,8 @@ object TezosDatabaseOperations extends LazyLogging {
       .filter(
         account => (account.accountId in bakersIds) && (account.blockId inSet blockHashes.map(_.value))
       )
-      .map(_.isBaker)
-      .update(true)
+      .map(account => (account.isBaker, account.isActiveBaker))
+      .update((true, Some(true)))
   }
 
   /** Updates accounts as bakers where applicable */

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
@@ -661,38 +661,6 @@ object TezosDatabaseOperations extends LazyLogging {
       )
       .transactionally
 
-  /** Updates accounts history with bakers */
-  def updateAccountsHistoryWithBakers(bakers: List[Voting.BakerRolls], block: Block): DBIO[Int] = {
-    logger.info(s"""Writing ${bakers.length} accounts history updates to the DB...""")
-    val bakersIdStrings = bakers.map(_.pkh.value)
-    Tables.AccountsHistory
-      .filter(
-        ahs =>
-          ahs.invalidatedAsof.isEmpty
-            && ahs.isBaker === false
-            && ahs.blockId === block.data.hash.value
-            && ahs.accountId.inSet(bakersIdStrings)
-      )
-      .map(_.isBaker)
-      .update(true)
-  }
-
-  /** Updates accounts with bakers */
-  def updateAccountsWithBakers(bakers: List[Voting.BakerRolls], block: Block): DBIO[Int] = {
-    logger.info(s"""Writing ${bakers.length} accounts updates to the DB...""")
-    val bakersIdStrings = bakers.map(_.pkh.value)
-    Tables.Accounts
-      .filter(
-        account =>
-          account.invalidatedAsof.isEmpty
-            && account.isBaker === false
-            && account.blockId === block.data.hash.value
-            && account.accountId.inSet(bakersIdStrings)
-      )
-      .map(_.isBaker)
-      .update(true)
-  }
-
   /** Updates accounts history entries as bakers where applicable */
   def updateAccountsHistoryWithBakers(blockHashes: Set[TezosBlockHash]): DBIO[Int] = {
     logger.info("Writing any baker accounts history updates to the DB...")

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosIndexer.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosIndexer.scala
@@ -66,9 +66,10 @@ class TezosIndexer private (
     with LorreProgressLogging {
 
   /** Schedules method for fetching baking rights */
-  system.scheduler.schedule(lorreConf.blockRightsFetching.initDelay, lorreConf.blockRightsFetching.interval)(
-    rightsProcessor.writeFutureRights()
-  )
+  if (lorreConf.blockRightsFetching.enabled)
+    system.scheduler.schedule(lorreConf.blockRightsFetching.initDelay, lorreConf.blockRightsFetching.interval)(
+      rightsProcessor.writeFutureRights()
+    )
 
   /** Tries to fetch blocks head to verify if connection with Tezos node was successfully established */
   @tailrec

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/processing/AccountsProcessor.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/processing/AccountsProcessor.scala
@@ -312,10 +312,13 @@ class AccountsProcessor(
     * table.
     */
   def markBakerAccounts(blockHashes: Set[TezosBlockHash])(implicit ec: ExecutionContext): Future[Done] =
-    indexedData.runQuery(TezosDb.updateAnyBakerAccountStored(blockHashes)).map {
+    indexedData.runQuery(TezosDb.updateAnyBakerAccountStored(blockHashes)).flatMap {
       case accounts :: history :: Nil =>
         logger.info(s"$accounts entries were identified and stored as bakers")
-        Done
+        Future.successful(Done)
+      case other =>
+        logger.error("The results from baker updates are inconsistent")
+        Future.failed(new IllegalStateException(s"Unexpected row counts for data updates: $other"))
     }
 
 }

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/processing/BakersProcessor.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/processing/BakersProcessor.scala
@@ -101,7 +101,7 @@ class BakersProcessor(
         .grouped(batchingConf.blockPageSize) //re-arranges the process batching
         .mapAsync(1)(
           taggedBakers =>
-            db.run(TezosDb.writeBakersAndCopyContracts(taggedBakers.toList))
+            db.run(TezosDb.writeBakers(taggedBakers.toList))
               .andThen(logWriteFailure)
         )
         .runFold((Monoid[Option[Int]].empty, Monoid[Option[Int]].empty)) {

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/processing/BlocksProcessor.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/processing/BlocksProcessor.scala
@@ -63,11 +63,10 @@ class BlocksProcessor(
     for {
       _ <- db.run(TezosDb.writeBlocksAndCheckpointAccounts(blocks, accountUpdates)) andThen logBlockOutcome
       _ <- tnsOperations.processNamesRegistrations(blocks).flatMap(db.run)
-      rollsData <- nodeOperator.getBakerRollsForBlocks(blocks)
-      rollsByBlockHash = rollsData.map { case (block, rolls) => block.data.hash -> rolls }.toMap
-      bakersCheckpoints <- accountsProcessor.processAccountsForBlocks(accountUpdates, rollsByBlockHash) // should this fail, we still recover data from the checkpoint
+      bakersCheckpoints <- accountsProcessor.processAccountsForBlocks(accountUpdates) // should this fail, we still recover data from the checkpoint
       _ <- bakersProcessor.processBakersForBlocks(bakersCheckpoints)
       _ <- bakersProcessor.updateBakersBalances(blocks)
+      rollsData <- nodeOperator.getBakerRollsForBlocks(blocks)
       _ <- processBlocksForGovernance(rollsData.toMap)
     } yield results.size
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -113,6 +113,9 @@ services:
       LORRE_RUNNER_PLATFORM: "tezos"
       LORRE_RUNNER_NETWORK: "carthagenet"
 
+      # Feature-Flag: set to false to disable the concurrent computation of future endorsement/baking rights
+      CONSEIL_LORRE_BLOCK_RIGHTS_FETCHING_ENABLED: "true"
+
       JVM_XMX: "4G"
     entrypoint: ["/root/wait-for.sh", "conseil-postgres:5432", "-t", "120", "--", "/root/entrypoint.sh", "conseil-lorre"]
     depends_on:


### PR DESCRIPTION
Should fix #922 

This version only match accounts for the bakers table after the whole blocks page is being processed, so that bakers from the same batch will figure when checking accounts.

In any case we look for any new delegate in each blocks page fetched. This allows to mark late delegate accounts that were previously originated but never used as delegates.

This PR introduce a correction for Rolls computation, due to previously incorrect scaling of rolls units of measures.

As a minor addition, we introduce a feature flag driven by the Env-var `CONSEIL_LORRE_BLOCK_RIGHTS_FETCHING_ENABLED`.
It allows to run the tezos indexer without computing future baking/endorsing rights, which comes useful for testing purposes only, to reduce noise when the feature under test is unrelated to future rights.