### PR TITLE
Protocol 008 Edonet support

### DIFF
--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/ethereum/Tables.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/ethereum/Tables.scala
@@ -432,8 +432,8 @@ trait Tables {
   )
 
   /** GetResult implicit for fetching ReceiptsRow objects using plain SQL queries */
-  implicit def GetResultReceiptsRow(implicit e0: GR[String], e1: GR[Int], e2: GR[Option[String]]): GR[ReceiptsRow] = GR {
-    prs =>
+  implicit def GetResultReceiptsRow(implicit e0: GR[String], e1: GR[Int], e2: GR[Option[String]]): GR[ReceiptsRow] =
+    GR { prs =>
       import prs._
       ReceiptsRow.tupled(
         (
@@ -449,7 +449,7 @@ trait Tables {
           <<?[String]
         )
       )
-  }
+    }
 
   /** Table description of table receipts. Objects of this class serve as prototypes for rows in queries. */
   class Receipts(_tableTag: Tag) extends profile.api.Table[ReceiptsRow](_tableTag, Some("ethereum"), "receipts") {

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/ethereum/domain/Bytecode.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/ethereum/domain/Bytecode.scala
@@ -57,9 +57,9 @@ case class Bytecode(value: String) {
 
   /**
     * Check if bytecode implements a particular function.
-    * Every function call is represented in the bytecode 
+    * Every function call is represented in the bytecode
     * by PUSH4 command with 4 bytes signature.
-    * 
+    *
     * example:
     * ...
     * DUP1

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosOptics.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosOptics.scala
@@ -283,6 +283,17 @@ object TezosOptics {
         )
 
     //Note, cycle 0 starts at the level 2 block
+    def extractVotingPeriodKind(block: BlockMetadata): Option[VotingPeriod.Kind] =
+      discardGenesis(block)
+        .flatMap(
+          b =>
+            b.voting_period_kind
+              .orElse(
+                b.voting_period_info.map(_.voting_period.kind)
+              )
+        )
+
+    //Note, cycle 0 starts at the level 2 block
     def extractVotingPeriodPosition(block: BlockMetadata): Option[Int] =
       discardGenesis(block)
         .flatMap(

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosOptics.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosOptics.scala
@@ -196,22 +196,103 @@ object TezosOptics {
     //Note, cycle 0 starts at the level 2 block
     def extractCycle(block: Block): Option[Int] =
       discardGenesis(block.data.metadata) //this returns an Option[BlockHeaderMetadata]
-        .map(_.level.cycle) //this is Option[Int]
+        .flatMap(
+          b =>
+            b.level
+              .map(_.cycle)
+              .orElse(b.level_info.map(_.cycle))
+        ) //this is Option[Int]
 
     //Note, cycle 0 starts at the level 2 block
     def extractCycle(block: BlockData): Option[Int] =
       discardGenesis(block.metadata) //this returns an Option[BlockHeaderMetadata]
-        .map(_.level.cycle) //this is Option[Int]
+        .flatMap(
+          b =>
+            b.level
+              .map(_.cycle)
+              .orElse(b.level_info.map(_.cycle))
+        ) //this is Option[Int]
+
+    //Note, cycle 0 starts at the level 2 block
+    def extractCycle(block: BlockMetadata): Option[Int] =
+      discardGenesis(block) //this returns an Option[BlockHeaderMetadata]
+        .flatMap(
+          b =>
+            b.level
+              .map(_.cycle)
+              .orElse(b.level_info.map(_.cycle))
+        ) //this is Option[Int]
 
     //Note, cycle 0 starts at the level 2 block
     def extractCyclePosition(block: BlockMetadata): Option[Int] =
       discardGenesis(block) //this returns an Option[BlockHeaderMetadata]
-        .map(_.level.cycle_position) //this is Option[Int]
+        .flatMap(
+          b =>
+            b.level
+              .map(_.cycle_position)
+              .orElse(b.level_info.map(_.cycle_position))
+        ) //this is Option[Int]
 
     //Note, cycle 0 starts at the level 2 block
     def extractPeriod(block: BlockMetadata): Option[Int] =
       discardGenesis(block)
-        .map(_.level.voting_period)
+        .flatMap(
+          b =>
+            b.level
+              .map(_.voting_period)
+              .orElse(
+                b.voting_period_info
+                  .map(_.voting_period.index)
+              )
+        )
+
+    //Note, cycle 0 starts at the level 2 block
+    def extractLevel(block: BlockMetadata): Option[BlockLevel] =
+      discardGenesis(block)
+        .flatMap(
+          b =>
+            b.level
+              .map(_.level)
+              .orElse(
+                b.level_info.map(_.level)
+              )
+        )
+
+    //Note, cycle 0 starts at the level 2 block
+    def extractLevelPosition(block: BlockMetadata): Option[Int] =
+      discardGenesis(block)
+        .flatMap(
+          b =>
+            b.level
+              .map(_.level_position)
+              .orElse(
+                b.level_info.map(_.level_position)
+              )
+        )
+
+    //Note, cycle 0 starts at the level 2 block
+    def extractVotingPeriod(block: BlockMetadata): Option[Int] =
+      discardGenesis(block)
+        .flatMap(
+          b =>
+            b.level
+              .map(_.voting_period)
+              .orElse(
+                b.voting_period_info.map(_.voting_period.index)
+              )
+        )
+
+    //Note, cycle 0 starts at the level 2 block
+    def extractVotingPeriodPosition(block: BlockMetadata): Option[Int] =
+      discardGenesis(block)
+        .flatMap(
+          b =>
+            b.level
+              .map(_.voting_period_position)
+              .orElse(
+                b.voting_period_info.map(_.position)
+              )
+        )
   }
 
   /** Provides optics to navigate across operations data structures */

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosTypes.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosTypes.scala
@@ -93,8 +93,10 @@ object TezosTypes {
       nonce_hash: Option[NonceHash],
       consumed_gas: PositiveBigNumber,
       baker: PublicKeyHash,
-      voting_period_kind: VotingPeriod.Kind,
-      level: BlockHeaderMetadataLevel
+      voting_period_kind: Option[VotingPeriod.Kind],
+      voting_period_info: Option[VotingPeriodInfo],
+      level: Option[BlockHeaderMetadataLevel],
+      level_info: Option[BlockHeaderMetadataLevelInfo]
   ) extends BlockMetadata
 
   final case class BlockHeaderMetadataLevel(
@@ -105,6 +107,26 @@ object TezosTypes {
       voting_period: Int,
       voting_period_position: Int,
       expected_commitment: Boolean
+  )
+
+  final case class BlockHeaderMetadataLevelInfo(
+      level: BlockLevel,
+      level_position: Int,
+      cycle: Int,
+      cycle_position: Int,
+      expected_commitment: Boolean
+  )
+
+  final case class VotingPeriodInfo(
+      voting_period: VotingPeriodObject,
+      position: Int,
+      remaining: Int
+  )
+
+  final case class VotingPeriodObject(
+      index: Int,
+      kind: VotingPeriod.Kind,
+      start_position: Int
   )
 
   /** only accepts standard block metadata, discarding the genesis metadata */

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/VotingOperations.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/VotingOperations.scala
@@ -21,8 +21,10 @@ object VotingOperations {
 
   /* Used to classify blocks by voting periods via metadata */
   private def votingPeriodIn(accept: VotingPeriod.ValueSet, metadata: BlockMetadata): Boolean = metadata match {
-    case BlockHeaderMetadata(_, _, _, _, voting_period_kind, _) =>
+    case BlockHeaderMetadata(_, _, _, _, Some(voting_period_kind), _, _, _) =>
       accept(voting_period_kind)
+    case BlockHeaderMetadata(_, _, _, _, _, Some(voting_period_info), _, _) =>
+      accept(voting_period_info.voting_period.kind)
     case GenesisMetadata =>
       false
   }

--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/tezos/TezosOpticsTest.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/tezos/TezosOpticsTest.scala
@@ -30,10 +30,12 @@ class TezosOpticsTest extends ConseilSpec {
           metadata = BlockHeaderMetadata(
             balance_updates = List.empty,
             baker = PublicKeyHash("_"),
-            voting_period_kind = defaultVotingPeriod,
+            voting_period_kind = Some(defaultVotingPeriod),
+            voting_period_info = None,
             nonce_hash = None,
             consumed_gas = PositiveDecimal(0),
-            level = BlockHeaderMetadataLevel(0, 0, 0, 0, 0, 0, expected_commitment = false)
+            level = Some(BlockHeaderMetadataLevel(0, 0, 0, 0, 0, 0, expected_commitment = false)),
+            level_info = None
           )
         )
       val blockVotes = CurrentVotes.empty

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/Balances.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/Balances.scala
@@ -80,7 +80,7 @@ object BlockBalances {
       Map(
         BlockTagged.fromBlockData(data, BLOCK_SOURCE) -> (data.metadata match {
               case GenesisMetadata => List.empty
-              case BlockHeaderMetadata(balance_updates, _, _, _, _, _) => balance_updates
+              case BlockHeaderMetadata(balance_updates, _, _, _, _, _, _, _) => balance_updates
             })
       )
   )

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseConversions.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseConversions.scala
@@ -902,7 +902,7 @@ private[tezos] object TezosDatabaseConversions {
 
         Tables.GovernanceRow(
           votingPeriod = extractVotingPeriod(metadata).get,
-          votingPeriodKind = metadata.voting_period_kind.toString, //TODO
+          votingPeriodKind = extractVotingPeriodKind(metadata).get.toString,
           cycle = extractCycle(metadata),
           level = extractLevel(metadata),
           blockHash = from.hash.value,

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseConversions.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseConversions.scala
@@ -195,7 +195,7 @@ private[tezos] object TezosDatabaseConversions {
         chainId = from.data.chain_id,
         hash = from.data.hash.value,
         operationsHash = header.operations_hash,
-        periodKind = metadata.map(_.voting_period_kind.toString),
+        periodKind = metadata.flatMap(extractVotingPeriodKind).map(_.toString),
         currentExpectedQuorum = expectedQuorum,
         activeProposal = proposal.map(_.id),
         baker = metadata.map(_.baker.value),

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosJsonDecoders.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosJsonDecoders.scala
@@ -157,6 +157,9 @@ private[tezos] object TezosJsonDecoders {
       val genesisMetadataDecoder: Decoder[GenesisMetadata.type] = deriveConfiguredDecoder
       implicit val metadataLevelDecoder: Decoder[BlockHeaderMetadataLevel] = deriveConfiguredDecoder
       val blockMetadataDecoder: Decoder[BlockHeaderMetadata] = deriveConfiguredDecoder
+      implicit val votingPeriodInfoDecoder: Decoder[VotingPeriodInfo] = deriveConfiguredDecoder
+      implicit val votingPeriodObjectDecoder: Decoder[VotingPeriodObject] = deriveConfiguredDecoder
+      implicit val blockHeaderMetadataLevelInfoDecoder: Decoder[BlockHeaderMetadataLevelInfo] = deriveConfiguredDecoder
       implicit val metadataDecoder: Decoder[BlockMetadata] = blockMetadataDecoder.widen or genesisMetadataDecoder.widen
       implicit val headerDecoder: Decoder[BlockHeader] = deriveConfiguredDecoder
       implicit val mainDecoder: Decoder[BlockData] = deriveConfiguredDecoder //remember to add ISO-control filtering

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/processing/BakingAndEndorsingRightsProcessor.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/processing/BakingAndEndorsingRightsProcessor.scala
@@ -1,13 +1,12 @@
 package tech.cryptonomic.conseil.indexer.tezos.processing
 
 import tech.cryptonomic.conseil.common.io.Logging.ConseilLogger
-import tech.cryptonomic.conseil.common.tezos.TezosOptics
+import tech.cryptonomic.conseil.common.tezos.{TezosOptics, TezosTypes}
 import tech.cryptonomic.conseil.common.tezos.TezosTypes.{
   Block,
   BlockHeaderMetadata,
   Endorsement,
   EndorsingRights,
-  GenesisMetadata,
   RightsFetchKey
 }
 import tech.cryptonomic.conseil.indexer.config
@@ -22,6 +21,7 @@ import akka.stream.scaladsl.Source
 import akka.stream.scaladsl.Sink
 import akka.stream.ActorMaterializer
 import slick.jdbc.PostgresProfile.api._
+
 import scala.concurrent.Future
 
 /** Takes care of fetching and processing rights to bake/endorse blocks,
@@ -50,10 +50,15 @@ class BakingAndEndorsingRightsProcessor(
     val blockHashesWithCycleAndGovernancePeriod = fetchingResults.map {
       case (Block(data, _, _), _) => {
         data.metadata match {
-          case GenesisMetadata =>
+          case TezosTypes.GenesisMetadata =>
             RightsFetchKey(data.hash, None, None)
-          case BlockHeaderMetadata(_, _, _, _, _, level) =>
-            RightsFetchKey(data.hash, Some(level.cycle), Some(level.voting_period))
+          case BlockHeaderMetadata(_, _, _, _, _, voting_period_info, level, level_info) =>
+            RightsFetchKey(
+              data.hash,
+              level.map(_.cycle).orElse(level_info.map(_.cycle)),
+              level.map(_.voting_period).orElse(voting_period_info.map(_.voting_period.index))
+            )
+
         }
       }
     }

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseConversionsTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseConversionsTest.scala
@@ -111,7 +111,7 @@ class TezosDatabaseConversionsTest
           'operationsHash (header.operations_hash),
           'currentExpectedQuorum (expectedQuorum),
           'activeProposal (proposal.map(_.id)),
-          'periodKind (metadata.map(_.voting_period_kind.toString)),
+          'periodKind (metadata.flatMap(_.voting_period_kind).map(_.toString)),
           'baker (metadata.map(_.baker.value)),
           'metaLevel (metadata.flatMap(_.level.map(_.level))),
           'metaLevelPosition (metadata.flatMap(_.level.map(_.level_position))),

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseConversionsTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseConversionsTest.scala
@@ -113,12 +113,12 @@ class TezosDatabaseConversionsTest
           'activeProposal (proposal.map(_.id)),
           'periodKind (metadata.map(_.voting_period_kind.toString)),
           'baker (metadata.map(_.baker.value)),
-          'metaLevel (metadata.map(_.level.level)),
-          'metaLevelPosition (metadata.map(_.level.level_position)),
-          'metaCycle (metadata.map(_.level.cycle)),
-          'metaCyclePosition (metadata.map(_.level.cycle_position)),
-          'metaVotingPeriod (metadata.map(_.level.voting_period)),
-          'metaVotingPeriodPosition (metadata.map(_.level.voting_period_position)),
+          'metaLevel (metadata.flatMap(_.level.map(_.level))),
+          'metaLevelPosition (metadata.flatMap(_.level.map(_.level_position))),
+          'metaCycle (metadata.flatMap(_.level.map(_.cycle))),
+          'metaCyclePosition (metadata.flatMap(_.level.map(_.cycle_position))),
+          'metaVotingPeriod (metadata.flatMap(_.level.map(_.voting_period))),
+          'metaVotingPeriodPosition (metadata.flatMap(_.level.map(_.voting_period_position))),
           'priority (block.data.header.priority),
           'forkId (Fork.mainForkId)
         )

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperationsTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperationsTest.scala
@@ -108,7 +108,7 @@ class TezosDatabaseOperationsTest
               row.chainId shouldEqual block.data.chain_id
               row.hash shouldEqual block.data.hash.value
               row.operationsHash shouldEqual block.data.header.operations_hash
-              row.periodKind shouldEqual metadata.map(_.voting_period_kind.toString)
+              row.periodKind shouldEqual metadata.flatMap(_.voting_period_kind).map(_.toString)
               row.currentExpectedQuorum shouldEqual block.votes.quorum
               row.activeProposal shouldEqual block.votes.active.map(_.id)
               row.baker shouldEqual metadata.map(_.baker.value)

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperationsTestFixtures.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperationsTestFixtures.scala
@@ -157,10 +157,12 @@ trait TezosDatabaseOperationsTestFixtures extends RandomGenerationKit {
               BlockHeaderMetadata(
                 balance_updates = List.empty,
                 baker = PublicKeyHash(generateHash(10)),
-                voting_period_kind = VotingPeriod.proposal,
+                voting_period_kind = Some(VotingPeriod.proposal),
                 nonce_hash = Some(NonceHash(generateHash(10))),
                 consumed_gas = PositiveDecimal(0),
-                level = randomMetadataLevel()
+                level = Some(randomMetadataLevel()),
+                voting_period_info = None,
+                level_info = None
               )
         ),
         operationGroups = List.empty,


### PR DESCRIPTION
Changes for support of the new fields added in Edonet and keeping it backward compatible.

Main changes consist of making following fields optional as they are being deprecated:
- `metadata.level`
- `metadata.voting_period_kind`

in favour of new optional fields: 

- `metadata.level_info`
- `metadata.voting_period_info`

After investigation, rest of the changes should not affect Lorre.