### PR TITLE
Conseil api routes fix

### DIFF
--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/ConseilApi.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/ConseilApi.scala
@@ -120,7 +120,7 @@ class ConseilApi(config: CombinedConfiguration)(implicit system: ActorSystem)
                               },
                               concat(ApiCache.cachedDataEndpoints.map {
                                 case (platform, routes) =>
-                                  logRequest(s"$platform Data Route", Logging.DebugLevel) {
+                                  logRequest(s"$platform Data Route", Logging.InfoLevel) {
                                     routes.getRoute ~ routes.postRoute
                                   }
                               }.toSeq: _*)

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/ConseilApi.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/ConseilApi.scala
@@ -1,7 +1,6 @@
 package tech.cryptonomic.conseil.api
 
 import java.util.UUID
-
 import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.http.scaladsl.server.Directives._
@@ -120,7 +119,7 @@ class ConseilApi(config: CombinedConfiguration)(implicit system: ActorSystem)
                               },
                               concat(ApiCache.cachedDataEndpoints.map {
                                 case (platform, routes) =>
-                                  logRequest(s"$platform Data Route", Logging.InfoLevel) {
+                                  logRequest(s"$platform Data Route", Logging.DebugLevel) {
                                     routes.getRoute ~ routes.postRoute
                                   }
                               }.toSeq: _*)

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/openapi/OpenApiDoc.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/openapi/OpenApiDoc.scala
@@ -17,6 +17,7 @@ import tech.cryptonomic.conseil.api.routes.platform.data.ApiDataStandardJsonCode
   queryResponseDecoder,
   queryResponseEncoder
 }
+import tech.cryptonomic.conseil.common.metadata.PlatformPath
 
 /** OpenAPI documentation object */
 object OpenApiDoc
@@ -32,6 +33,10 @@ object OpenApiDoc
 
   /** OpenAPI definition */
   def openapi: OpenApi = openApi(Info("Conseil API", "0.0.1"))(
+    queryEndpoint(PlatformPath("tezos")),
+    queryEndpoint(PlatformPath("bitcoin")),
+    queryEndpoint(PlatformPath("ethereum")),
+    queryEndpoint(PlatformPath("quorum")),
     tezosBlocksEndpoint,
     tezosBlocksHeadEndpoint,
     tezosBlockByHashEndpoint,

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/openapi/OpenApiDoc.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/openapi/OpenApiDoc.scala
@@ -17,7 +17,6 @@ import tech.cryptonomic.conseil.api.routes.platform.data.ApiDataStandardJsonCode
   queryResponseDecoder,
   queryResponseEncoder
 }
-import tech.cryptonomic.conseil.common.metadata.PlatformPath
 
 /** OpenAPI documentation object */
 object OpenApiDoc
