### PR TITLE
fixed micheline -> michelson conversion 

### DIFF
--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/parser/JsonParser.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/parser/JsonParser.scala
@@ -75,8 +75,8 @@ object JsonParser {
       annots: Option[List[String]] = None
   ) extends JsonExpression {
     private def reformatPairListsAsNestedPairs(expr: JsonExpression): JsonExpression = expr match {
-      case xx @ JsonType("pair", Some(_ :: _ :: Nil), _) =>
-        xx
+      case expr @ JsonType("pair", Some(_ :: _ :: Nil), _) =>
+        expr
       case JsonType("pair", Some(x :: y :: xs), annots) =>
         JsonType(
           "pair",
@@ -88,7 +88,7 @@ object JsonParser {
           ),
           annots
         )
-      case x => x
+      case idExpr => idExpr
     }
 
     override def toMichelsonExpression =

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/bigmaps/BigMapsOperationsTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/bigmaps/BigMapsOperationsTest.scala
@@ -7,7 +7,12 @@ import slick.jdbc.PostgresProfile.api._
 import tech.cryptonomic.conseil.common.sql.CustomProfileExtension
 import tech.cryptonomic.conseil.common.testkit.InMemoryDatabase
 import tech.cryptonomic.conseil.common.testkit.util.RandomSeed
-import tech.cryptonomic.conseil.common.tezos.Tables.{BigMapContentsRow, BigMapsRow, OriginatedAccountMapsRow, TokenBalancesRow}
+import tech.cryptonomic.conseil.common.tezos.Tables.{
+  BigMapContentsRow,
+  BigMapsRow,
+  OriginatedAccountMapsRow,
+  TokenBalancesRow
+}
 import tech.cryptonomic.conseil.common.tezos.{Fork, Tables, TezosOptics, TezosTypes}
 import tech.cryptonomic.conseil.common.tezos.TezosTypes._
 import tech.cryptonomic.conseil.indexer.tezos.michelson.contracts.TokenContracts

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/parser/JsonParserSpec.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/tezos/michelson/parser/JsonParserSpec.scala
@@ -740,4 +740,56 @@ class JsonParserSpec extends AnyFlatSpec with Matchers with LoggingTestSupport {
         )
       )
     }
+
+  it should "correctly transform pair list to nested pairs" in {
+      val json =
+        """{
+        |   "prim":"pair",
+        |   "args":[
+        |      {
+        |         "prim":"address",
+        |         "annots":[
+        |            "%contract"
+        |         ]
+        |      },
+        |      {
+        |         "prim":"string",
+        |         "annots":[
+        |            "%counterAsset"
+        |         ]
+        |      },
+        |      {
+        |         "prim":"nat",
+        |         "annots":[
+        |            "%decimals"
+        |         ]
+        |      }
+        |   ]
+        |}""".stripMargin
+
+      //pair ( address %contract ) ( pair ( string %counterAsset ) ( nat %decimals ) )
+
+      parse[MichelsonExpression](json) should equal(
+        Right(
+          MichelsonType(
+            "pair",
+            List(
+              MichelsonType(
+                "address",
+                List.empty,
+                List("%contract")
+              ),
+              MichelsonType(
+                "pair",
+                List(
+                  MichelsonType("string", List.empty, List("%counterAsset")),
+                  MichelsonType("nat", List.empty, List("%decimals"))
+                )
+              )
+            )
+          )
+        )
+      )
+    }
+
 }


### PR DESCRIPTION
Problem was that in edonet protocol update pairs could represent lists. Our parser handled it, but it did not nest them after conversion.
Simplified example: `{"prim": "pair", "args":[1,2,3]}` we represented as `pair (1 2 3)`, which was incorrect. 
Correct result should look like `pair (1  pair (2 3) )`.

Fixed that and added test to prove it.