### PR TITLE
Conseil timeouts fix

### DIFF
--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/directives/RecordingDirectives.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/directives/RecordingDirectives.scala
@@ -40,7 +40,9 @@ class RecordingDirectives(implicit concurrent: Concurrent[IO]) extends ConseilLo
         _ <- requestInfoMap.put(requestMap.updated(correlationId, value))
       } yield ()).unsafeRunSync()
 
-      requestMapModify(map => map.updated(correlationId, RequestValues.fromHttpRequestAndIp(request, ip, stringEntity)))(_ => ())
+      requestMapModify(
+        map => map.updated(correlationId, RequestValues.fromHttpRequestAndIp(request, ip, stringEntity))
+      )(_ => ())
         .unsafeRunSync()
 
       val response = BasicDirectives.mapResponse { resp =>
@@ -118,16 +120,15 @@ class RecordingDirectives(implicit concurrent: Concurrent[IO]) extends ConseilLo
     /** Extracts Request values from request context and ip address */
     def fromHttpRequestAndIp(request: HttpRequest, ip: RemoteAddress, stringEntity: String)(
         implicit materializer: Materializer
-    ): RequestValues = {
-        RequestValues(
-          httpMethod = request.method.value,
-          requestBody = stringEntity,
-          clientIp = ip.toOption.map(_.toString).getOrElse("unknown"),
-          path = request.uri.path.toString(),
-          apiVersion = if (request.uri.path.toString().startsWith("/v2")) "v2" else "v1",
-          apiKey = request.headers.find(_.is("apikey")).map(_.value()).getOrElse(""),
-          startTime = System.nanoTime()
-        )
-    }
+    ): RequestValues =
+      RequestValues(
+        httpMethod = request.method.value,
+        requestBody = stringEntity,
+        clientIp = ip.toOption.map(_.toString).getOrElse("unknown"),
+        path = request.uri.path.toString(),
+        apiVersion = if (request.uri.path.toString().startsWith("/v2")) "v2" else "v1",
+        apiKey = request.headers.find(_.is("apikey")).map(_.value()).getOrElse(""),
+        startTime = System.nanoTime()
+      )
   }
 }

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/metadata/MetadataService.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/metadata/MetadataService.scala
@@ -21,7 +21,11 @@ class MetadataService(
   private val platforms = transformation.overridePlatforms(config.getPlatforms(), shouldLog = false)
 
   private val networks = platforms.map { platform =>
-    platform.path -> transformation.overrideNetworks(platform.path, config.getNetworks(platform.name), shouldLog = false)
+    platform.path -> transformation.overrideNetworks(
+      platform.path,
+      config.getNetworks(platform.name),
+      shouldLog = false
+    )
   }.toMap
 
   private val entities = {
@@ -31,7 +35,8 @@ class MetadataService(
     networks.values.flatten
       .map(_.path)
       .map(
-        networkPath => networkPath -> transformation.overrideEntities(networkPath, futureEntities(networkPath), shouldLog = false)
+        networkPath =>
+          networkPath -> transformation.overrideEntities(networkPath, futureEntities(networkPath), shouldLog = false)
       )
       .toMap
   }
@@ -45,7 +50,10 @@ class MetadataService(
     val result = Future.traverse(entityPaths) { path =>
       platformDiscoveryOperations
         .getTableAttributes(path)
-        .map(attributes => path -> transformation.overrideAttributes(path, attributes.getOrElse(List.empty), shouldLog = false))
+        .map(
+          attributes =>
+            path -> transformation.overrideAttributes(path, attributes.getOrElse(List.empty), shouldLog = false)
+        )
     }
 
     Await.result(result.map(_.toMap), 10 seconds)

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/metadata/UnitTransformation.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/metadata/UnitTransformation.scala
@@ -18,7 +18,11 @@ class UnitTransformation(overrides: MetadataConfiguration) extends ConseilLogSup
   }
 
   // overrides networks
-  def overrideNetworks(platformPath: PlatformPath, networks: List[Network], shouldLog: Boolean = true): List[Network] = {
+  def overrideNetworks(
+      platformPath: PlatformPath,
+      networks: List[Network],
+      shouldLog: Boolean = true
+  ): List[Network] = {
     if (shouldLog) {
       logDifferences(networks.map(_.path), overrides.networks(platformPath).keys.toList)
     }

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/metadata/UnitTransformation.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/metadata/UnitTransformation.scala
@@ -10,14 +10,18 @@ import tech.cryptonomic.conseil.common.util.OptionUtil.when
 class UnitTransformation(overrides: MetadataConfiguration) extends ConseilLogSupport {
 
   // overrides platforms
-  def overridePlatforms(platforms: List[Platform]): List[Platform] = {
-    logDifferences(platforms.map(_.path), overrides.allPlatforms.keys.toList)
+  def overridePlatforms(platforms: List[Platform], shouldLog: Boolean = true): List[Platform] = {
+    if (shouldLog) {
+      logDifferences(platforms.map(_.path), overrides.allPlatforms.keys.toList)
+    }
     platforms.flatMap(platform => overridePlatform(platform, PlatformPath(platform.name)))
   }
 
   // overrides networks
-  def overrideNetworks(platformPath: PlatformPath, networks: List[Network]): List[Network] = {
-    logDifferences(networks.map(_.path), overrides.networks(platformPath).keys.toList)
+  def overrideNetworks(platformPath: PlatformPath, networks: List[Network], shouldLog: Boolean = true): List[Network] = {
+    if (shouldLog) {
+      logDifferences(networks.map(_.path), overrides.networks(platformPath).keys.toList)
+    }
     networks.flatMap(network => overrideNetwork(network, network.path))
   }
 

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/metadata/TransparentUnitTransformation.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/metadata/TransparentUnitTransformation.scala
@@ -7,12 +7,14 @@ import tech.cryptonomic.conseil.common.metadata.{EntityPath, NetworkPath, Platfo
 /* UnitTransformation implementation for test purposes. It overrides nothing. */
 object TransparentUnitTransformation extends UnitTransformation(MetadataConfiguration(Map.empty)) {
   override def overridePlatforms(
-      platforms: List[PlatformDiscoveryTypes.Platform]
+      platforms: List[PlatformDiscoveryTypes.Platform],
+      shouldLog: Boolean
   ): List[PlatformDiscoveryTypes.Platform] = platforms
 
   override def overrideNetworks(
       platformPath: PlatformPath,
-      networks: List[PlatformDiscoveryTypes.Network]
+      networks: List[PlatformDiscoveryTypes.Network],
+      shouldLog: Boolean
   ): List[PlatformDiscoveryTypes.Network] = networks
 
   override def overrideEntities(


### PR DESCRIPTION
Problem was that when i tried to extract entity to pass to the logs(query logs ot be exact) I did it with apparently really low timeout - 1 second. Simple changing increase of timeout wasn't always enough - sometimes it failed after 10x more requests than regularly. Therefore I've decided to use directive which extracts entity for me and just passed it to my recording directive. Multiple tests showed that I'm not able to crash Conseil after over 100x more requests than at the beginning.

Additionally I've removed spamming of the missing metadata logs for each API call - now it shows missing metadata only during the start of Conseil.