### PR TITLE
Feature/support multiple dbs

### DIFF
--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/ConseilApi.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/ConseilApi.scala
@@ -179,11 +179,8 @@ class ConseilApi(config: CombinedConfiguration)(implicit system: ActorSystem)
 
     private val cacheOverrides = new AttributeValuesCacheConfiguration(config.metadata)
     private val metadataCaching = MetadataCaching.empty[IO].unsafeRunSync()
-//    private val metadataOperations: DatabaseRunner = new DatabaseRunner {
-//      override lazy val dbReadHandle = DatabaseUtil.conseilDb
-//    }
 
-    private val metadataOps: Map[(String, String), DatabaseRunner] = config.platforms
+    private val metadataOperations: Map[(String, String), DatabaseRunner] = config.platforms
       .getDatabases()
       .mapValues(
         db =>
@@ -194,7 +191,7 @@ class ConseilApi(config: CombinedConfiguration)(implicit system: ActorSystem)
 
     lazy val cachedDiscoveryOperations: GenericPlatformDiscoveryOperations =
       new GenericPlatformDiscoveryOperations(
-        metadataOps,
+        metadataOperations,
         metadataCaching,
         cacheOverrides,
         config.server.cacheTTL,

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/ConseilApi.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/ConseilApi.scala
@@ -150,16 +150,30 @@ class ConseilApi(config: CombinedConfiguration)(implicit system: ActorSystem)
     implicit private val dispatcher: ExecutionContext = system.dispatchers.lookup("akka.http.dispatcher")
     private lazy val cache: Map[BlockchainPlatform, ApiDataRoutes] = forVisiblePlatforms {
       case Platforms.Tezos =>
-        val operations = new TezosDataOperations()
+        val operations = new TezosDataOperations(
+          config.platforms
+            .getDatabase(Platforms.Tezos.name, config.platforms.getNetworks(Platforms.Tezos.name).head.name)
+        )
         TezosDataRoutes(metadataService, config.metadata, operations, config.server.maxQueryResultSize)
       case Platforms.Bitcoin =>
-        val operations = new BitcoinDataOperations()
+        val operations = new BitcoinDataOperations(
+          config.platforms
+            .getDatabase(Platforms.Bitcoin.name, config.platforms.getNetworks(Platforms.Bitcoin.name).head.name)
+        )
         BitcoinDataRoutes(metadataService, config.metadata, operations, config.server.maxQueryResultSize)
       case Platforms.Ethereum =>
-        val operations = new EthereumDataOperations(Platforms.Ethereum.name)
+        val operations = new EthereumDataOperations(
+          Platforms.Ethereum.name,
+          config.platforms
+            .getDatabase(Platforms.Ethereum.name, config.platforms.getNetworks(Platforms.Ethereum.name).head.name)
+        )
         EthereumDataRoutes(metadataService, config.metadata, operations, config.server.maxQueryResultSize)
       case Platforms.Quorum =>
-        val operations = new EthereumDataOperations(Platforms.Quorum.name)
+        val operations = new EthereumDataOperations(
+          Platforms.Quorum.name,
+          config.platforms
+            .getDatabase(Platforms.Quorum.name, config.platforms.getNetworks(Platforms.Quorum.name).head.name)
+        )
         QuorumDataRoutes(metadataService, config.metadata, operations, config.server.maxQueryResultSize)
     }
 

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/metadata/AttributeValuesCacheConfiguration.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/metadata/AttributeValuesCacheConfiguration.scala
@@ -1,7 +1,7 @@
 package tech.cryptonomic.conseil.api.metadata
 
 import tech.cryptonomic.conseil.common.config.MetadataConfiguration
-import tech.cryptonomic.conseil.common.config.Types.{AttributeName, EntityName, PlatformName}
+import tech.cryptonomic.conseil.common.config.Types.{AttributeName, EntityName, NetworkName, PlatformName}
 import tech.cryptonomic.conseil.common.generic.chain.PlatformDiscoveryTypes.AttributeCacheConfiguration
 import tech.cryptonomic.conseil.common.metadata.{AttributePath, Path}
 import tech.cryptonomic.conseil.common.util.OptionUtil.when
@@ -30,11 +30,11 @@ class AttributeValuesCacheConfiguration(metadataConfiguration: MetadataConfigura
     when(metadataConfiguration.isVisible(path))(value).flatten
 
   /** extracts tuple (platform, entity, attribute) which needs to be cached */
-  def getAttributesToCache: List[(PlatformName, EntityName, AttributeName)] =
+  def getAttributesToCache: List[(PlatformName, NetworkName, EntityName, AttributeName)] =
     metadataConfiguration.allAttributes.filter {
       case (_, conf) => conf.cacheConfig.exists(_.cached)
     }.keys
       .filter(metadataConfiguration.isVisible)
-      .map(path => (path.up.up.up.platform, path.up.entity, path.attribute))
+      .map(path => (path.up.up.up.platform, path.up.up.network, path.up.entity, path.attribute))
       .toList
 }

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinDataOperations.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinDataOperations.scala
@@ -1,5 +1,6 @@
 package tech.cryptonomic.conseil.api.routes.platform.data.bitcoin
 
+import com.typesafe.config.Config
 import slick.jdbc.PostgresProfile.api._
 import tech.cryptonomic.conseil.api.routes.platform.data.ApiDataOperations
 import tech.cryptonomic.conseil.common.bitcoin.BitcoinTypes.BitcoinBlockHash
@@ -8,8 +9,8 @@ import tech.cryptonomic.conseil.common.util.DatabaseUtil
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class BitcoinDataOperations extends ApiDataOperations {
-  override lazy val dbReadHandle: Database = DatabaseUtil.conseilDb
+class BitcoinDataOperations(dbConfig: Config) extends ApiDataOperations {
+  override lazy val dbReadHandle: Database = Database.forConfig("", dbConfig)
 
   /** Fetches the list of blocks for given query */
   def fetchBlocks(query: Query)(implicit ex: ExecutionContext): Future[Option[List[QueryResponse]]] =

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ethereum/EthereumDataOperations.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ethereum/EthereumDataOperations.scala
@@ -1,5 +1,6 @@
 package tech.cryptonomic.conseil.api.routes.platform.data.ethereum
 
+import com.typesafe.config.Config
 import slick.jdbc.PostgresProfile.api._
 import tech.cryptonomic.conseil.api.routes.platform.data.ApiDataOperations
 import tech.cryptonomic.conseil.common.ethereum.EthereumTypes.EthereumBlockHash
@@ -13,8 +14,8 @@ import scala.concurrent.{ExecutionContext, Future}
   *
   * @param prefix the name of the schema under which database are stored
   */
-class EthereumDataOperations(prefix: String) extends ApiDataOperations {
-  override lazy val dbReadHandle: Database = DatabaseUtil.conseilDb
+class EthereumDataOperations(prefix: String, dbConfig: Config) extends ApiDataOperations {
+  override lazy val dbReadHandle: Database = Database.forConfig("", dbConfig)
 
   /** Fetches the list of blocks for given query */
   def fetchBlocks(query: Query)(implicit ex: ExecutionContext): Future[Option[List[QueryResponse]]] =

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataOperations.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataOperations.scala
@@ -1,6 +1,7 @@
 package tech.cryptonomic.conseil.api.routes.platform.data.tezos
 
 import com.github.ghik.silencer.silent
+import com.typesafe.config.Config
 import slick.jdbc.PostgresProfile.api._
 import tech.cryptonomic.conseil.api.routes.platform.data.ApiDataOperations
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.{OperationType, Predicate}
@@ -22,7 +23,7 @@ object TezosDataOperations {
   private val nonInvalidatedPredicate = Predicate(InvalidationAwareAttribute, OperationType.isnull)
 }
 
-class TezosDataOperations extends ApiDataOperations {
+class TezosDataOperations(dbConfig: Config) extends ApiDataOperations {
   import TezosDataOperations._
 
   override protected val forkRelatedFields = Set("invalidated_asof", "fork_id")
@@ -38,7 +39,7 @@ class TezosDataOperations extends ApiDataOperations {
       nonInvalidatedPredicate :: Nil
   }
 
-  override lazy val dbReadHandle: Database = DatabaseUtil.conseilDb
+  override lazy val dbReadHandle: Database = Database.forConfig("", dbConfig)
 
   /**
     * Fetches the most recent block stored in the database.

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/GenericPlatformDiscoveryOperations.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/GenericPlatformDiscoveryOperations.scala
@@ -26,18 +26,18 @@ import scala.concurrent.{ExecutionContext, Future}
 object GenericPlatformDiscoveryOperations {
 
   def apply(
-      dbRunner: DBIORunner,
+      dbRunners: Map[(String, String), DBIORunner],
       caching: MetadataCaching[IO],
       cacheOverrides: AttributeValuesCacheConfiguration,
       cacheTTL: FiniteDuration,
       highCardinalityLimit: Int
   )(implicit executionContext: ExecutionContext, contextShift: ContextShift[IO]): GenericPlatformDiscoveryOperations =
-    new GenericPlatformDiscoveryOperations(dbRunner, caching, cacheOverrides, cacheTTL, highCardinalityLimit)
+    new GenericPlatformDiscoveryOperations(dbRunners, caching, cacheOverrides, cacheTTL, highCardinalityLimit)
 }
 
 /** Class providing the implementation of the metadata calls with caching */
 class GenericPlatformDiscoveryOperations(
-    dbRunner: DBIORunner,
+    dbRunners: Map[(String, String), DBIORunner],
     caching: MetadataCaching[IO],
     cacheOverrides: AttributeValuesCacheConfiguration,
     cacheTTL: FiniteDuration,
@@ -51,11 +51,22 @@ class GenericPlatformDiscoveryOperations(
 
   /** Method for initializing values of the cache */
   def init(config: List[(Platform, Network)]): Future[Unit] = {
-    val platforms = config.map(_._1)
+    val entities = config.map {
+      case (platform, network) =>
+        IO.fromFuture(
+          IO(dbRunners((platform.name, network.name)).runQuery(preCacheEntities(platform.name, network.name)))
+        )
+    }.sequence.map(_.reduce(_ ++ _))
 
-    val entities = IO.fromFuture(IO(dbRunner.runQuery(preCacheEntities(config))))
-    val attributes = IO.fromFuture(IO(dbRunner.runQuery(preCacheAttributes(platforms))))
-    val attributeValues = IO.fromFuture(IO(dbRunner.runQuery(preCacheAttributeValues(platforms))))
+    val attributes = config.map {
+      case (platform, network) =>
+        IO.fromFuture(IO(dbRunners(platform.name, network.name).runQuery(preCacheAttributes(platform, network))))
+    }.sequence.map(_.reduce(_ ++ _))
+
+    val attributeValues = config.map {
+      case (platform, network) =>
+        IO.fromFuture(IO(dbRunners(platform.name, network.name).runQuery(preCacheAttributeValues(platform, network))))
+    }.sequence.map(_.reduce(_ ++ _))
 
     (
       entities flatMap caching.fillEntitiesCache,
@@ -69,15 +80,16 @@ class GenericPlatformDiscoveryOperations(
     * @param  platforms list of platforms for which we want to fetch attributes
     * @return database action with attributes to be cached
     **/
-  private def preCacheAttributes(platforms: List[Platform]): DBIO[AttributesCache] =
-    DBIO.sequence(platforms.map(preCacheAttributes)).map(_.reduce(_ ++ _))
+//  private def preCacheAttributes(platforms: List[Platform]): DBIO[AttributesCache] =
+//    DBIO.sequence(platforms.map(preCacheAttributes)).map(_.reduce(_ ++ _))
 
   /** Pre-caching attributes from slick without cardinality
     *
     * @param  platform platform for which we want to fetch attributes
+    * @param network  network for which we want to fetch entities within specific platform
     * @return database action with attributes to be cached
     * */
-  private def preCacheAttributes(platform: Platform): DBIO[AttributesCache] = {
+  private def preCacheAttributes(platform: Platform, network: Network): DBIO[AttributesCache] = {
     val result = for {
       tables <- MTable.getTables(Some(""), Some(platform.name), Some(""), Some(Seq("TABLE", "VIEW")))
       columns <- getColumns(tables)
@@ -87,7 +99,7 @@ class GenericPlatformDiscoveryOperations(
       for {
         cols <- columns
         head <- cols.headOption.toVector
-        key = AttributesCacheKey(platform.name, head.table.name)
+        key = AttributesCacheKey(platform.name, network.name, head.table.name)
         entry = CacheEntry(0L, cols.map(c => makeAttributes(c, primaryKeys, indexes)).toList)
       } yield key -> entry
 
@@ -152,21 +164,21 @@ class GenericPlatformDiscoveryOperations(
     * @param  platforms the list of platforms for which we want to fetch attribute values
     * @return database action with attribute values to be cached
     * */
-  private def preCacheAttributeValues(platforms: List[Platform]): DBIO[AttributeValuesCache] =
-    DBIO.sequence(platforms.map(preCacheAttributeValues)).map(_.reduce(_ ++ _))
+//  private def preCacheAttributeValues(platforms: List[Platform]): DBIO[AttributeValuesCache] =
+//    DBIO.sequence(platforms.map(preCacheAttributeValues)).map(_.reduce(_ ++ _))
 
   /** Pre-caching attribute values from slick for specific platform
     *
     * @param  platform platform for which we want to fetch attribute values
     * @return database action with attribute values to be cached
     * */
-  private def preCacheAttributeValues(platform: Platform): DBIO[AttributeValuesCache] =
+  private def preCacheAttributeValues(platform: Platform, network: Network): DBIO[AttributeValuesCache] =
     DBIO.sequence {
       cacheOverrides.getAttributesToCache.collect {
-        case (schema, table, column) if schema == platform.name =>
+        case (schema, network.name, table, column) if schema == platform.name =>
           selectDistinct(platform.name, table, column).map { values =>
             val radixTree = RadixTree(values.map(x => x.toLowerCase -> x): _*)
-            AttributeValuesCacheKey(platform.name, table, column) -> CacheEntry(now, radixTree)
+            AttributeValuesCacheKey(platform.name, network.name, table, column) -> CacheEntry(now, radixTree)
           }
       }
     }.map(_.toMap)
@@ -189,7 +201,10 @@ class GenericPlatformDiscoveryOperations(
               _ <- caching.putEntities(key, ent)
               _ <- contextShift.shift
               updatedEntities <- IO.fromFuture(
-                IO(dbRunner.runQuery(preCacheEntities(networkPath.up.platform, networkPath.network)))
+                IO(
+                  dbRunners((networkPath.up.platform, networkPath.network))
+                    .runQuery(preCacheEntities(networkPath.up.platform, networkPath.network))
+                )
               )
               _ <- caching.putEntities(key, updatedEntities(key).value)
             } yield ()).unsafeRunAsyncAndForget()
@@ -205,10 +220,10 @@ class GenericPlatformDiscoveryOperations(
     * @param xs list of platform-network pairs for which we want to fetch entities
     * @return database action with entities to be cached
     * */
-  private def preCacheEntities(xs: List[(Platform, Network)]): DBIO[EntitiesCache] =
-    DBIO
-      .sequence(xs.map { case (platform, network) => preCacheEntities(platform.name, network.name) })
-      .map(_.reduce(_ ++ _))
+//  private def preCacheEntities(xs: List[(Platform, Network)]): DBIO[EntitiesCache] =
+//    DBIO
+//      .sequence(xs.map { case (platform, network) => preCacheEntities(platform.name, network.name) })
+//      .map(_.reduce(_ ++ _))
 
   /** Pre-caching entities values from slick for specific platform-network pair
     *
@@ -261,6 +276,7 @@ class GenericPlatformDiscoveryOperations(
                 test = attributeFilter.length >= minMatchLength,
                 right = getAttributeValuesFromCache(
                   attributePath.up.up.up.platform,
+                  attributePath.up.up.network,
                   attributePath.up.entity,
                   attributePath.attribute,
                   attributeFilter,
@@ -272,6 +288,7 @@ class GenericPlatformDiscoveryOperations(
               Right(
                 getAttributeValuesFromCache(
                   attributePath.up.up.up.platform,
+                  attributePath.up.up.network,
                   attributePath.up.entity,
                   attributePath.attribute,
                   "",
@@ -295,6 +312,7 @@ class GenericPlatformDiscoveryOperations(
                     attr =>
                       makeAttributesQuery(
                         attributePath.up.up.up.platform,
+                        attributePath.up.up.network,
                         attributePath.up.entity,
                         attr.name,
                         withFilter
@@ -312,23 +330,30 @@ class GenericPlatformDiscoveryOperations(
   /** Gets attribute values from cache and updates them if necessary */
   private def getAttributeValuesFromCache(
       platform: String,
+      network: String,
       tableName: String,
       columnName: String,
       attributeFilter: String,
       maxResultLength: Int
   ): Future[List[String]] =
     caching
-      .getAttributeValues(AttributeValuesCacheKey(platform, tableName, columnName))
+      .getAttributeValues(AttributeValuesCacheKey(platform, network, tableName, columnName))
       .flatMap {
         case Some(CacheEntry(last, radixTree)) if !cacheExpired(last) =>
           IO.pure(radixTree.filterPrefix(attributeFilter.toLowerCase).values.take(maxResultLength).toList)
         case Some(CacheEntry(_, oldRadixTree)) =>
           (for {
-            _ <- caching.putAttributeValues(AttributeValuesCacheKey(platform, tableName, columnName), oldRadixTree)
+            _ <- caching.putAttributeValues(
+              AttributeValuesCacheKey(platform, network, tableName, columnName),
+              oldRadixTree
+            )
             _ <- contextShift.shift
-            attributeValues <- IO.fromFuture(IO(makeAttributesQuery(platform, tableName, columnName, None)))
+            attributeValues <- IO.fromFuture(IO(makeAttributesQuery(platform, network, tableName, columnName, None)))
             radixTree = RadixTree(attributeValues.map(x => x.toLowerCase -> x): _*)
-            _ <- caching.putAttributeValues(AttributeValuesCacheKey(platform, tableName, columnName), radixTree)
+            _ <- caching.putAttributeValues(
+              AttributeValuesCacheKey(platform, network, tableName, columnName),
+              radixTree
+            )
           } yield ()).unsafeRunAsyncAndForget()
           IO.pure(oldRadixTree.filterPrefix(attributeFilter).values.take(maxResultLength).toList)
         case None =>
@@ -346,17 +371,18 @@ class GenericPlatformDiscoveryOperations(
     * */
   private def makeAttributesQuery(
       platform: String,
+      network: String,
       tableName: String,
       column: String,
       withFilter: Option[String]
   ): Future[List[String]] =
     withFilter match {
       case Some(filter) =>
-        dbRunner.runQuery(
+        dbRunners((platform, network)).runQuery(
           selectDistinctLike(platform, tableName, column, Sanitizer.sanitizeForSql(filter))
         )
       case None =>
-        dbRunner.runQuery(selectDistinct(platform, tableName, column))
+        dbRunners((platform, network)).runQuery(selectDistinct(platform, tableName, column))
     }
 
   /**
@@ -368,7 +394,7 @@ class GenericPlatformDiscoveryOperations(
   override def getTableAttributes(entityPath: EntityPath): Future[Option[List[Attribute]]] =
     caching.getCachingStatus.map { status =>
       if (status == Finished) {
-        val key = AttributesCacheKey(entityPath.up.up.platform, entityPath.entity)
+        val key = AttributesCacheKey(entityPath.up.up.platform, entityPath.up.network, entityPath.entity)
         caching
           .getAttributes(key)
           .flatMap { attributesOpt =>
@@ -406,7 +432,7 @@ class GenericPlatformDiscoveryOperations(
     */
   override def getTableAttributesWithoutUpdatingCache(entityPath: EntityPath): Future[Option[List[Attribute]]] =
     caching
-      .getAttributes(AttributesCacheKey(entityPath.up.up.platform, entityPath.entity))
+      .getAttributes(AttributesCacheKey(entityPath.up.up.platform, entityPath.up.network, entityPath.entity))
       .map { attrOpt =>
         attrOpt.map(_.value)
       }
@@ -414,7 +440,8 @@ class GenericPlatformDiscoveryOperations(
 
   /** Runs query and attributes with updated counts */
   private def getUpdatedAttributes(entityPath: EntityPath, columns: List[Attribute]): Future[List[Attribute]] =
-    dbRunner.runQuery(getUpdatedAttributesQuery(entityPath, columns))
+    dbRunners((entityPath.up.up.platform, entityPath.up.network))
+      .runQuery(getUpdatedAttributesQuery(entityPath, columns))
 
   /** Query for returning partial attributes with updated counts */
   private def getUpdatedAttributesQuery(entityPath: EntityPath, columns: List[Attribute]): DBIO[List[Attribute]] =
@@ -454,7 +481,7 @@ class GenericPlatformDiscoveryOperations(
       for {
         entCache <- caching.getEntities(EntitiesCacheKey(platform.name, network.name))
         attrCache <- entCache.toList
-          .map(_.value.map(e => AttributesCacheKey(platform.name, e.name)).toSet)
+          .map(_.value.map(e => AttributesCacheKey(platform.name, network.name, e.name)).toSet)
           .map(keys => caching.getAllAttributesByKeys(keys))
           .sequence
           .map(_.reduce(_ ++ _))
@@ -464,7 +491,8 @@ class GenericPlatformDiscoveryOperations(
             getAllUpdatedAttributes(platform.name, network.name, entC.value, attrCache)
         )
         _ <- updatedAttributes.traverse {
-          case (tableName, attr) => caching.putAttributes(AttributesCacheKey(platform.name, tableName), attr)
+          case (tableName, attr) =>
+            caching.putAttributes(AttributesCacheKey(platform.name, network.name, tableName), attr)
         }
       } yield ()
 
@@ -494,7 +522,7 @@ class GenericPlatformDiscoveryOperations(
         getUpdatedAttributesQuery(entityPath, attrs).map(entityName.key -> _)
     }
     val action = DBIO.sequence(queries).map(_.toList)
-    IO.fromFuture(IO(dbRunner.runQuery(action)))
+    IO.fromFuture(IO(dbRunners((platform, network)).runQuery(action)))
   }
 
 }

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/config/ConseilAppConfigTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/config/ConseilAppConfigTest.scala
@@ -28,6 +28,16 @@ class ConseilAppConfigTest extends ConseilSpec {
                                             |      port: 8732
                                             |      path-prefix: "tezos/alphanet/"
                                             |    }
+                                            |    db {
+                                            |      dataSourceClass: "org.postgresql.ds.PGSimpleDataSource"
+                                            |      properties {
+                                            |        user: "foo"
+                                            |        password: "bar"
+                                            |        url: "jdbc:postgresql://localhost:5432/postgres"
+                                            |      }
+                                            |      numThreads: 10
+                                            |      maxConnections: 10
+                                            |    }
                                             |  },
                                             |  {
                                             |    name: "tezos"
@@ -40,6 +50,16 @@ class ConseilAppConfigTest extends ConseilSpec {
                                             |      path-prefix: "tezos/alphanet-staging/"
                                             |      trace-calls: "true"
                                             |    }
+                                            |    db {
+                                            |      dataSourceClass: "org.postgresql.ds.PGSimpleDataSource"
+                                            |      properties {
+                                            |        user: "foo"
+                                            |        password: "bar"
+                                            |        url: "jdbc:postgresql://localhost:5432/postgres"
+                                            |      }
+                                            |      numThreads: 10
+                                            |      maxConnections: 10
+                                            |    }
                                             |  }
                                             |]
         """.stripMargin)
@@ -51,6 +71,7 @@ class ConseilAppConfigTest extends ConseilSpec {
             "alphanet",
             enabled = true,
             TezosNodeConfiguration("localhost", 8732, "http", "tezos/alphanet/"),
+            cfg.getConfigList("platforms").get(0).getConfig("db"),
             None
           ),
           TezosConfiguration(
@@ -63,6 +84,7 @@ class ConseilAppConfigTest extends ConseilSpec {
               "tezos/alphanet-staging/",
               traceCalls = true
             ),
+            cfg.getConfigList("platforms").get(1).getConfig("db"),
             None
           )
         )
@@ -84,6 +106,16 @@ class ConseilAppConfigTest extends ConseilSpec {
                                               |      port: 8732
                                               |      path-prefix: ""
                                               |    }
+                                              |    db {
+                                              |      dataSourceClass: "org.postgresql.ds.PGSimpleDataSource"
+                                              |      properties {
+                                              |        user: "foo"
+                                              |        password: "bar"
+                                              |        url: "jdbc:postgresql://localhost:5432/postgres"
+                                              |      }
+                                              |      numThreads: 10
+                                              |      maxConnections: 10
+                                              |    }
                                               |  },
                                               |  {
                                               |    name: "OpenChain"
@@ -94,6 +126,16 @@ class ConseilAppConfigTest extends ConseilSpec {
                                               |      hostname: "nautilus.cryptonomic.tech",
                                               |      port: 8732
                                               |      path-prefix: "openchain/alphanet/"
+                                              |    }
+                                              |    db {
+                                              |      dataSourceClass: "org.postgresql.ds.PGSimpleDataSource"
+                                              |      properties {
+                                              |        user: "foo"
+                                              |        password: "bar"
+                                              |        url: "jdbc:postgresql://localhost:5432/postgres"
+                                              |      }
+                                              |      numThreads: 10
+                                              |      maxConnections: 10
                                               |    }
                                               |  }
                                               |]

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataTypesTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataTypesTest.scala
@@ -1,7 +1,8 @@
 package tech.cryptonomic.conseil.api.routes.platform.data
 
-import java.sql.Timestamp
+import com.typesafe.config.ConfigFactory
 
+import java.sql.Timestamp
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{BeforeAndAfterEach, OneInstancePerTest}
 import org.scalatest.LoneElement._
@@ -30,10 +31,29 @@ class ApiDataTypesTest extends ConseilSpec with MockFactory with BeforeAndAfterE
   def createMetadataService(stubbing: => Unit = ()): MetadataService = {
     stubbing
 
+    val dbCfg = ConfigFactory.parseString("""
+                                            |    db {
+                                            |      dataSourceClass: "org.postgresql.ds.PGSimpleDataSource"
+                                            |      properties {
+                                            |        user: "foo"
+                                            |        password: "bar"
+                                            |        url: "jdbc:postgresql://localhost:5432/postgres"
+                                            |      }
+                                            |      numThreads: 10
+                                            |      maxConnections: 10
+                                            |    }
+        """.stripMargin)
+
     new MetadataService(
       PlatformsConfiguration(
         List(
-          TezosConfiguration("alphanet", enabled = true, TezosNodeConfiguration("tezos-host", 123, "https://"), None)
+          TezosConfiguration(
+            "alphanet",
+            enabled = true,
+            TezosNodeConfiguration("tezos-host", 123, "https://"),
+            dbCfg,
+            None
+          )
         )
       ),
       TransparentUnitTransformation,

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinDataOperationsTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinDataOperationsTest.scala
@@ -1,7 +1,6 @@
 package tech.cryptonomic.conseil.api.routes.platform.data.bitcoin
 
 import java.sql.Timestamp
-
 import org.scalatest.concurrent.IntegrationPatience
 import slick.jdbc.PostgresProfile.api._
 import tech.cryptonomic.conseil.api.BitcoinInMemoryDatabaseSetup
@@ -24,7 +23,7 @@ class BitcoinDataOperationsTest
     with BitcoinDataOperationsTest.Fixtures {
 
   "BitcoinDataOperations" should {
-      val sut = new BitcoinDataOperations {
+      val sut = new BitcoinDataOperations(dbConfig) {
         override lazy val dbReadHandle = dbHandler
       }
 

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/ethereum/EthereumDataOperationsTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/ethereum/EthereumDataOperationsTest.scala
@@ -22,7 +22,7 @@ class EthereumDataOperationsTest
     with EthereumDataOperationsTest.Fixtures {
 
   "EthereumDataOperations" should {
-      val sut = new EthereumDataOperations("ethereum") {
+      val sut = new EthereumDataOperations("ethereum", dbConfig) {
         override lazy val dbReadHandle = dbHandler
       }
 

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataOperationsTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataOperationsTest.scala
@@ -31,7 +31,7 @@ class TezosDataOperationsTest
   import scala.concurrent.ExecutionContext.Implicits.global
   "TezosDataOperations" should {
 
-      val sut = new TezosDataOperations {
+      val sut = new TezosDataOperations(dbConfig) {
         override lazy val dbReadHandle = dbHandler
       }
 

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosForkDataOperationsTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosForkDataOperationsTest.scala
@@ -27,7 +27,7 @@ class TezosForkDataOperationsTest
   import scala.concurrent.ExecutionContext.Implicits.global
   "TezosDataOperations" should {
 
-      val sut = new TezosDataOperations {
+      val sut = new TezosDataOperations(dbConfig) {
         override lazy val dbReadHandle = dbHandler
       }
 

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/PlatformDiscoveryTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/PlatformDiscoveryTest.scala
@@ -2,6 +2,7 @@ package tech.cryptonomic.conseil.api.routes.platform.discovery
 
 import akka.http.scaladsl.model.{ContentTypes, StatusCodes}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import com.typesafe.config.ConfigFactory
 import org.scalamock.scalatest.MockFactory
 import io.circe._
 import tech.cryptonomic.conseil.api.metadata.{AttributeValuesCacheConfiguration, MetadataService, UnitTransformation}
@@ -26,6 +27,19 @@ class PlatformDiscoveryTest extends ConseilSpec with ScalatestRouteTest with Moc
       val platformDiscoveryOperations = new TestPlatformDiscoveryOperations
       val cacheOverrides = stub[AttributeValuesCacheConfiguration]
 
+      val dbCfg = ConfigFactory.parseString("""
+                                                    |    db {
+                                                    |      dataSourceClass: "org.postgresql.ds.PGSimpleDataSource"
+                                                    |      properties {
+                                                    |        user: "foo"
+                                                    |        password: "bar"
+                                                    |        url: "jdbc:postgresql://localhost:5432/postgres"
+                                                    |      }
+                                                    |      numThreads: 10
+                                                    |      maxConnections: 10
+                                                    |    }
+        """.stripMargin)
+
       val sut = (metadataOverridesConfiguration: Map[PlatformName, PlatformConfiguration]) =>
         PlatformDiscovery(
           new MetadataService(
@@ -35,6 +49,7 @@ class PlatformDiscoveryTest extends ConseilSpec with ScalatestRouteTest with Moc
                   "mainnet",
                   enabled = true,
                   TezosNodeConfiguration("tezos-host", 123, "https://"),
+                  dbCfg,
                   None
                 )
               )

--- a/conseil-common-testkit/src/main/scala/tech/cryptonomic/conseil/common/testkit/InMemoryDatabase.scala
+++ b/conseil-common-testkit/src/main/scala/tech/cryptonomic/conseil/common/testkit/InMemoryDatabase.scala
@@ -40,6 +40,8 @@ trait InMemoryDatabase extends BeforeAndAfterAll with BeforeAndAfterEach with In
        |  }
     """.stripMargin
 
+  lazy val dbConfig = ConfigFactory.parseString(confString)
+
   lazy val dbHandler: Database = Database.forConfig("testdb", config = ConfigFactory.parseString(confString))
 
   override protected def beforeAll(): Unit = {

--- a/conseil-common/src/main/resources/reference.conf
+++ b/conseil-common/src/main/resources/reference.conf
@@ -19,34 +19,6 @@ nautilus-cloud {
 # Slick debug level
 logger.scala.slick = ALL # Configure in logback.xml
 
-//databases {
-//  tezos {
-//    mainnet {
-//      db {
-//        dataSourceClass: "org.postgresql.ds.PGSimpleDataSource"
-//
-//        properties {
-//          user: "foo"
-//          user: ${?CONSEIL_XTZ_DB_USER}
-//
-//          password: "bar"
-//          password: ${?CONSEIL_XTZ_DB_PASSWORD}
-//
-//          url: "jdbc:postgresql://localhost:5432/postgres"
-//          url: ${?CONSEIL_XTZ_DB_URL}
-//
-//          reWriteBatchedInserts: true
-//        }
-//        # The following numbers are based on literature from here: https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
-//        # We might want to fine-tune these on the actual infrastructure, doing testing with different values
-//        # Please keep both values aligned in your configuration to avoid this issue: https://github.com/dnvriend/akka-persistence-jdbc/issues/177
-//        numThreads: 10
-//        maxConnections: 10
-//      }
-//    }
-//  }
-//}
-
 # Settings for blockchains Conseil can connect to. Nested by blockchain name and network.
 platforms: [
   {

--- a/conseil-common/src/main/resources/reference.conf
+++ b/conseil-common/src/main/resources/reference.conf
@@ -19,6 +19,34 @@ nautilus-cloud {
 # Slick debug level
 logger.scala.slick = ALL # Configure in logback.xml
 
+//databases {
+//  tezos {
+//    mainnet {
+//      db {
+//        dataSourceClass: "org.postgresql.ds.PGSimpleDataSource"
+//
+//        properties {
+//          user: "foo"
+//          user: ${?CONSEIL_XTZ_DB_USER}
+//
+//          password: "bar"
+//          password: ${?CONSEIL_XTZ_DB_PASSWORD}
+//
+//          url: "jdbc:postgresql://localhost:5432/postgres"
+//          url: ${?CONSEIL_XTZ_DB_URL}
+//
+//          reWriteBatchedInserts: true
+//        }
+//        # The following numbers are based on literature from here: https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
+//        # We might want to fine-tune these on the actual infrastructure, doing testing with different values
+//        # Please keep both values aligned in your configuration to avoid this issue: https://github.com/dnvriend/akka-persistence-jdbc/issues/177
+//        numThreads: 10
+//        maxConnections: 10
+//      }
+//    }
+//  }
+//}
+
 # Settings for blockchains Conseil can connect to. Nested by blockchain name and network.
 platforms: [
   {
@@ -42,6 +70,28 @@ platforms: [
 
       path-prefix: "tezos/zeronet/"
       path-prefix: ${?CONSEIL_XTZ_NODE_PATH_PREFIX}
+    }
+
+    db {
+      dataSourceClass: "org.postgresql.ds.PGSimpleDataSource"
+
+      properties {
+        user: "foo"
+        user: ${?CONSEIL_XTZ_DB_USER}
+
+        password: "bar"
+        password: ${?CONSEIL_XTZ_DB_PASSWORD}
+
+        url: "jdbc:postgresql://localhost:5432/postgres"
+        url: ${?CONSEIL_XTZ_DB_URL}
+
+        reWriteBatchedInserts: true
+      }
+      # The following numbers are based on literature from here: https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
+      # We might want to fine-tune these on the actual infrastructure, doing testing with different values
+      # Please keep both values aligned in your configuration to avoid this issue: https://github.com/dnvriend/akka-persistence-jdbc/issues/177
+      numThreads: 10
+      maxConnections: 10
     }
   },
   {
@@ -69,6 +119,28 @@ platforms: [
       # the password used in local Bitcoin node from the docker-compose.yml file
       password: "sP9PV88xtbGwLMAEi2rVlZ7jIFfJbpOmTUCsBBBRN9I="
       password: ${?CONSEIL_BTC_NODE_PASSWORD}
+    }
+
+    db {
+      dataSourceClass: "org.postgresql.ds.PGSimpleDataSource"
+
+      properties {
+        user: "foo"
+        user: ${?CONSEIL_BTC_DB_USER}
+
+        password: "bar"
+        password: ${?CONSEIL_BTC_DB_PASSWORD}
+
+        url: "jdbc:postgresql://localhost:5432/postgres"
+        url: ${?CONSEIL_BTC_DB_URL}
+
+        reWriteBatchedInserts: true
+      }
+      # The following numbers are based on literature from here: https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
+      # We might want to fine-tune these on the actual infrastructure, doing testing with different values
+      # Please keep both values aligned in your configuration to avoid this issue: https://github.com/dnvriend/akka-persistence-jdbc/issues/177
+      numThreads: 10
+      maxConnections: 10
     }
 
     batching {
@@ -99,6 +171,28 @@ platforms: [
 
     node: "https://localhost:8332"
     node: ${?CONSEIL_ETH_NODE}
+
+    db {
+      dataSourceClass: "org.postgresql.ds.PGSimpleDataSource"
+
+      properties {
+        user: "foo"
+        user: ${?CONSEIL_ETH_DB_USER}
+
+        password: "bar"
+        password: ${?CONSEIL_ETH_DB_PASSWORD}
+
+        url: "jdbc:postgresql://localhost:5432/postgres"
+        url: ${?CONSEIL_ETH_DB_URL}
+
+        reWriteBatchedInserts: true
+      }
+      # The following numbers are based on literature from here: https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
+      # We might want to fine-tune these on the actual infrastructure, doing testing with different values
+      # Please keep both values aligned in your configuration to avoid this issue: https://github.com/dnvriend/akka-persistence-jdbc/issues/177
+      numThreads: 10
+      maxConnections: 10
+    }
 
     retry {
       max-wait: 2s
@@ -139,6 +233,28 @@ platforms: [
 
     node: "https://localhost:8332"
     node: ${?CONSEIL_QUO_NODE}
+
+    db {
+      dataSourceClass: "org.postgresql.ds.PGSimpleDataSource"
+
+      properties {
+        user: "foo"
+        user: ${?CONSEIL_QUO_DB_USER}
+
+        password: "bar"
+        password: ${?CONSEIL_QUO_DB_PASSWORD}
+
+        url: "jdbc:postgresql://localhost:5432/postgres"
+        url: ${?CONSEIL_QUO_DB_URL}
+
+        reWriteBatchedInserts: true
+      }
+      # The following numbers are based on literature from here: https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
+      # We might want to fine-tune these on the actual infrastructure, doing testing with different values
+      # Please keep both values aligned in your configuration to avoid this issue: https://github.com/dnvriend/akka-persistence-jdbc/issues/177
+      numThreads: 10
+      maxConnections: 10
+    }
 
     retry {
       max-wait: 2s

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/cache/MetadataCaching.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/cache/MetadataCaching.scala
@@ -21,11 +21,12 @@ object MetadataCaching {
   case class EntitiesCacheKey(platform: String, network: String) extends CacheKey {
     val key: String = s"$platform.$network"
   }
-  case class AttributesCacheKey(platform: String, table: String) extends CacheKey {
-    val key: String = s"$platform.$table"
+  case class AttributesCacheKey(platform: String, network: String, table: String) extends CacheKey {
+    val key: String = s"$platform.$network.$table"
   }
-  case class AttributeValuesCacheKey(platform: String, table: String, column: String) extends CacheKey {
-    val key: String = s"$platform.$table.$column"
+  case class AttributeValuesCacheKey(platform: String, network: String, table: String, column: String)
+      extends CacheKey {
+    val key: String = s"$platform.$network.$table.$column"
   }
 
   type Cache[K <: CacheKey, A] = Map[K, CacheEntry[A]]

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/config/Platforms.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/config/Platforms.scala
@@ -1,9 +1,11 @@
 package tech.cryptonomic.conseil.common.config
 
 import com.typesafe.config.Config
+import slick.jdbc.JdbcBackend.Database
 
 import java.net.URL
 import tech.cryptonomic.conseil.common.generic.chain.PlatformDiscoveryTypes.{Network, Platform}
+
 import scala.concurrent.duration.Duration
 
 /** defines configuration types for conseil available platforms */
@@ -74,6 +76,12 @@ object Platforms {
         .map { config =>
           Network(config.network, config.network.capitalize, config.platform.name, config.network)
         }
+
+    def getDatabase(platformName: String, network: String, enabled: Boolean = true): Config =
+      platforms
+        .filter(v => v.platform.name == platformName && v.network == network && v.enabled == enabled)
+        .map(_.db)
+        .head
   }
 
   /** configurations to describe a tezos node */

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/config/Platforms.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/config/Platforms.scala
@@ -1,7 +1,8 @@
 package tech.cryptonomic.conseil.common.config
 
-import java.net.URL
+import com.typesafe.config.Config
 
+import java.net.URL
 import tech.cryptonomic.conseil.common.generic.chain.PlatformDiscoveryTypes.{Network, Platform}
 import scala.concurrent.duration.Duration
 
@@ -99,6 +100,9 @@ object Platforms {
 
     /** Defines the name of the network for specific blockchain */
     def network: String
+
+    /**  */
+    def db: Config
   }
 
   /** collects all config related to a tezos network */
@@ -106,9 +110,13 @@ object Platforms {
       network: String,
       enabled: Boolean,
       node: TezosNodeConfiguration,
+      db: Config,
       tns: Option[TNSContractConfiguration]
   ) extends PlatformConfiguration {
     override val platform: BlockchainPlatform = Tezos
+//
+//    lazy val db = Database.forConfig(s"databases.${platform.name}.${network}.db")
+//    lazy val a = ConfigFactory.load().getConfigList("").get(0).getConfig("db")
   }
 
   /** configurations to describe a bitcoin node */
@@ -136,6 +144,7 @@ object Platforms {
       network: String,
       enabled: Boolean,
       node: BitcoinNodeConfiguration,
+      db: Config,
       batching: BitcoinBatchFetchConfiguration
   ) extends PlatformConfiguration {
     override val platform: BlockchainPlatform = Bitcoin
@@ -176,6 +185,7 @@ object Platforms {
       network: String,
       enabled: Boolean,
       node: URL,
+      db: Config,
       retry: EthereumRetryConfiguration,
       batching: EthereumBatchFetchConfiguration
   ) extends PlatformConfiguration {
@@ -187,12 +197,13 @@ object Platforms {
       network: String,
       enabled: Boolean,
       node: URL,
+      db: Config,
       retry: EthereumRetryConfiguration,
       batching: EthereumBatchFetchConfiguration
   ) extends PlatformConfiguration {
     override val platform: BlockchainPlatform = Quorum
 
-    lazy val toEthereumConfiguration = EthereumConfiguration(network, enabled, node, retry, batching)
+    lazy val toEthereumConfiguration = EthereumConfiguration(network, enabled, node, db, retry, batching)
   }
 
 }

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/config/Platforms.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/config/Platforms.scala
@@ -77,11 +77,18 @@ object Platforms {
           Network(config.network, config.network.capitalize, config.platform.name, config.network)
         }
 
-    def getDatabase(platformName: String, network: String, enabled: Boolean = true): Config =
+    def getDbConfig(platformName: String, network: String, enabled: Boolean = true): Config =
       platforms
         .filter(v => v.platform.name == platformName && v.network == network && v.enabled == enabled)
         .map(_.db)
         .head
+
+    def getDatabases(enabled: Boolean = true): Map[(String, String), Database] =
+      platforms
+        .filter(_.enabled == enabled)
+        .map(c => (c.platform.name, c.network) -> Database.forConfig("", c.db))
+        .toMap
+
   }
 
   /** configurations to describe a tezos node */

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/config/Platforms.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/config/Platforms.scala
@@ -116,7 +116,7 @@ object Platforms {
     /** Defines the name of the network for specific blockchain */
     def network: String
 
-    /**  */
+    /** View on the db config object */
     def db: Config
   }
 
@@ -129,9 +129,6 @@ object Platforms {
       tns: Option[TNSContractConfiguration]
   ) extends PlatformConfiguration {
     override val platform: BlockchainPlatform = Tezos
-//
-//    lazy val db = Database.forConfig(s"databases.${platform.name}.${network}.db")
-//    lazy val a = ConfigFactory.load().getConfigList("").get(0).getConfig("db")
   }
 
   /** configurations to describe a bitcoin node */

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/io/MainOutputs.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/io/MainOutputs.scala
@@ -39,11 +39,11 @@ object MainOutputs {
 
   /* custom display of each configuration type */
   val showPlatformConfiguration: PartialFunction[PlatformConfiguration, String] = {
-    case TezosConfiguration(_, _, TezosNodeConfiguration(host, port, protocol, prefix, chainEnv, trace), _) =>
+    case TezosConfiguration(_, _, TezosNodeConfiguration(host, port, protocol, prefix, chainEnv, trace), _, _) =>
       s"node $protocol://$host:$port/$prefix/$chainEnv" + (if (trace) " [call tracing enabled]" else "")
-    case EthereumConfiguration(network, _, node, _, _) =>
+    case EthereumConfiguration(network, _, node, _, _, _) =>
       s"network: ${network} node: ${node}"
-    case BitcoinConfiguration(_, _, node, _) =>
+    case BitcoinConfiguration(_, _, node, _, _) =>
       s"node ${node.url}"
   }
 

--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/config/PlatformsTest.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/config/PlatformsTest.scala
@@ -1,5 +1,6 @@
 package tech.cryptonomic.conseil.common.config
 
+import com.typesafe.config.ConfigFactory
 import tech.cryptonomic.conseil.common.config.Platforms.{
   BitcoinBatchFetchConfiguration,
   BitcoinConfiguration,
@@ -13,11 +14,25 @@ import tech.cryptonomic.conseil.common.testkit.ConseilSpec
 
 class PlatformsTest extends ConseilSpec {
 
+  private val dbCfg = ConfigFactory.parseString("""
+        |    db {
+        |      dataSourceClass: "org.postgresql.ds.PGSimpleDataSource"
+        |      properties {
+        |        user: "foo"
+        |        password: "bar"
+        |        url: "jdbc:postgresql://localhost:5432/postgres"
+        |      }
+        |      numThreads: 10
+        |      maxConnections: 10
+        |    }
+        """.stripMargin)
+
   private val configTezosNode = TezosNodeConfiguration("host", 0, "protocol")
-  private val configTezos = TezosConfiguration("mainnet", enabled = true, configTezosNode, None)
+  private val configTezos = TezosConfiguration("mainnet", enabled = true, configTezosNode, dbCfg, None)
   private val configBitcoinNode = BitcoinNodeConfiguration("host", 0, "protocol", "username", "password")
   private val configBitcoinBatching = BitcoinBatchFetchConfiguration(1, 1, 1, 1, 1)
-  private val configBitcoin = BitcoinConfiguration("testnet", enabled = false, configBitcoinNode, configBitcoinBatching)
+  private val configBitcoin =
+    BitcoinConfiguration("testnet", enabled = false, configBitcoinNode, dbCfg, configBitcoinBatching)
   private val config = PlatformsConfiguration(List(configTezos, configBitcoin))
 
   private val platformTezos = PlatformDiscoveryTypes.Platform("tezos", "Tezos")

--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/config/PlatformsTest.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/config/PlatformsTest.scala
@@ -15,7 +15,7 @@ import tech.cryptonomic.conseil.common.testkit.ConseilSpec
 class PlatformsTest extends ConseilSpec {
 
   private val dbCfg = ConfigFactory.parseString("""
-        |    db {
+        |    {
         |      dataSourceClass: "org.postgresql.ds.PGSimpleDataSource"
         |      properties {
         |        user: "foo"
@@ -57,6 +57,14 @@ class PlatformsTest extends ConseilSpec {
       "return allow to ask for networks, for disabled platforms and specific name" in {
         config.getNetworks("tezos", enabled = false) shouldBe empty
         config.getNetworks("bitcoin", enabled = false) should contain only networkBitcoin
+      }
+
+      "return configs for enabled platforms" in {
+        config.getDbConfig("tezos", "mainnet") shouldBe dbCfg
+      }
+
+      "return databases for enabled platforms" in {
+        config.getDatabases().keys.toList should contain theSameElementsAs List(("tezos", "mainnet"))
       }
     }
 }

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/config/LorreAppConfigTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/config/LorreAppConfigTest.scala
@@ -1,6 +1,6 @@
 package tech.cryptonomic.conseil.indexer.config
 
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 import tech.cryptonomic.conseil.common.config.Platforms.{TezosConfiguration, TezosNodeConfiguration}
 import tech.cryptonomic.conseil.indexer.config.LorreAppConfig.Loaders._
 import tech.cryptonomic.conseil.indexer.config.LorreAppConfig.Natural
@@ -52,6 +52,16 @@ class LorreAppConfigTest extends ConseilSpec {
                                               |      port: 8732
                                               |      path-prefix: "tezos/alphanet/"
                                               |    }
+                                              |    db {
+                                              |      dataSourceClass: "org.postgresql.ds.PGSimpleDataSource"
+                                              |      properties {
+                                              |        user: "foo"
+                                              |        password: "bar"
+                                              |        url: "jdbc:postgresql://localhost:5432/postgres"
+                                              |      }
+                                              |      numThreads: 10
+                                              |      maxConnections: 10
+                                              |    }
                                               |  }
                                               |]
         """.stripMargin)
@@ -61,6 +71,7 @@ class LorreAppConfigTest extends ConseilSpec {
           "alphanet",
           enabled = true,
           TezosNodeConfiguration("localhost", 8732, "http", "tezos/alphanet/"),
+          cfg.getConfigList("platforms").get(0).getConfig("db"),
           None
         )
       }
@@ -78,6 +89,16 @@ class LorreAppConfigTest extends ConseilSpec {
                                             |      port: 8732
                                             |      pathPrefix: "tezos/alphanet/"
                                             |    }
+                                            |    db {
+                                            |      dataSourceClass: "org.postgresql.ds.PGSimpleDataSource"
+                                            |      properties {
+                                            |        user: "foo"
+                                            |        password: "bar"
+                                            |        url: "jdbc:postgresql://localhost:5432/postgres"
+                                            |      }
+                                            |      numThreads: 10
+                                            |      maxConnections: 10
+                                            |    }
                                             |  }
                                             |]
         """.stripMargin)
@@ -87,6 +108,7 @@ class LorreAppConfigTest extends ConseilSpec {
           "alphanet",
           enabled = true,
           TezosNodeConfiguration("localhost", 8732, "http"),
+          cfg.getConfigList("platforms").get(0).getConfig("db"),
           None
         )
       }


### PR DESCRIPTION
This PR introduces support for per-blockchain databases in conseil-api. This will allow to store indexed blockchain data in separate dbs

Note: This PR requires changes in config `platforms` key

## Changes to the .conf files

`reference.conf` introduces a new sub-entry `db` for each platform defined.

This entry allows user to define separate database for each platform defined. The data is still expected to be in the appropriate db namespace.

If the data for all defined platforms is stored in the same database, the sub-entry `db` should have the same value.

```
platforms: [
  {
    name: "tezos"
    network: "alphanet"
    enabled: true,
    node: {
      protocol: "http",
      hostname: "localhost",
      port: 8732
       path-prefix: "tezos/alphanet/"
    }

    db {
      dataSourceClass: "org.postgresql.ds.PGSimpleDataSource"
      properties {
        user: "foo"
        password: "bar"
        url: "jdbc:postgresql://localhost:5432/postgres"
      }
      numThreads: 10
      maxConnections: 10
    }

  }
```