### PR TITLE
Only apply query predicates changes for fork-sensitive entities

### DIFF
--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataOperations.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataOperations.scala
@@ -16,8 +16,10 @@ object TezosDataOperations {
   case class OperationGroupResult(operation_group: Tables.OperationGroupsRow, operations: Seq[Tables.OperationsRow])
   case class AccountResult(account: Tables.AccountsRow)
 
+  final val InvalidationAwareAttribute = "invalidated_asof"
+
   /* this is the basic predicate that will remove any row which was fork-invalidated from results */
-  private val nonInvalidatedPredicate = Predicate("invalidated_asof", OperationType.isnull)
+  private val nonInvalidatedPredicate = Predicate(InvalidationAwareAttribute, OperationType.isnull)
 }
 
 class TezosDataOperations extends ApiDataOperations {

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinDataRoutesTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinDataRoutesTest.scala
@@ -36,7 +36,7 @@ class BitcoinDataRoutesTest
   blockAttributes.foreach(platformDiscoveryOperations.addAttribute(testEntityPath, _))
 
   private val conseilOps: BitcoinDataOperations = new BitcoinDataOperations {
-    override def queryWithPredicates(prefix: String, tableName: String, query: Query)(
+    override def queryWithPredicates(prefix: String, tableName: String, query: Query, hideForkInvalid: Boolean = false)(
         implicit ec: ExecutionContext
     ): Future[List[QueryResponse]] =
       Future.successful(responseAsMap)

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/ethereum/EthereumDataRoutesTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/ethereum/EthereumDataRoutesTest.scala
@@ -48,7 +48,7 @@ class EthereumDataRoutesTest
   blockAttributes.foreach(platformDiscoveryOperations.addAttribute(testEntityPath, _))
 
   private val conseilOps: EthereumDataOperations = new EthereumDataOperations("ethereum") {
-    override def queryWithPredicates(prefix: String, tableName: String, query: Query)(
+    override def queryWithPredicates(prefix: String, tableName: String, query: Query, hideForkInvalid: Boolean = false)(
         implicit ec: ExecutionContext
     ): Future[List[QueryResponse]] =
       Future.successful(responseAsMap)

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataOperationsTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataOperationsTest.scala
@@ -1531,8 +1531,8 @@ class TezosDataOperationsTest
             Tables.Blocks.baseTableRow.tableName,
             columns,
             predicates,
-            sortBy,
             List.empty,
+            sortBy,
             None,
             None,
             OutputType.json,
@@ -1565,8 +1565,8 @@ class TezosDataOperationsTest
             Tables.Blocks.baseTableRow.tableName,
             columns,
             predicates,
-            sortBy,
             List.empty,
+            sortBy,
             None,
             None,
             OutputType.json,
@@ -1599,8 +1599,8 @@ class TezosDataOperationsTest
             Tables.Blocks.baseTableRow.tableName,
             columns,
             predicates,
-            sortBy,
             List.empty,
+            sortBy,
             None,
             None,
             OutputType.json,
@@ -1633,8 +1633,8 @@ class TezosDataOperationsTest
             Tables.Blocks.baseTableRow.tableName,
             columns,
             predicates,
-            sortBy,
             List.empty,
+            sortBy,
             None,
             None,
             OutputType.json,
@@ -1673,8 +1673,8 @@ class TezosDataOperationsTest
             Tables.Blocks.baseTableRow.tableName,
             columns,
             predicates,
-            sortBy,
             List.empty,
+            sortBy,
             None,
             None,
             OutputType.json,
@@ -2000,7 +2000,7 @@ class TezosDataOperationsTest
         )
 
         val expectedQuery =
-          "SELECT SUM(medium) as sum_medium,low,high FROM tezos.fees WHERE true  AND invalidated_asof ISNULL AND medium = '4' IS false AND low BETWEEN '0' AND '1' GROUP BY low,high ORDER BY sum_medium desc LIMIT 3"
+          "SELECT SUM(medium) as sum_medium,low,high FROM tezos.fees WHERE true  AND medium = '4' IS false AND low BETWEEN '0' AND '1' GROUP BY low,high ORDER BY sum_medium desc LIMIT 3"
         val populateAndTest = for {
           _ <- Tables.Fees ++= feesTmp
           found <- sut.selectWithPredicates(
@@ -2008,8 +2008,8 @@ class TezosDataOperationsTest
             table = Tables.Fees.baseTableRow.tableName,
             columns = List(SimpleField("low"), SimpleField("medium"), SimpleField("high")),
             predicates = predicates,
-            ordering = List(QueryOrdering("sum_medium", OrderDirection.desc)),
             aggregation = aggregate,
+            ordering = List(QueryOrdering("sum_medium", OrderDirection.desc)),
             temporalPartition = None,
             snapshot = None,
             outputType = OutputType.sql,

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataRoutesTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataRoutesTest.scala
@@ -29,22 +29,11 @@ class TezosDataRoutesTest
     with TezosDataRoutesTest.Fixtures {
 
   private val conseilOps: TezosDataOperations = new TezosDataOperations {
-    override def queryWithPredicates(prefix: String, tableName: String, query: Query)(
+    override def queryWithPredicates(prefix: String, tableName: String, query: Query, hideForkInvalid: Boolean = false)(
         implicit ec: ExecutionContext
     ): Future[List[QueryResponse]] =
       Future.successful(responseAsMap)
   }
-
-  private val cfg = PlatformsConfiguration(
-    List(
-      TezosConfiguration(
-        "alphanet",
-        enabled = true,
-        TezosNodeConfiguration(protocol = "http", hostname = "localhost", port = 8732),
-        None
-      )
-    )
-  )
 
   private val testEntity = Entity("accounts", "Test Entity", 0)
   private val testNetworkPath = NetworkPath("alphanet", PlatformPath("tezos"))

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/generic/chain/DataOperations.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/generic/chain/DataOperations.scala
@@ -11,12 +11,13 @@ trait DataOperations {
 
   /** Interface method for querying with given predicates
     *
-    * @param  schema    name of the database schema
-    * @param  tableName name of the table which we query
-    * @param  query     query predicates and fields
+    * @param  schema            name of the database schema
+    * @param  tableName         name of the table which we query
+    * @param  query             query predicates and fields
+    * @param  hideForkInvalid should the query take care of hiding fork-invalidated entries?
     * @return query result as a map
     * */
-  def queryWithPredicates(schema: String, tableName: String, query: Query)(
+  def queryWithPredicates(schema: String, tableName: String, query: Query, hideForkInvalid: Boolean = false)(
       implicit ec: ExecutionContext
   ): Future[List[QueryResponse]]
 }

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/bigmaps/BigMapsConversions.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/bigmaps/BigMapsConversions.scala
@@ -47,14 +47,14 @@ object BigMapsConversions extends LazyLogging {
           )
         case (hash, _, BigMapAlloc(_, InvalidDecimal(json), _, _)) =>
           logger.warn(
-            "A big_map_diff allocation hasn't been converted to a BigMap on db, because the map id '{}' is not a valid number. The block containing the Origination operation is {}",
+            "Big Map Allocations: A big_map_diff allocation hasn't been converted to a BigMap on db, because the map id '{}' is not a valid number. The block containing the Origination operation is {}",
             json,
             hash.value
           )
           None
         case diff =>
           logger.warn(
-            "A big_map_diff result will be ignored by the allocation conversion to BigMap on db, because the diff action is not supported: {}",
+            "Big Map Allocations: A big_map_diff result will be ignored by the allocation conversion to BigMap on db, because the diff action is not supported: {}",
             from.get._2
           )
           None
@@ -86,14 +86,14 @@ object BigMapsConversions extends LazyLogging {
           )
         case (hash, _, BigMapUpdate(_, _, _, InvalidDecimal(json), _)) =>
           logger.warn(
-            "A big_map_diff update hasn't been converted to a BigMapContent on db, because the map id '{}' is not a valid number. The block containing the Transation operation is {}",
+            "Big Map Updates: A big_map_diff update hasn't been converted to a BigMapContent on db, because the map id '{}' is not a valid number. The block containing the Transation operation is {}",
             json,
             hash.value
           )
           None
         case diff =>
           logger.warn(
-            "A big_map_diff result will be ignored by the update conversion to BigMapContent on db, because the diff action is not supported: {}",
+            "Big Map Updates: A big_map_diff result will be ignored by the update conversion to BigMapContent on db, because the diff action is not supported: {}",
             from.get._2
           )
           None
@@ -116,7 +116,7 @@ object BigMapsConversions extends LazyLogging {
           )
         case (hash, ids, BigMapAlloc(_, InvalidDecimal(json), _, _)) =>
           logger.warn(
-            "A big_map_diff allocation hasn't been converted to a relation for OriginatedAccounts to BigMap on db, because the map id '{}' is not a valid number. The block containing the Transation operation is {}, involving accounts {}",
+            "Big Map Origin: A big_map_diff allocation hasn't been converted to a relation for OriginatedAccounts to BigMap on db, because the map id '{}' is not a valid number. The block containing the Transation operation is {}, involving accounts {}",
             json,
             ids.mkString(", "),
             hash.value
@@ -124,7 +124,7 @@ object BigMapsConversions extends LazyLogging {
           List.empty
         case diff =>
           logger.warn(
-            "A big_map_diff result will be ignored and not be converted to a relation for OriginatedAccounts to BigMap on db, because the diff action is not supported: {}",
+            "Big Map Origin: A big_map_diff result will be ignored and not be converted to a relation for OriginatedAccounts to BigMap on db, because the diff action is not supported: {}",
             from.get._2
           )
           List.empty


### PR DESCRIPTION
Fixes #934 

The fix enumerates the entities that are impacted by forks at the ApiOperation level and only applies additional processing on top of the query for those.