### PR TITLE
Granada related fixes and updates.

### DIFF
--- a/conseil-common/src/main/resources/reference.conf
+++ b/conseil-common/src/main/resources/reference.conf
@@ -301,8 +301,8 @@ akka {
 
   # fixes the issue when lorre does not quit after system.shutdown()
   coordinated-shutdown.run-by-actor-system-terminate = off
-  parsing.max-to-strict-bytes: 20m
-  parsing.max-to-strict-bytes: ${?CONSEIL_LORRE_AKKA_MAX_TO_STRICT_BYTES}
+  http.parsing.max-to-strict-bytes: 20m
+  http.parsing.max-to-strict-bytes: ${?CONSEIL_LORRE_AKKA_MAX_TO_STRICT_BYTES}
 }
 
 # Custom libSodium settings

--- a/conseil-common/src/main/resources/reference.conf
+++ b/conseil-common/src/main/resources/reference.conf
@@ -43,6 +43,7 @@ platforms: [
       path-prefix: ""
       path-prefix: ${?CONSEIL_XTZ_NODE_PATH_PREFIX}
 
+      # allows to trace calls made to the tezos node
       trace-calls: false
       trace-calls: ${?CONSEIL_XTZ_NODE_TRACE_CALLS}
     }

--- a/conseil-common/src/main/resources/reference.conf
+++ b/conseil-common/src/main/resources/reference.conf
@@ -301,7 +301,7 @@ akka {
 
   # fixes the issue when lorre does not quit after system.shutdown()
   coordinated-shutdown.run-by-actor-system-terminate = off
-  http.parsing.max-to-strict-bytes: 20m
+  http.parsing.max-to-strict-bytes: 100m
   http.parsing.max-to-strict-bytes: ${?CONSEIL_LORRE_AKKA_MAX_TO_STRICT_BYTES}
 }
 

