### PR TITLE
Fix for docker logging issue

### DIFF
--- a/conseil-api/src/main/resources/application.conf
+++ b/conseil-api/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 include "metadata.conf"
-
+include "logging.conf"
 conseil {
   hostname: "0.0.0.0"
   hostname: ${?CONSEIL_API_HOSTNAME}

--- a/conseil-api/src/main/resources/logging.conf
+++ b/conseil-api/src/main/resources/logging.conf
@@ -1,15 +1,17 @@
-muted: false
-loggers: [
-    {
-        name: "com.base22",
-        muted: true
-    },
-    {
-        name: "slick",
-        level: "INFO"
-    }
-    {
-        name: "com.zaxxer.hikari"
-        level: "INFO"
-    }
-]
+logging: {
+    muted: false
+    loggers: [
+        {
+            name: "com.base22",
+            muted: true
+        },
+        {
+            name: "slick",
+            level: "INFO"
+        }
+        {
+            name: "com.zaxxer.hikari"
+            level: "INFO"
+        }
+    ]
+}

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/io/Logging.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/io/Logging.scala
@@ -31,15 +31,30 @@ object Logging {
     val showConfig =
       userProvidedPath.fold("scanning resources for logging.conf files")(conf => s"using provided file at $conf")
     info(s"Initializing Conseil logging from configuration: $showConfig...")
-    pureconfig
-      .loadConfig[Config](userProvidedPath getOrElse resourcePath)
-      .fold(
-        failures => {
-          error("I can't load the logging configuration")
-          failures.toList.foreach(fail => error(s"${fail.description} ${fail.location.getOrElse("")}"))
-        },
-        configure
-      )
+
+    userProvidedPath match {
+      case Some(value) =>
+        pureconfig
+          .loadConfig[Config](value, "logging")
+          .fold(
+            failures => {
+              error("I can't load the logging configuration from path")
+              failures.toList.foreach(fail => error(s"${fail.description} ${fail.location.getOrElse("")}"))
+            },
+            configure
+          )
+      case None =>
+        pureconfig
+          .loadConfig[Config]("logging")
+          .fold(
+            failures => {
+              error("I can't load the logging configuration")
+              failures.toList.foreach(fail => error(s"${fail.description} ${fail.location.getOrElse("")}"))
+            },
+            configure
+          )
+    }
+
     info("Conseil logging configuration done")
   }
 

--- a/conseil-lorre/src/main/resources/application.conf
+++ b/conseil-lorre/src/main/resources/application.conf
@@ -1,3 +1,5 @@
+include "logging.conf"
+
 lorre {
   sleep-interval: 5 s
   bootup-retry-interval: 10 s

--- a/conseil-lorre/src/main/resources/logging.conf
+++ b/conseil-lorre/src/main/resources/logging.conf
@@ -1,47 +1,49 @@
-muted: false
-loggers: [
-    {
-        name: "com.base22",
-        muted: true
-    },
-    {
-        name: "slick",
-        level: "INFO"
-    },
-    {
-        name: "com.zaxxer.hikari",
-        level: "INFO"
-    },
-    {
-        name: "tech.cryptonomic.conseil.common",
-        level: "INFO"
-    },
-    {
-        name: "tech.cryptonomic.conseil.indexer",
-        level: "INFO"
-    },
-    {
-        name: "RightsFetcher",
-        level: "INFO"
-    },
-    {
-        name: "RightsUpdater",
-        level: "INFO"
-    },
-    {
-        # we don't provide a fallback level, hence this will log only if the env level is set
-        name: "tech.cryptonomic.conseil.indexer.tezos.bigmaps.BigMapsOperations",
-        from-env: "LORRE_BIG_MAPS_LOG_LEVEL"
-    },
-    {
-        name: "tech.cryptonomic.conseil.indexer.tezos.michelson.contracts.TNSContracts",
-        from-env: "LORRE_TNS_LOG_LEVEL",
-        level: "INFO"
-    },
-    {
-        #  get extra info from the akka-streamed async calls to the node, if trace-calls is enabled on the node conf.
-        # change the level of the root logger handler accordingly to see the output (i.e. add outputLevel: "DEBUG")
-        name: "tech.cryptonomic.conseil.indexer.tezos.node-rpc.batch",
-        level: "DEBUG"
-    }
-]
+logging: {
+    muted: false
+    loggers: [
+        {
+            name: "com.base22",
+            muted: true
+        },
+        {
+            name: "slick",
+            level: "INFO"
+        },
+        {
+            name: "com.zaxxer.hikari",
+            level: "INFO"
+        },
+        {
+            name: "tech.cryptonomic.conseil.common",
+            level: "INFO"
+        },
+        {
+            name: "tech.cryptonomic.conseil.indexer",
+            level: "INFO"
+        },
+        {
+            name: "RightsFetcher",
+            level: "INFO"
+        },
+        {
+            name: "RightsUpdater",
+            level: "INFO"
+        },
+        {
+            # we don't provide a fallback level, hence this will log only if the env level is set
+            name: "tech.cryptonomic.conseil.indexer.tezos.bigmaps.BigMapsOperations",
+            from-env: "LORRE_BIG_MAPS_LOG_LEVEL"
+        },
+        {
+            name: "tech.cryptonomic.conseil.indexer.tezos.michelson.contracts.TNSContracts",
+            from-env: "LORRE_TNS_LOG_LEVEL",
+            level: "INFO"
+        },
+        {
+            #  get extra info from the akka-streamed async calls to the node, if trace-calls is enabled on the node conf.
+            # change the level of the root logger handler accordingly to see the output (i.e. add outputLevel: "DEBUG")
+            name: "tech.cryptonomic.conseil.indexer.tezos.node-rpc.batch",
+            level: "DEBUG"
+        }
+    ]
+}


### PR DESCRIPTION
Made a fix for docker logging issue. Problem was that in the jar generated by assembly resource for `logging.conf` could not be found, so instead I made a logging conf part of the regular config - included it in the `application.conf`. It still can be overriden by file, but now will be in an object `logging`.