@@ -33,10 +32,10 @@ object OpenApiDoc
 
   /** OpenAPI definition */
   def openapi: OpenApi = openApi(Info("Conseil API", "0.0.1"))(
-    queryEndpoint(PlatformPath("tezos")),
-    queryEndpoint(PlatformPath("bitcoin")),
-    queryEndpoint(PlatformPath("ethereum")),
-    queryEndpoint(PlatformPath("quorum")),
+    tezosQueryEndpoint,
+    bitcoinQueryEndpoint,
+    ethereumQueryEndpoint,
+    quorumQueryEndpoint,
     tezosBlocksEndpoint,
     tezosBlocksHeadEndpoint,
     tezosBlockByHashEndpoint,

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/openapi/OpenApiDoc.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/openapi/OpenApiDoc.scala
@@ -32,7 +32,6 @@ object OpenApiDoc
 
   /** OpenAPI definition */
   def openapi: OpenApi = openApi(Info("Conseil API", "0.0.1"))(
-    queryEndpoint,
     tezosBlocksEndpoint,
     tezosBlocksHeadEndpoint,
     tezosBlockByHashEndpoint,

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataEndpoints.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataEndpoints.scala
@@ -4,22 +4,23 @@ import endpoints.algebra
 import tech.cryptonomic.conseil.api.routes.platform.data.ApiDataTypes.ApiQuery
 import tech.cryptonomic.conseil.api.routes.validation.Validation
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.QueryResponseWithOutput
+import tech.cryptonomic.conseil.common.metadata.PlatformPath
 
 /** Trait, which provides default query endpoint and methods used while creating endpoints */
 trait ApiDataEndpoints extends algebra.JsonEntitiesFromSchemas with Validation {
   self: ApiDataJsonSchemas =>
 
   /** Common path among endpoints */
-  private val commonPath = path / "v2" / "data" / segment[String](name = "platform") / segment[String](name = "network")
+  private val commonPath = path / "v2" / "data"
 
   /** V2 Query endpoint definition */
-  def queryEndpoint: Endpoint[
-    (String, String, String, ApiQuery, Option[String]),
+  def queryEndpoint(platform: PlatformPath): Endpoint[
+    (String, String, ApiQuery, Option[String]),
     Option[Validation.QueryValidating[QueryResponseWithOutput]]
   ] =
     endpoint(
       request = post(
-        url = commonPath / segment[String](name = "entity"),
+        url = commonPath / platform.platform / segment[String](name = "network") / segment[String](name = "entity"),
         entity = jsonRequest[ApiQuery],
         headers = optRequestHeader("apiKey")
       ),

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataEndpoints.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataEndpoints.scala
@@ -4,23 +4,23 @@ import endpoints.algebra
 import tech.cryptonomic.conseil.api.routes.platform.data.ApiDataTypes.ApiQuery
 import tech.cryptonomic.conseil.api.routes.validation.Validation
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.QueryResponseWithOutput
-import tech.cryptonomic.conseil.common.metadata.PlatformPath
 
 /** Trait, which provides default query endpoint and methods used while creating endpoints */
 trait ApiDataEndpoints extends algebra.JsonEntitiesFromSchemas with Validation {
   self: ApiDataJsonSchemas =>
 
   /** Common path among endpoints */
-  private val commonPath = path / "v2" / "data"
+  private def commonPath(platform: String) =
+    path / "v2" / "data" / platform / segment[String](name = "network") / segment[String](name = "entity")
 
   /** V2 Query endpoint definition */
-  def queryEndpoint(platform: PlatformPath): Endpoint[
+  def queryEndpoint(platform: String): Endpoint[
     (String, String, ApiQuery, Option[String]),
     Option[Validation.QueryValidating[QueryResponseWithOutput]]
   ] =
     endpoint(
       request = post(
-        url = commonPath / platform.platform / segment[String](name = "network") / segment[String](name = "entity"),
+        url = commonPath(platform),
         entity = jsonRequest[ApiQuery],
         headers = optRequestHeader("apiKey")
       ),

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinDataEndpoints.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinDataEndpoints.scala
@@ -1,8 +1,10 @@
 package tech.cryptonomic.conseil.api.routes.platform.data.bitcoin
 
-import tech.cryptonomic.conseil.api.routes.platform.data.{ApiDataEndpoints, ApiDataJsonSchemas}
+import tech.cryptonomic.conseil.api.routes.platform.data.{ApiDataEndpoints, ApiDataJsonSchemas, ApiDataTypes}
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.QueryResponse
 import endpoints.algebra
+import tech.cryptonomic.conseil.api.routes.validation.Validation.QueryValidating
+import tech.cryptonomic.conseil.common.generic.chain.DataTypes
 
 /** Trait containing endpoints definition */
 trait BitcoinDataEndpoints
@@ -11,7 +13,13 @@ trait BitcoinDataEndpoints
     with ApiDataJsonSchemas
     with BitcoinFilterFromQueryString {
 
-  private val root = path / "v2" / "data" / "bitcoin" / segment[String](name = "network")
+  private val platform = "bitcoin"
+
+  private val root = path / "v2" / "data" / platform / segment[String](name = "network")
+
+  def bitcoinQueryEndpoint: Endpoint[(String, String, ApiDataTypes.ApiQuery, Option[String]), Option[
+    QueryValidating[DataTypes.QueryResponseWithOutput]
+  ]] = queryEndpoint(platform)
 
   /** V2 Blocks endpoint definition */
   def bitcoinBlocksEndpoint: Endpoint[((String, BitcoinFilter), Option[String]), Option[List[QueryResponse]]] =

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinDataRoutes.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinDataRoutes.scala
@@ -30,19 +30,20 @@ case class BitcoinDataRoutes(
   private val platformPath = PlatformPath("bitcoin")
 
   /** V2 Route implementation for query endpoint */
-  override val postRoute: Route = queryEndpoint.implementedByAsync {
-    case (platform, network, entity, apiQuery, _) =>
-      val path = EntityPath(entity, NetworkPath(network, PlatformPath(platform)))
+  override def postRoute: Route = queryEndpoint(platformPath).implementedByAsync {
+    case (network, entity, apiQuery, _) =>
+      val path = EntityPath(entity, NetworkPath(network, platformPath))
 
       pathValidation(path) {
         apiQuery
           .validate(path, metadataService, metadataConfiguration)
           .flatMap { validationResult =>
             validationResult.map { validQuery =>
-              operations.queryWithPredicates(platform, entity, validQuery.withLimitCap(maxQueryResultSize)).map {
-                queryResponses =>
+              operations
+                .queryWithPredicates(platformPath.platform, entity, validQuery.withLimitCap(maxQueryResultSize))
+                .map { queryResponses =>
                   QueryResponseWithOutput(queryResponses, validQuery.output)
-              }
+                }
             }.left.map(Future.successful).bisequence
           }
           .map(Some(_))

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinDataRoutes.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinDataRoutes.scala
@@ -30,7 +30,7 @@ case class BitcoinDataRoutes(
   private val platformPath = PlatformPath("bitcoin")
 
   /** V2 Route implementation for query endpoint */
-  override def postRoute: Route = queryEndpoint(platformPath).implementedByAsync {
+  override val postRoute: Route = bitcoinQueryEndpoint.implementedByAsync {
     case (network, entity, apiQuery, _) =>
       val path = EntityPath(entity, NetworkPath(network, platformPath))
 

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ethereum/EthereumDataEndpoints.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ethereum/EthereumDataEndpoints.scala
@@ -1,11 +1,18 @@
 package tech.cryptonomic.conseil.api.routes.platform.data.ethereum
 
+import tech.cryptonomic.conseil.api.routes.platform.data.{ApiDataEndpoints, ApiDataTypes}
+import tech.cryptonomic.conseil.api.routes.validation.Validation.QueryValidating
+import tech.cryptonomic.conseil.common.generic.chain.DataTypes
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.QueryResponse
 
 /** Represents list of endpoints exposed for Ethereum Blockchain */
 trait EthereumDataEndpoints extends EthereumDataEndpointsCreator {
 
   private val platform: String = "ethereum"
+
+  def ethereumQueryEndpoint: Endpoint[(String, String, ApiDataTypes.ApiQuery, Option[String]), Option[
+    QueryValidating[DataTypes.QueryResponseWithOutput]
+  ]] = queryEndpoint(platform)
 
   def ethereumBlocksEndpoint: Endpoint[((String, EthereumFilter), Option[String]), Option[List[QueryResponse]]] =
     blocksEndpoint(platform)
@@ -58,6 +65,10 @@ trait EthereumDataEndpoints extends EthereumDataEndpointsCreator {
 trait QuorumDataEndpoints extends EthereumDataEndpointsCreator {
 
   private val platform: String = "quorum"
+
+  def quorumQueryEndpoint: Endpoint[(String, String, ApiDataTypes.ApiQuery, Option[String]), Option[
+    QueryValidating[DataTypes.QueryResponseWithOutput]
+  ]] = queryEndpoint(platform)
 
   def quorumBlocksEndpoint: Endpoint[((String, EthereumFilter), Option[String]), Option[List[QueryResponse]]] =
     blocksEndpoint(platform)

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ethereum/EthereumDataRoutes.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ethereum/EthereumDataRoutes.scala
@@ -14,7 +14,7 @@ case class EthereumDataRoutes(
     maxQueryResultSize: Int
 )(implicit val executionContext: ExecutionContext)
     extends EthereumDataRoutesCreator {
-  override val platform: PlatformPath = PlatformPath("ethereum")
+  override val platformPath: PlatformPath = PlatformPath("ethereum")
 }
 
 /** Represents the data routes for Quorum Blockchain */
@@ -25,5 +25,5 @@ case class QuorumDataRoutes(
     maxQueryResultSize: Int
 )(implicit val executionContext: ExecutionContext)
     extends EthereumDataRoutesCreator {
-  override val platform: PlatformPath = PlatformPath("quorum")
+  override val platformPath: PlatformPath = PlatformPath("quorum")
 }

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ethereum/EthereumDataRoutesCreator.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ethereum/EthereumDataRoutesCreator.scala
@@ -38,21 +38,22 @@ trait EthereumDataRoutesCreator
   def maxQueryResultSize: Int
 
   /** Path for the specific platform */
-  def platform: PlatformPath
+  def platformPath: PlatformPath
 
   /** V2 Route implementation for query endpoint */
-  override val postRoute: Route = queryEndpoint.implementedByAsync {
-    case (platform, network, entity, apiQuery, _) =>
-      val path = EntityPath(entity, NetworkPath(network, PlatformPath(platform)))
+  override def postRoute: Route = queryEndpoint(platformPath).implementedByAsync {
+    case (network, entity, apiQuery, _) =>
+      val path = EntityPath(entity, NetworkPath(network, platformPath))
       pathValidation(path) {
         apiQuery
           .validate(path, metadataService, metadataConfiguration)
           .flatMap { validationResult =>
             validationResult.map { validQuery =>
-              operations.queryWithPredicates(platform, entity, validQuery.withLimitCap(maxQueryResultSize)).map {
-                queryResponses =>
+              operations
+                .queryWithPredicates(platformPath.platform, entity, validQuery.withLimitCap(maxQueryResultSize))
+                .map { queryResponses =>
                   QueryResponseWithOutput(queryResponses, validQuery.output)
-              }
+                }
             }.left.map(Future.successful).bisequence
           }
           .map(Some(_))
@@ -168,7 +169,7 @@ trait EthereumDataRoutesCreator
   private def platformNetworkValidation[A](network: String)(
       operation: => Future[Option[A]]
   ): Future[Option[A]] =
-    pathValidation(NetworkPath(network, platform))(operation)
+    pathValidation(NetworkPath(network, platformPath))(operation)
 
   private def pathValidation[A](path: metadata.Path)(
       operation: => Future[Option[A]]

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ethereum/EthereumDataRoutesCreator.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ethereum/EthereumDataRoutesCreator.scala
@@ -41,7 +41,7 @@ trait EthereumDataRoutesCreator
   def platformPath: PlatformPath
 
   /** V2 Route implementation for query endpoint */
-  override def postRoute: Route = queryEndpoint(platformPath).implementedByAsync {
+  override val postRoute: Route = ethereumQueryEndpoint.implementedByAsync {
     case (network, entity, apiQuery, _) =>
       val path = EntityPath(entity, NetworkPath(network, platformPath))
       pathValidation(path) {

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataEndpoints.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataEndpoints.scala
@@ -1,11 +1,12 @@
 package tech.cryptonomic.conseil.api.routes.platform.data.tezos
 
-import tech.cryptonomic.conseil.api.routes.platform.data.ApiDataEndpoints
+import tech.cryptonomic.conseil.api.routes.platform.data.{ApiDataEndpoints, ApiDataTypes}
 import tech.cryptonomic.conseil.api.routes.platform.data.tezos.TezosDataOperations._
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes._
 import tech.cryptonomic.conseil.common.tezos.Tables
 import tech.cryptonomic.conseil.common.tezos.Tables.BlocksRow
 import endpoints.algebra
+import tech.cryptonomic.conseil.api.routes.validation.Validation.QueryValidating
 
 /** Trait containing endpoints definition */
 trait TezosDataEndpoints
@@ -14,7 +15,13 @@ trait TezosDataEndpoints
     with TezosDataJsonSchemas
     with TezosFilterFromQueryString {
 
-  private val root = path / "v2" / "data" / "tezos" / segment[String](name = "network")
+  private val platform = "tezos"
+
+  private val root = path / "v2" / "data" / platform / segment[String](name = "network")
+
+  def tezosQueryEndpoint: Endpoint[(String, String, ApiDataTypes.ApiQuery, Option[String]), Option[
+    QueryValidating[QueryResponseWithOutput]
+  ]] = queryEndpoint(platform)
 
   /** V2 Blocks endpoint definition */
   def tezosBlocksEndpoint: Endpoint[((String, TezosFilter), Option[String]), Option[List[QueryResponse]]] =

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataRoutes.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataRoutes.scala
@@ -60,7 +60,7 @@ case class TezosDataRoutes(
   )
 
   /** V2 Route implementation for query endpoint */
-  override def postRoute: Route = queryEndpoint(platformPath).implementedByAsync {
+  override val postRoute: Route = tezosQueryEndpoint.implementedByAsync {
     case (network, entity, apiQuery, _) =>
       val path = EntityPath(entity, NetworkPath(network, platformPath))
 

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataRoutes.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataRoutes.scala
@@ -60,9 +60,9 @@ case class TezosDataRoutes(
   )
 
   /** V2 Route implementation for query endpoint */
-  override val postRoute: Route = queryEndpoint.implementedByAsync {
-    case (platform, network, entity, apiQuery, _) =>
-      val path = EntityPath(entity, NetworkPath(network, PlatformPath(platform)))
+  override def postRoute: Route = queryEndpoint(platformPath).implementedByAsync {
+    case (network, entity, apiQuery, _) =>
+      val path = EntityPath(entity, NetworkPath(network, platformPath))
 
       pathValidation(path) {
         shouldHideForkEntries(entity)(
@@ -72,7 +72,12 @@ case class TezosDataRoutes(
               .flatMap { validationResult =>
                 validationResult.map { validQuery =>
                   operations
-                    .queryWithPredicates(platform, entity, validQuery.withLimitCap(maxQueryResultSize), hideForkData)
+                    .queryWithPredicates(
+                      platformPath.platform,
+                      entity,
+                      validQuery.withLimitCap(maxQueryResultSize),
+                      hideForkData
+                    )
                     .map { queryResponses =>
                       QueryResponseWithOutput(queryResponses, validQuery.output)
                     }

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinDataRoutesTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinDataRoutesTest.scala
@@ -1,6 +1,7 @@
 package tech.cryptonomic.conseil.api.routes.platform.data.bitcoin
 
 import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.stephenn.scalatest.jsonassert.JsonMatchers
 import org.scalamock.scalatest.MockFactory
@@ -89,7 +90,7 @@ class BitcoinDataRoutesTest
           uri = "/v2/data/notSupportedPlatform/mainnet/blocks",
           entity = HttpEntity(MediaTypes.`application/json`, jsonStringRequest)
         )
-        postRequest ~> addHeader("apiKey", "hooman") ~> routes.postRoute ~> check {
+        postRequest ~> addHeader("apiKey", "hooman") ~> Route.seal(routes.postRoute) ~> check {
           status shouldBe StatusCodes.NotFound
         }
       }

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/ethereum/EthereumDataRoutesTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/ethereum/EthereumDataRoutesTest.scala
@@ -1,6 +1,7 @@
 package tech.cryptonomic.conseil.api.routes.platform.data.ethereum
 
 import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterEach
@@ -23,7 +24,6 @@ import tech.cryptonomic.conseil.common.metadata.{EntityPath, NetworkPath, Platfo
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
-
 import java.net.URL
 import tech.cryptonomic.conseil.common.config.Platforms.EthereumRetryConfiguration
 import tech.cryptonomic.conseil.common.testkit.ConseilSpec
@@ -93,7 +93,7 @@ class EthereumDataRoutesTest
           uri = "/v2/data/notSupportedPlatform/mainnet/blocks",
           entity = HttpEntity(MediaTypes.`application/json`, jsonStringRequest)
         )
-        postRequest ~> addHeader("apiKey", "hooman") ~> routes.postRoute ~> check {
+        postRequest ~> addHeader("apiKey", "hooman") ~> Route.seal(routes.postRoute) ~> check {
           status shouldBe StatusCodes.NotFound
         }
       }

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataRoutesTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataRoutesTest.scala
@@ -1,6 +1,7 @@
 package tech.cryptonomic.conseil.api.routes.platform.data.tezos
 
 import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.stephenn.scalatest.jsonassert.JsonMatchers
 import org.scalamock.scalatest.MockFactory
@@ -84,7 +85,7 @@ class TezosDataRoutesTest
           uri = "/v2/data/notSupportedPlatform/alphanet/accounts",
           entity = HttpEntity(MediaTypes.`application/json`, jsonStringRequest)
         )
-        postRequest ~> addHeader("apiKey", "hooman") ~> routes.postRoute ~> check {
+        postRequest ~> addHeader("apiKey", "hooman") ~> Route.seal(routes.postRoute) ~> check {
           status shouldBe StatusCodes.NotFound
         }
       }

--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/bitcoin/BitcoinFixtures.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/bitcoin/BitcoinFixtures.scala
@@ -226,7 +226,7 @@ trait BitcoinFixtures {
       weight = 536,
       version = 1,
       time = 1294691980,
-      locktime = 0,
+      locktime = 0L,
       blocktime = 1294691980,
       vin = List(inputResult),
       vout = List(outputResult)

--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/bitcoin/BitcoinFixtures.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/bitcoin/BitcoinFixtures.scala
@@ -226,7 +226,7 @@ trait BitcoinFixtures {
       weight = 536,
       version = 1,
       time = 1294691980,
-      locktime = 0L,
+      locktime = 0,
       blocktime = 1294691980,
       vin = List(inputResult),
       vout = List(outputResult)


### PR DESCRIPTION
This PR fixes a bug in conseil api where for multiple blockchains enabled, queryEndpoint was always by TezosDataRoutes.postRoute causing failing SQL query to be built for different blockchains.

Fix was to split common queryEndpoint into separate query endpoints