### PR TITLE
Fix for configuration and reverting previous changes for issue when Lorre did not quit correctly

### DIFF
--- a/conseil-common/src/main/resources/reference.conf
+++ b/conseil-common/src/main/resources/reference.conf
@@ -207,6 +207,10 @@ akka {
     # give more room for async response in head-of-line blocking on the same connection or other slow responses
     response-entity-subscription-timeout: 60 seconds
   }
+
+  # fixes the issue when lorre does not quit after system.shutdown()
+  coordinated-shutdown.run-by-actor-system-terminate = off
+
 }
 
 # Custom libSodium settings

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosIndexer.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosIndexer.scala
@@ -238,7 +238,7 @@ class TezosIndexer private (
           accountResets => mainLoop(0, accountResets),
           error => {
             logger.error("Could not get the unprocessed events block levels for this chain network", error)
-            throw error
+            error
           }
         ),
       Duration.Inf

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val pureConfig = "0.10.2"
     val scopt = "4.0.0-RC2"
 
-    val akka = "2.6.3"
+    val akka = "2.6.11"
     val akkaHttp = "10.2.1"
     val akkaHttpJson = "1.35.2"
     val akkaHttpCors = "1.1.0"


### PR DESCRIPTION
Because in logging PR we updated akka version some things changed. System termination is working differently now, but with  adding one switch to config I've managed to change it. Also reverted previous changes.