### PR TITLE
927 - Bakers rolls size in config

### DIFF
--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/config/ConseilAppConfigTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/config/ConseilAppConfigTest.scala
@@ -20,6 +20,7 @@ class ConseilAppConfigTest extends ConseilSpec {
                                             |platforms: [
                                             |  {
                                             |    name: "tezos"
+                                            |    baker-rolls-size: 8000
                                             |    network: "alphanet"
                                             |    enabled: true,
                                             |    node: {
@@ -41,6 +42,7 @@ class ConseilAppConfigTest extends ConseilSpec {
                                             |  },
                                             |  {
                                             |    name: "tezos"
+                                            |    baker-rolls-size: 8000
                                             |    network: "alphanet-staging"
                                             |    enabled: false,
                                             |    node: {
@@ -71,6 +73,7 @@ class ConseilAppConfigTest extends ConseilSpec {
             "alphanet",
             enabled = true,
             TezosNodeConfiguration("localhost", 8732, "http", "tezos/alphanet/"),
+            BigDecimal.decimal(8000),
             cfg.getConfigList("platforms").get(0).getConfig("db"),
             None
           ),
@@ -84,6 +87,7 @@ class ConseilAppConfigTest extends ConseilSpec {
               "tezos/alphanet-staging/",
               traceCalls = true
             ),
+            BigDecimal.decimal(8000),
             cfg.getConfigList("platforms").get(1).getConfig("db"),
             None
           )
@@ -98,6 +102,7 @@ class ConseilAppConfigTest extends ConseilSpec {
                                               |platforms: [
                                               |  {
                                               |    name: "tezos"
+                                              |    baker-rolls-size: 8000
                                               |    network: "alphanet"
                                               |    enabled: true,
                                               |    node: {

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/metadata/MetadataServiceTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/metadata/MetadataServiceTest.scala
@@ -57,6 +57,7 @@ class MetadataServiceTest
             "mainnet",
             enabled = true,
             TezosNodeConfiguration("tezos-host", 123, "https://"),
+            BigDecimal.decimal(8000),
             dbCfg,
             None
           ),

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataTypesTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataTypesTest.scala
@@ -51,6 +51,7 @@ class ApiDataTypesTest extends ConseilSpec with MockFactory with BeforeAndAfterE
             "alphanet",
             enabled = true,
             TezosNodeConfiguration("tezos-host", 123, "https://"),
+            BigDecimal.decimal(8000),
             dbCfg,
             None
           )

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataRoutesTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataRoutesTest.scala
@@ -69,6 +69,7 @@ class TezosDataRoutesTest
             "alphanet",
             enabled = true,
             TezosNodeConfiguration("tezos-host", 123, "https://"),
+            BigDecimal.decimal(8000),
             dbCfg,
             None
           )

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/GenericPlatformDiscoveryOperationsTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/GenericPlatformDiscoveryOperationsTest.scala
@@ -89,6 +89,7 @@ class GenericPlatformDiscoveryOperationsTest
               "alphanet",
               enabled = true,
               TezosNodeConfiguration(protocol = "http", hostname = "localhost", port = 8732),
+              BigDecimal.decimal(8000),
               dbCfg,
               None
             )
@@ -105,6 +106,7 @@ class GenericPlatformDiscoveryOperationsTest
               "alphanet",
               enabled = true,
               TezosNodeConfiguration(protocol = "http", hostname = "localhost", port = 8732),
+              BigDecimal.decimal(8000),
               dbCfg,
               None
             ),
@@ -117,6 +119,7 @@ class GenericPlatformDiscoveryOperationsTest
                 port = 8732,
                 pathPrefix = "tezos/alphanet/"
               ),
+              BigDecimal.decimal(8000),
               dbCfg,
               None
             )
@@ -132,6 +135,7 @@ class GenericPlatformDiscoveryOperationsTest
               "alphanet",
               enabled = true,
               TezosNodeConfiguration(protocol = "http", hostname = "localhost", port = 8732),
+              BigDecimal.decimal(8000),
               dbCfg,
               None
             ),

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/PlatformDiscoveryTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/PlatformDiscoveryTest.scala
@@ -49,6 +49,7 @@ class PlatformDiscoveryTest extends ConseilSpec with ScalatestRouteTest with Moc
                   "mainnet",
                   enabled = true,
                   TezosNodeConfiguration("tezos-host", 123, "https://"),
+                  BigDecimal.decimal(8000),
                   dbCfg,
                   None
                 )