--- a/conseil-common/src/main/resources/reference.conf
+++ b/conseil-common/src/main/resources/reference.conf
@@ -40,8 +40,11 @@ platforms: [
       port: 8732
       port: ${?CONSEIL_XTZ_NODE_PORT}
 
-      path-prefix: "tezos/zeronet/"
+      path-prefix: ""
       path-prefix: ${?CONSEIL_XTZ_NODE_PATH_PREFIX}
+
+      trace-calls: false
+      trace-calls: ${?CONSEIL_XTZ_NODE_TRACE_CALLS}
     }
 
     db {
@@ -298,7 +301,8 @@ akka {
 
   # fixes the issue when lorre does not quit after system.shutdown()
   coordinated-shutdown.run-by-actor-system-terminate = off
-
+  parsing.max-to-strict-bytes: 20m
+  parsing.max-to-strict-bytes: ${?CONSEIL_LORRE_AKKA_MAX_TO_STRICT_BYTES}
 }
 
 # Custom libSodium settings

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosTypes.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosTypes.scala
@@ -566,7 +566,8 @@ object TezosTypes {
 
   final case class CycleBalance(
       cycle: Int,
-      deposit: PositiveBigNumber,
+      deposit: Option[PositiveBigNumber],
+      deposits: Option[PositiveBigNumber],
       fees: PositiveBigNumber,
       rewards: PositiveBigNumber
   )

--- a/conseil-lorre/src/main/resources/application.conf
+++ b/conseil-lorre/src/main/resources/application.conf
@@ -39,7 +39,7 @@ lorre {
     metadata-fetching-is-on: false
     metadata-fetching-is-on: ${?CONSEIL_LORRE_BLOCK_RIGHTS_FETCHING_ENABLED}
     fork-handling-is-on: false
-      fork-handling-is-on: ${?CONSEIL_LORRE_FORK_DETECTION_ENABLED}
+    fork-handling-is-on: ${?CONSEIL_LORRE_FORK_DETECTION_ENABLED}
   }
 
   # Replace database name, user and password in an env-specific config file.

--- a/conseil-lorre/src/main/resources/application.conf
+++ b/conseil-lorre/src/main/resources/application.conf
@@ -36,10 +36,10 @@ lorre {
   enabled-features {
     block-rights-fetching-is-on: true
     block-rights-fetching-is-on: ${?CONSEIL_LORRE_BLOCK_RIGHTS_FETCHING_ENABLED}
-    metadata-fetching-is-on: true
+    metadata-fetching-is-on: false
     metadata-fetching-is-on: ${?CONSEIL_LORRE_BLOCK_RIGHTS_FETCHING_ENABLED}
     fork-handling-is-on: false
-    fork-handling-is-on: ${?CONSEIL_LORRE_FORK_DETECTION_ENABLED}
+      fork-handling-is-on: ${?CONSEIL_LORRE_FORK_DETECTION_ENABLED}
   }
 
   # Replace database name, user and password in an env-specific config file.
@@ -105,6 +105,7 @@ lorre {
     cycle-size: 4096 # size of the cycle, by default 4096
     fetch-size: 200 # amount of rights we fetch at once
     update-size: 16 # amount of rights we update after Lorre syncs
+    update-size: ${?CONSEIL_LORRE_RIGHTS_UPDATE_SIZE}
   }
 
   metadata-fetching {

--- a/conseil-lorre/src/main/resources/logging.conf
+++ b/conseil-lorre/src/main/resources/logging.conf
@@ -52,6 +52,7 @@ logging: {
             #  get extra info from the akka-streamed async calls to the node, if trace-calls is enabled on the node conf.
             # change the level of the root logger handler accordingly to see the output (i.e. add outputLevel: "DEBUG")
             name: "tech.cryptonomic.conseil.indexer.tezos.node-rpc.batch",
+            from-env: "LORRE_NODE_RPC_BATCH_LOG_LEVEL",
             level: "DEBUG"
         }
     ]

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosDatabaseOperations.scala
@@ -446,32 +446,22 @@ object TezosDatabaseOperations extends ConseilLogSupport {
   val berLogger = Logger("RightsFetcher")
 
   /**
-    * Updates timestamps in the baking_rights table
+    * Updates in the baking_rights table
     * @param bakingRights baking rights to be updated
     */
-  def updateBakingRightsTimestamp(bakingRights: List[BakingRights]): DBIO[List[Int]] =
-    DBIO.sequence {
-      bakingRights.map { upd =>
-        Tables.BakingRights
-          .filter(er => er.delegate === upd.delegate && er.blockLevel === upd.level)
-          .map(_.estimatedTime)
-          .update(upd.estimated_time.map(datetime => Timestamp.from(datetime.toInstant)))
-      }
-    }
+  def updateBakingRights(bakingRights: List[BakingRights]): DBIO[Option[Int]] = {
+    import CustomProfileExtension.api._
+    Tables.BakingRights.insertOrUpdateAll(bakingRights.map(_.convertTo[Tables.BakingRightsRow]))
+  }
 
   /**
     * Updates timestamps in the endorsing_rights table
     * @param endorsingRights endorsing rights to be updated
     */
-  def updateEndorsingRightsTimestamp(endorsingRights: List[EndorsingRights]): DBIO[List[Int]] =
-    DBIO.sequence {
-      endorsingRights.map { upd =>
-        Tables.EndorsingRights
-          .filter(er => er.delegate === upd.delegate && er.blockLevel === upd.level)
-          .map(_.estimatedTime)
-          .update(upd.estimated_time.map(datetime => Timestamp.from(datetime.toInstant)))
-      }
-    }
+  def updateEndorsingRights(endorsingRights: List[EndorsingRights]): DBIO[Option[Int]] = {
+    import CustomProfileExtension.api._
+    Tables.EndorsingRights.insertOrUpdateAll(endorsingRights.flatMap(_.convertToA[List, Tables.EndorsingRightsRow]))
+  }
 
   /**
     * Writes baking rights to the database

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosIndexer.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosIndexer.scala
@@ -113,7 +113,7 @@ class TezosIndexer private (
       _ <- TezosFeeOperations
         .processTezosAverageFees(lorreConf.feesAverageTimeWindow)
         .whenA(iteration % lorreConf.feeUpdateInterval == 0)
-      _ <- rightsProcessor.updateRightsTimestamps()
+      _ <- rightsProcessor.updateRights()
     } yield Some(unhandled)
 
     /* Won't stop Lorre on failure from processing the chain, unless overridden by the environment to halt.

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/Tzip16MetadataFetcher.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/Tzip16MetadataFetcher.scala
@@ -41,8 +41,8 @@ object Tzip16MetadataJsonDecoders {
   import io.circe.generic.semiauto._
 
   /** Representation of Metadata compient with TZIP-16 format
-   * MOre info on the fields can be found here: https://tzip.tezosagora.org/proposal/tzip-16/
-   * */
+    * MOre info on the fields can be found here: https://tzip.tezosagora.org/proposal/tzip-16/
+    * */
   case class Tzip16Metadata(
       name: String,
       description: String,
@@ -85,10 +85,11 @@ class Tzip16MetadataOperator(
 
   def getMetadataWithRegisteredTokensRow(
       addresses: List[(Tables.RegisteredTokensRow, Tables.BigMapContentsRow, MetadataUrl)]
-  ): Future[List[((Tables.RegisteredTokensRow, Tables.BigMapContentsRow, MetadataUrl), Option[(MetadataUrl, Tzip16Metadata)])]] =
+  ): Future[
+    List[((Tables.RegisteredTokensRow, Tables.BigMapContentsRow, MetadataUrl), Option[(MetadataUrl, Tzip16Metadata)])]
+  ] =
     fetch[(Tables.RegisteredTokensRow, Tables.BigMapContentsRow, MetadataUrl), Option[(MetadataUrl, Tzip16Metadata)], Future, List, Throwable]
       .run(addresses)
-
 
   implicit val metadataFetcherRegisteredTokensRow: FutureFetcher {
     type In = (Tables.RegisteredTokensRow, Tables.BigMapContentsRow, MetadataUrl)

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/bigmaps/BigMapsOperations.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/bigmaps/BigMapsOperations.scala
@@ -27,6 +27,7 @@ import tech.cryptonomic.conseil.common.tezos.TezosTypes.BlockTagged.fromBlockDat
   */
 case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) extends ConseilLogSupport {
   import profile.api._
+  import io.scalaland.chimney.dsl._
 
   /** Create an action to find and copy big maps based on the diff contained in the blocks
     *
@@ -95,7 +96,10 @@ case class BigMapsOperations[Profile <: ExPostgresProfile](profile: Profile) ext
           DBIO.sequence {
             List(
               Tables.BigMapContents.insertOrUpdateAll(rowsToWrite),
-              Tables.BigMapContentsHistory ++= updateData.map(Tables.BigMapContentsHistoryRow.tupled).distinct
+              Tables.BigMapContentsHistory ++= updateData
+                    .map(BigMapContentsRow.tupled)
+                    .map(_.transformInto[Tables.BigMapContentsHistoryRow])
+                    .distinct
             )
           }
         }

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/processing/BakingAndEndorsingRightsProcessor.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/processing/BakingAndEndorsingRightsProcessor.scala
@@ -151,7 +151,7 @@ class BakingAndEndorsingRightsProcessor(
   }
 
   /** Updates timestamps in the baking/endorsing rights tables */
-  private[tezos] def updateRightsTimestamps()(implicit ec: ExecutionContext): Future[Unit] = {
+  private[tezos] def updateRights()(implicit ec: ExecutionContext): Future[Unit] = {
     val logger = ConseilLogger("RightsUpdater")
     import cats.implicits._
     val blockHead = nodeOperator.getBareBlockHead()
@@ -162,16 +162,16 @@ class BakingAndEndorsingRightsProcessor(
       val br = nodeOperator.getBatchBakingRightsByLevels(blockLevelsToUpdate).flatMap { bakingRightsResult =>
         val brResults = bakingRightsResult.values.flatten
         logger.info(s"Got ${brResults.size} baking rights")
-        db.run(TezosDb.updateBakingRightsTimestamp(brResults.toList))
+        db.run(TezosDb.updateBakingRights(brResults.toList))
       }
       val er = nodeOperator.getBatchEndorsingRightsByLevel(blockLevelsToUpdate).flatMap { endorsingRightsResult =>
         val erResults = endorsingRightsResult.values.flatten
         logger.info(s"Got ${erResults.size} endorsing rights")
-        db.run(TezosDb.updateEndorsingRightsTimestamp(erResults.toList))
+        db.run(TezosDb.updateEndorsingRights(erResults.toList))
       }
       (br, er).mapN {
         case (bb, ee) =>
-          logger.info(s"Updated ${bb.sum} baking rights and ${ee.sum} endorsing rights rows")
+          logger.info(s"Updated $bb baking rights and $ee endorsing rights rows")
       }
     }
   }

--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/processing/MetadataProcessor.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/processing/MetadataProcessor.scala
@@ -4,10 +4,7 @@ import akka.stream.ActorMaterializer
 import tech.cryptonomic.conseil.common.tezos.Tables
 import tech.cryptonomic.conseil.common.tezos.TezosTypes.Micheline
 import tech.cryptonomic.conseil.indexer.tezos.michelson.contracts.TokenContracts.Tzip16
-import tech.cryptonomic.conseil.indexer.tezos.{
-  Tzip16MetadataOperator,
-  TezosDatabaseOperations => TezosDb
-}
+import tech.cryptonomic.conseil.indexer.tezos.{Tzip16MetadataOperator, TezosDatabaseOperations => TezosDb}
 import cats.instances.future._
 import cats.syntax.applicative._
 import cats.implicits._
@@ -15,15 +12,16 @@ import slick.jdbc.PostgresProfile.api._
 import tech.cryptonomic.conseil.common.io.Logging.ConseilLogSupport
 
 import scala.concurrent.{ExecutionContext, Future}
+
 /**
- * Class for processing metadata
- * I used following algorithm to process:
- * If the metadata-type is other, fetch the metadata from IPFS and save it in the metadata table.
- * If the metadata-type is self, use the metadata_path to update the metadata table.
- * If the metadata-type is contract, use the contract address and metadata_path to update the metadata table.
- * If the metadata-type is web, fetch the metadata from the web and update the metadata table.
- * If isNFT is true, use the metadata_big_map_id and metadata_big_map_type to update the metadata table.
- * */
+  * Class for processing metadata
+  * I used following algorithm to process:
+  * If the metadata-type is other, fetch the metadata from IPFS and save it in the metadata table.
+  * If the metadata-type is self, use the metadata_path to update the metadata table.
+  * If the metadata-type is contract, use the contract address and metadata_path to update the metadata table.
+  * If the metadata-type is web, fetch the metadata from the web and update the metadata table.
+  * If isNFT is true, use the metadata_big_map_id and metadata_big_map_type to update the metadata table.
+  * */
 class MetadataProcessor(
     metadataOperator: Tzip16MetadataOperator,
     db: Database


### PR DESCRIPTION
This PR contains bunch of fixes related to the Granada upgrade:
1. Baking/endorsing rights update after main loop reaches the head(previously only `estimated_time` was updated)
2. Explicitly using config setting for tracing calls and `parsing.max-to-strict-bytes`(responsible for recent errors with request too large) and adding reading  those values from env variables
3. Adding renamed field `deposits` to `CycleBalance` case class so we will avoid some warnings(and keeping the original one so we will be backward compatible)
4. Adding env variables for logging - it seems that we already support logging initial connection to Tezos node, but it was hidden - I've added it explicitly. We could say that this PR also resolves #966 