### PR TITLE
Fixed test error + proper use of Try if import found in scope

### DIFF
--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosJsonDecoders.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/TezosJsonDecoders.scala
@@ -171,13 +171,13 @@ private[tezos] object TezosJsonDecoders {
       /* try decoding a number */
       implicit private val bignumDecoder: Decoder[Decimal] =
         Decoder.decodeString
-          .emapTry(jsonString => scala.util.Try(BigDecimal(jsonString)))
+          .emapTry(jsonString => Try(BigDecimal(jsonString)))
           .map(Decimal)
 
       /* try decoding a positive number */
       implicit private val positiveBignumDecoder: Decoder[PositiveDecimal] =
         Decoder.decodeString
-          .emapTry(jsonString => scala.util.Try(BigDecimal(jsonString)))
+          .emapTry(jsonString => Try(BigDecimal(jsonString)))
           .ensure(_ >= 0, "The passed-in json string is not a non-negative number")
           .map(PositiveDecimal)
 


### PR DESCRIPTION
This PR fixes the error in `JsonDecodersTestFixtures` caused by the absence of the expected constructor's argument and the wrong type of another provided argument. It's enough to provide dummy `None` values for an optional parameter. Additionally, there were some occurrences of `scala.util.Try` even though there was already an import `import scala.util.Try` in the scope.