### PR TITLE
951 - Remove duplicates in operation results balance updates if part of the operation already

### DIFF
--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosTypes.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosTypes.scala
@@ -3,6 +3,7 @@ package tech.cryptonomic.conseil.common.tezos
 import java.time.{Instant, ZonedDateTime}
 import scala.util.Try
 import cats.Functor
+import cats.syntax.functor._
 
 /**
   * Classes used for deserializing Tezos node RPC results.
@@ -484,7 +485,10 @@ object TezosTypes {
   ) {
     val asTuple = (ref.hash, ref.level, ref.timestamp, ref.cycle, ref.period, content)
 
-    /** Helper method for updating content of the class */
+    /** Helper method for updating content of the class
+      *
+      */
+    @deprecated("Please use the cats.Functor syntax to call .as(newContent)")
     def updateContent[A](newContent: A): BlockTagged[A] = this.copy(content = newContent)
   }
 

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/Balances.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/Balances.scala
@@ -30,6 +30,7 @@ object SymbolSourceLabels {
 object OperationBalances {
 
   import SymbolSourceLabels._
+  import cats.implicits._
 
   //single polymorphic instance
   implicit def opsBalanceUpdatesGetter[OP <: Operation] =
@@ -37,24 +38,26 @@ object OperationBalances {
       case b: BlockTagged[OP] =>
         b.content match {
           case e: Endorsement =>
-            Map(b.updateContent(OPERATION_SOURCE) -> e.metadata.balance_updates)
+            Map(b.as(OPERATION_SOURCE) -> e.metadata.balance_updates)
           case nr: SeedNonceRevelation =>
-            Map(b.updateContent(OPERATION_SOURCE) -> nr.metadata.balance_updates)
+            Map(b.as(OPERATION_SOURCE) -> nr.metadata.balance_updates)
           case aa: ActivateAccount =>
-            Map(b.updateContent(OPERATION_SOURCE) -> aa.metadata.balance_updates)
+            Map(b.as(OPERATION_SOURCE) -> aa.metadata.balance_updates)
           case r: Reveal =>
-            Map(b.updateContent(OPERATION_SOURCE) -> r.metadata.balance_updates)
+            Map(b.as(OPERATION_SOURCE) -> r.metadata.balance_updates)
           case t: Transaction =>
             Map(
-              b.updateContent(OPERATION_SOURCE) -> t.metadata.balance_updates,
-              b.updateContent(OPERATION_RESULT_SOURCE) -> t.metadata.operation_result.balance_updates
+              b.as(OPERATION_SOURCE) -> t.metadata.balance_updates,
+              b.as(OPERATION_RESULT_SOURCE) -> t.metadata.operation_result.balance_updates
                     .getOrElse(List.empty)
+                    .filterNot(t.metadata.balance_updates.toSet)
             )
           case o: Origination =>
             Map(
-              b.updateContent(OPERATION_SOURCE) -> o.metadata.balance_updates,
-              b.updateContent(OPERATION_RESULT_SOURCE) -> o.metadata.operation_result.balance_updates
+              b.as(OPERATION_SOURCE) -> o.metadata.balance_updates,
+              b.as(OPERATION_RESULT_SOURCE) -> o.metadata.operation_result.balance_updates
                     .getOrElse(List.empty)
+                    .filterNot(o.metadata.balance_updates.toSet)
             )
           case _ =>
             Map.empty


### PR DESCRIPTION
Fixes #951 

CAVEAT: We might want to reconsider if keeping duplicates has some specific meaning and we don't want to remove 'em.