### PR TITLE
Upgrade Alpine packages - Snyk scans.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ WORKDIR /src
 RUN sbt clean assembly -J-Xss32m
 
 FROM openjdk:13-alpine
+RUN apk add --upgrade apk-tools busybox musl-utils
 RUN apk --no-cache add ca-certificates
 RUN apk add netcat-openbsd
 WORKDIR /root/


### PR DESCRIPTION
Alpine packages upgrade for Snyk vulnerability scanning.

Before:

```
Tested 17 dependencies for known vulnerabilities, found 16 vulnerabilities.

Base Image         Vulnerabilities  Severity
openjdk:13-alpine  16               7 high, 7 medium, 2 low
```

After:

```
✓ Tested 17 dependencies for known vulnerabilities, no vulnerable paths found.
```