### PR TITLE
965 - fixed issue with UTF8 string generation

### DIFF
--- a/conseil-common-testkit/src/main/scala/tech/cryptonomic/conseil/common/testkit/util/RandomTestKit.scala
+++ b/conseil-common-testkit/src/main/scala/tech/cryptonomic/conseil/common/testkit/util/RandomTestKit.scala
@@ -96,7 +96,7 @@ trait RandomGenerationKit {
   /** Can the string be safely stored as a database column?
     * This depends on the database type definitions.
     */
-  def canBeWrittenToDb(string: String): Boolean = !string.contains(nullUTF_8)
+  def canBeWrittenToDb(string: String): Boolean = (!string.contains(nullUTF_8)) && string.forall(Character.isDefined)
 
   /** Can the number be safely stored as a database column?
     * This depends on the database type definitions.

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/bigmaps/BigMapsOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/bigmaps/BigMapsOperations.scala
@@ -27,6 +27,7 @@ import tech.cryptonomic.conseil.common.tezos.TezosTypes.BlockTagged.fromBlockDat
   */
 case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) extends ConseilLogSupport {
   import profile.api._
+  import io.scalaland.chimney.dsl._
 
   /** Create an action to find and copy big maps based on the diff contained in the blocks
     *
@@ -95,7 +96,10 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
           DBIO.sequence {
             List(
               Tables.BigMapContents.insertOrUpdateAll(rowsToWrite),
-              Tables.BigMapContentsHistory ++= updateData.map(Tables.BigMapContentsHistoryRow.tupled).distinct
+              Tables.BigMapContentsHistory ++= updateData
+                    .map(BigMapContentsRow.tupled)
+                    .map(_.transformInto[Tables.BigMapContentsHistoryRow])
+                    .distinct
             )
           }
         }


### PR DESCRIPTION
resolves #965 
fixed property tests UTF8 string generator and issue with big maps history which probably happened during merge.

Tested many times locally I think it works correctly now.