### PR TITLE
expose json logging via env var

### DIFF
--- a/conseil-api/src/main/resources/logging.conf
+++ b/conseil-api/src/main/resources/logging.conf
@@ -1,6 +1,10 @@
 logging: {
     muted: false
-    output-json-with-service-name: ${?CONSEIL_LOG_JSON_SERVICE_NAME}
+
+    enable-json-output: false
+    enable-json-output: ${?CONSEIL_ENABLE_JSON_OUTPUT}
+
+    output-json-with-service-name: "conseil-api"
     loggers: [
         {
             name: "com.base22",

--- a/conseil-api/src/main/resources/logging.conf
+++ b/conseil-api/src/main/resources/logging.conf
@@ -1,5 +1,6 @@
 logging: {
     muted: false
+    output-json-with-service-name: ${?CONSEIL_LOG_JSON_SERVICE_NAME}
     loggers: [
         {
             name: "com.base22",

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/io/Logging.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/io/Logging.scala
@@ -148,6 +148,7 @@ object Logging {
             .withHandler(formatter = sharedFormatter, minimumLevel = loggingConfig.outputLevel.map(Level(_)))
         case (_, Some(serviceName), logstashEndpoint) =>
           //outputs json formatting, based on logstash standards, possibly sending to an external server directly
+          warn("Setting json logging")
           val jsonHandler = JsonLogging.JsonWriter(serviceName, logstash = logstashEndpoint)
           Logger.root
             .clearHandlers()

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/io/Logging.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/io/Logging.scala
@@ -94,6 +94,7 @@ object Logging {
       muted: Boolean = false,
       loggers: List[LoggerConfig] = List.empty,
       outputLevel: Option[String],
+      enableJsonOutput: Boolean,
       outputJsonWithServiceName: Option[String] = None,
       outputToLogstash: Option[URL] = None
   )
@@ -136,20 +137,23 @@ object Logging {
     /* Assigns the same formatting to any logger by defining it on the parent root logger */
     /* Cross-check config values to assess the appropriate logging schema */
     val configuredRootLogger =
-      (loggingConfig.muted, loggingConfig.outputJsonWithServiceName, loggingConfig.outputToLogstash) match {
+      (loggingConfig.muted, loggingConfig.enableJsonOutput, loggingConfig.outputToLogstash) match {
         case (true, _, _) =>
           //remove anything
           warn("Setting any logging to OFF")
           Logger.root.clearHandlers().clearModifiers().withModifier(LevelFilter.ExcludeAll)
-        case (_, None, _) =>
+        case (_, false, _) =>
           //standard out logger with shared formatting for any child
           Logger.root
             .clearHandlers()
             .withHandler(formatter = sharedFormatter, minimumLevel = loggingConfig.outputLevel.map(Level(_)))
-        case (_, Some(serviceName), logstashEndpoint) =>
+        case (_, true, logstashEndpoint) =>
           //outputs json formatting, based on logstash standards, possibly sending to an external server directly
           warn("Setting json logging")
-          val jsonHandler = JsonLogging.JsonWriter(serviceName, logstash = logstashEndpoint)
+          val jsonHandler = JsonLogging.JsonWriter(
+            loggingConfig.outputJsonWithServiceName.getOrElse("conseil-service"),
+            logstash = logstashEndpoint
+          )
           Logger.root
             .clearHandlers()
             .withHandler(writer = jsonHandler, minimumLevel = loggingConfig.outputLevel.map(Level(_)))

--- a/conseil-lorre/src/main/resources/logging.conf
+++ b/conseil-lorre/src/main/resources/logging.conf
@@ -1,6 +1,10 @@
 logging: {
     muted: false
-    output-json-with-service-name: ${?CONSEIL_LOG_JSON_SERVICE_NAME}
+
+    enable-json-output: false
+    enable-json-output: ${?CONSEIL_ENABLE_JSON_OUTPUT}
+
+    output-json-with-service-name: "conseil-lorre"
     loggers: [
         {
             name: "com.base22",

--- a/conseil-lorre/src/main/resources/logging.conf
+++ b/conseil-lorre/src/main/resources/logging.conf
@@ -1,9 +1,14 @@
 logging: {
     muted: false
+    output-json-with-service-name: ${?CONSEIL_LOG_JSON_SERVICE_NAME}
     loggers: [
         {
             name: "com.base22",
             muted: true
+        },
+        {
+            name: "org.http4s",
+            level: "INFO"
         },
         {
             name: "slick",


### PR DESCRIPTION
This PR enables json logging for conseil docker container through `CONSEIL_ENABLE_JSON_OUTPUT` env variable

Ex. `CONSEIL_ENABLE_JSON_OUTPUT="true"`

Also http4s log level for lorre was set to INFO to lower log volume