--- a/conseil-common/src/main/resources/reference.conf
+++ b/conseil-common/src/main/resources/reference.conf
@@ -24,6 +24,10 @@ platforms: [
   {
     name: "tezos"
 
+    baker-rolls-size: 8000
+    baker-rolls-size: ${?CONSEIL_XTZ_BACKER_ROLLS_SIZE}
+
+    network: "mainnet"
     network: "granadanet"
     network: ${?CONSEIL_XTZ_NETWORK}
 

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/config/Platforms.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/config/Platforms.scala
@@ -125,6 +125,7 @@ object Platforms {
       network: String,
       enabled: Boolean,
       node: TezosNodeConfiguration,
+      bakerRollsSize: BigDecimal,
       db: Config,
       tns: Option[TNSContractConfiguration]
   ) extends PlatformConfiguration {

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/io/MainOutputs.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/io/MainOutputs.scala
@@ -39,7 +39,7 @@ object MainOutputs {
 
   /* custom display of each configuration type */
   val showPlatformConfiguration: PartialFunction[PlatformConfiguration, String] = {
-    case TezosConfiguration(_, _, TezosNodeConfiguration(host, port, protocol, prefix, chainEnv, trace), _, _) =>
+    case TezosConfiguration(_, _, TezosNodeConfiguration(host, port, protocol, prefix, chainEnv, trace), _, _, _) =>
       s"node $protocol://$host:$port/$prefix/$chainEnv" + (if (trace) " [call tracing enabled]" else "")
     case EthereumConfiguration(network, _, node, _, _, _) =>
       s"network: ${network} node: ${node}"

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosTypes.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosTypes.scala
@@ -1,8 +1,14 @@
 package tech.cryptonomic.conseil.common.tezos
 
-import java.time.{Instant, ZonedDateTime}
-import scala.util.Try
+import tech.cryptonomic.conseil.common.config.Platforms._
+
 import cats.Functor
+import pureconfig._
+import pureconfig.generic.auto._
+
+import java.time.Instant
+import java.time.ZonedDateTime
+import scala.util.Try
 
 /**
   * Classes used for deserializing Tezos node RPC results.
@@ -14,7 +20,7 @@ object TezosTypes {
 
   //TODO use in a custom decoder for json strings that needs to have a proper encoding
   lazy val isBase58Check: String => Boolean = (s: String) => {
-    val pattern = "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]*$".r.pattern
+    val pattern = "^[^\\W0OlI_]*$".r.pattern
     pattern.matcher(s).matches
   }
 
@@ -687,9 +693,9 @@ object TezosTypes {
   /** Utilities related to the baking process */
   object Baking {
 
-    //we'll move this to a proper chain configuration value later on
     /** how big is a baker roll in tez */
-    final val BakerRollsSize = BigDecimal.decimal(8000)
+    final val BakerRollsSize =
+      loadConfig[TezosConfiguration](namespace = "platforms").fold(_ => BigDecimal.decimal(8000), _.bakerRollsSize)
 
     /** Starting from the staking balance, infers number of rolls for a given baker. */
     def computeRollsFromStakes(stakingBalance: PositiveBigNumber): Option[Int] =

--- a/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/config/PlatformsTest.scala
+++ b/conseil-common/src/test/scala/tech/cryptonomic/conseil/common/config/PlatformsTest.scala
@@ -28,7 +28,8 @@ class PlatformsTest extends ConseilSpec {
         """.stripMargin)
 
   private val configTezosNode = TezosNodeConfiguration("host", 0, "protocol")
-  private val configTezos = TezosConfiguration("mainnet", enabled = true, configTezosNode, dbCfg, None)
+  private val configTezos =
+    TezosConfiguration("mainnet", enabled = true, configTezosNode, BigDecimal.decimal(8000), dbCfg, None)
   private val configBitcoinNode = BitcoinNodeConfiguration("host", 0, "protocol", "username", "password")
   private val configBitcoinBatching = BitcoinBatchFetchConfiguration(1, 1, 1, 1, 1)
   private val configBitcoin =

--- a/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/config/LorreAppConfigTest.scala
+++ b/conseil-lorre/src/test/scala/tech/cryptonomic/conseil/indexer/config/LorreAppConfigTest.scala
@@ -1,6 +1,6 @@
 package tech.cryptonomic.conseil.indexer.config
 
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.ConfigFactory
 import tech.cryptonomic.conseil.common.config.Platforms.{TezosConfiguration, TezosNodeConfiguration}
 import tech.cryptonomic.conseil.indexer.config.LorreAppConfig.Loaders._
 import tech.cryptonomic.conseil.indexer.config.ConfigUtil.Natural
@@ -44,6 +44,7 @@ class LorreAppConfigTest extends ConseilSpec {
                                               |platforms: [
                                               |  {
                                               |    name: "tezos"
+                                              |    baker-rolls-size: 8000
                                               |    network: "alphanet"
                                               |    enabled: true,
                                               |    node: {
@@ -71,6 +72,7 @@ class LorreAppConfigTest extends ConseilSpec {
           "alphanet",
           enabled = true,
           TezosNodeConfiguration("localhost", 8732, "http", "tezos/alphanet/"),
+          BigDecimal.decimal(8000),
           cfg.getConfigList("platforms").get(0).getConfig("db"),
           None
         )
@@ -81,6 +83,7 @@ class LorreAppConfigTest extends ConseilSpec {
                                             |platforms: [
                                             |  {
                                             |    name: "tezos"
+                                            |    baker-rolls-size: 8000
                                             |    network: "alphanet"
                                             |    enabled: true,
                                             |    node: {
@@ -108,6 +111,7 @@ class LorreAppConfigTest extends ConseilSpec {
           "alphanet",
           enabled = true,
           TezosNodeConfiguration("localhost", 8732, "http"),
+          BigDecimal.decimal(8000),
           cfg.getConfigList("platforms").get(0).getConfig("db"),
           None
         )

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       # CONSEIL_XTZ_NODE_HOSTNAME:???     # (default nautilus.cryptonomic.tech)
       # CONSEIL_XTZ_NODE_PORT:???         # (default 8732)
       # CONSEIL_XTZ_NODE_PATH_PREFIX:???  # (default tezos/zeronet/)
+      # CONSEIL_XTZ_BACKER_ROLLS_SIZE:??? # (default 8000)
 
       # CONSEIL_BTC_NETWORK:???                           # (default mainnet)
       # CONSEIL_BTC_ENABLED:???                           # (default false)
@@ -87,6 +88,7 @@ services:
       # CONSEIL_XTZ_NODE_HOSTNAME:???     # (default nautilus.cryptonomic.tech)
       # CONSEIL_XTZ_NODE_PORT:???         # (default 8732)
       # CONSEIL_XTZ_NODE_PATH_PREFIX:???  # (default tezos/zeronet/)
+      # CONSEIL_XTZ_BACKER_ROLLS_SIZE:??? # (default 8000)
 
       # CONSEIL_BTC_NETWORK:??? # (default mainnet)
       # CONSEIL_BTC_ENABLED:??? # (default false)


### PR DESCRIPTION
This PR adds bakers rolls size to the `reference.conf` config file in `conseil-common`. It additionally updates tests respectively.