### PR TITLE
Bumped up the version of `endpoints4s` library

### DIFF
--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/Docs.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/Docs.scala
@@ -1,8 +1,8 @@
 package tech.cryptonomic.conseil.api.routes
 
 import tech.cryptonomic.conseil.api.routes.openapi.OpenApiDoc
-import endpoints.akkahttp.server
-import endpoints.openapi.model.OpenApi
+import endpoints4s.akkahttp.server
+import endpoints4s.openapi.model.OpenApi
 
 /** implements a server endpoint to provide
   * the openapi definition as a json file

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/info/AppInfo.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/info/AppInfo.scala
@@ -1,7 +1,7 @@
 package tech.cryptonomic.conseil.api.routes.info
 
 import akka.http.scaladsl.server.Route
-import endpoints.akkahttp
+import endpoints4s.akkahttp
 import tech.cryptonomic.conseil.BuildInfo
 
 /** defines endpoints to expose the currently deployed application information (e.g version, ...) */

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/info/AppInfoEndpoint.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/info/AppInfoEndpoint.scala
@@ -1,6 +1,6 @@
 package tech.cryptonomic.conseil.api.routes.info
 
-import endpoints.algebra
+import endpoints4s.algebra
 import AppInfo.Info
 
 /** Trait containing AppInfo endpoint definition */

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/info/AppInfoJsonSchemas.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/info/AppInfoJsonSchemas.scala
@@ -1,6 +1,6 @@
 package tech.cryptonomic.conseil.api.routes.info
 
-import endpoints.generic
+import endpoints4s.generic
 import AppInfo.{GitInfo, Info}
 
 /** Trait containing AppInfo schema */

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/openapi/OpenApiDoc.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/openapi/OpenApiDoc.scala
@@ -1,8 +1,8 @@
 package tech.cryptonomic.conseil.api.routes.openapi
 
-import endpoints.algebra.Documentation
-import endpoints.openapi
-import endpoints.openapi.model.{Info, MediaType, OpenApi, Schema}
+import endpoints4s.algebra.Documentation
+import endpoints4s.openapi
+import endpoints4s.openapi.model.{Info, MediaType, OpenApi, Schema}
 import tech.cryptonomic.conseil.api.routes.info.AppInfoEndpoint
 import tech.cryptonomic.conseil.api.routes.platform.data.bitcoin.BitcoinDataEndpoints
 import tech.cryptonomic.conseil.api.routes.platform.data.ethereum.{EthereumDataEndpoints, QuorumDataEndpoints}
@@ -94,7 +94,7 @@ object OpenApiDoc
     */
   override def validated[A](
       response: List[DocumentedResponse],
-      invalidDocs: endpoints.algebra.Documentation
+      invalidDocs: Documentation
   ): List[DocumentedResponse] =
     response ++ List(
           DocumentedResponse(
@@ -102,7 +102,7 @@ object OpenApiDoc
             documentation = invalidDocs.getOrElse(""),
             headers = DocumentedHeaders(List.empty),
             content = Map(
-              "application/json" -> MediaType(schema = Some(Schema.Array(Left(Schema.simpleString), None, None)))
+              "application/json" -> MediaType(schema = Some(Schema.Array(Left(Schema.simpleString), None, None, None)))
             )
           ),
           DocumentedResponse(
@@ -126,7 +126,7 @@ object OpenApiDoc
           documentation = invalidDocs.getOrElse(""),
           headers = DocumentedHeaders(List.empty),
           content = Map(
-            "application/json" -> MediaType(schema = Some(Schema.Array(Left(Schema.simpleString), None, None)))
+            "application/json" -> MediaType(schema = Some(Schema.Array(Left(Schema.simpleString), None, None, None)))
           )
         )
 

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataEndpoints.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataEndpoints.scala
@@ -1,6 +1,6 @@
 package tech.cryptonomic.conseil.api.routes.platform.data
 
-import endpoints.algebra
+import endpoints4s.algebra
 import tech.cryptonomic.conseil.api.routes.platform.data.ApiDataTypes.ApiQuery
 import tech.cryptonomic.conseil.api.routes.validation.Validation
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.QueryResponseWithOutput

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataJsonSchemas.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataJsonSchemas.scala
@@ -1,6 +1,6 @@
 package tech.cryptonomic.conseil.api.routes.platform.data
 
-import endpoints.generic
+import endpoints4s.generic
 import tech.cryptonomic.conseil.api.routes.platform.data.ApiDataTypes.ApiQuery
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes._
 

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataStandardJsonCodecs.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataStandardJsonCodecs.scala
@@ -1,8 +1,8 @@
 package tech.cryptonomic.conseil.api.routes.platform.data
 
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.QueryResponse
-import endpoints.algebra.{Decoder, Encoder}
-import endpoints.{Invalid, Valid}
+import endpoints4s.{Decoder, Encoder}
+import endpoints4s.{Invalid, Valid}
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.{Field, FormattedField, SimpleField}
 import ujson.{Bool, Num, Str}
 

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiFilter.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiFilter.scala
@@ -1,7 +1,7 @@
 package tech.cryptonomic.conseil.api.routes.platform.data
 
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.{OrderDirection, QueryOrdering}
-import endpoints.{Invalid, Valid, Validated}
+import endpoints4s.{Invalid, Valid, Validated}
 
 /** Trait which provides common elements for creating filters in API */
 trait ApiFilter {

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiFilterQueryString.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiFilterQueryString.scala
@@ -1,6 +1,6 @@
 package tech.cryptonomic.conseil.api.routes.platform.data
 
-import endpoints.algebra
+import endpoints4s.algebra
 import tech.cryptonomic.conseil.api.routes.platform.data.ApiFilter.Sorting
 import tech.cryptonomic.conseil.api.routes.platform.data.ApiFilter.Sorting._
 

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiServerJsonSchema.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiServerJsonSchema.scala
@@ -1,7 +1,7 @@
 package tech.cryptonomic.conseil.api.routes.platform.data
 
-import endpoints.akkahttp.server.JsonEntitiesFromSchemas
-import endpoints.algebra.{Decoder, Encoder}
+import endpoints4s.akkahttp.server.JsonEntitiesFromSchemas
+import endpoints4s.{Decoder, Encoder}
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.QueryResponse
 import ApiDataStandardJsonCodecs.{
   anyDecoder,

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiValidation.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiValidation.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
 import akka.http.scaladsl.server.Directives.complete
 import akka.http.scaladsl.server.Route
 import akka.util.ByteString
-import endpoints.algebra.Documentation
+import endpoints4s.algebra.Documentation
 import tech.cryptonomic.conseil.api.routes.validation.Validation.QueryValidating
 import tech.cryptonomic.conseil.api.routes.platform.data.CsvConversions._
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.{OutputType, QueryResponseWithOutput}

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinDataEndpoints.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinDataEndpoints.scala
@@ -2,7 +2,7 @@ package tech.cryptonomic.conseil.api.routes.platform.data.bitcoin
 
 import tech.cryptonomic.conseil.api.routes.platform.data.{ApiDataEndpoints, ApiDataJsonSchemas, ApiDataTypes}
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.QueryResponse
-import endpoints.algebra
+import endpoints4s.algebra
 import tech.cryptonomic.conseil.api.routes.validation.Validation.QueryValidating
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes
 

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinDataHelpers.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinDataHelpers.scala
@@ -1,8 +1,8 @@
 package tech.cryptonomic.conseil.api.routes.platform.data.bitcoin
 
 import akka.http.scaladsl.server.Route
-import endpoints.akkahttp.server.Endpoints
-import endpoints.algebra.Documentation
+import endpoints4s.akkahttp.server.Endpoints
+import endpoints4s.algebra.Documentation
 import tech.cryptonomic.conseil.api.routes.platform.data.ApiServerJsonSchema
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.QueryValidationError
 import tech.cryptonomic.conseil.api.routes.platform.data.ApiValidation.defaultValidated

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinFilterFromQueryString.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/bitcoin/BitcoinFilterFromQueryString.scala
@@ -1,6 +1,6 @@
 package tech.cryptonomic.conseil.api.routes.platform.data.bitcoin
 
-import endpoints.algebra.JsonEntities
+import endpoints4s.algebra.JsonEntities
 import tech.cryptonomic.conseil.api.routes.platform.data.ApiFilter.Sorting
 
 /** Trait containing helper functions which are necessary for parsing query parameter strings as Filter */

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ethereum/EthereumDataEndpointsCreator.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ethereum/EthereumDataEndpointsCreator.scala
@@ -2,7 +2,7 @@ package tech.cryptonomic.conseil.api.routes.platform.data.ethereum
 
 import tech.cryptonomic.conseil.api.routes.platform.data.{ApiDataEndpoints, ApiDataJsonSchemas}
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.QueryResponse
-import endpoints.algebra
+import endpoints4s.algebra
 
 /** Trait containing endpoints definitions for Ethereum-related blockchains */
 trait EthereumDataEndpointsCreator

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ethereum/EthereumDataHelpers.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ethereum/EthereumDataHelpers.scala
@@ -1,8 +1,8 @@
 package tech.cryptonomic.conseil.api.routes.platform.data.ethereum
 
 import akka.http.scaladsl.server.Route
-import endpoints.akkahttp.server.Endpoints
-import endpoints.algebra.Documentation
+import endpoints4s.akkahttp.server.Endpoints
+import endpoints4s.algebra.Documentation
 
 import tech.cryptonomic.conseil.api.routes.validation.Validation.QueryValidating
 import tech.cryptonomic.conseil.api.routes.platform.data.ApiValidation.defaultValidated

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ethereum/EthereumFilterFromQueryString.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/ethereum/EthereumFilterFromQueryString.scala
@@ -1,6 +1,6 @@
 package tech.cryptonomic.conseil.api.routes.platform.data.ethereum
 
-import endpoints.algebra.JsonEntities
+import endpoints4s.algebra.JsonEntities
 import tech.cryptonomic.conseil.api.routes.platform.data.ApiFilter.Sorting
 import tech.cryptonomic.conseil.api.routes.platform.data.ApiFilterQueryString
 

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataEndpoints.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataEndpoints.scala
@@ -5,7 +5,7 @@ import tech.cryptonomic.conseil.api.routes.platform.data.tezos.TezosDataOperatio
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes._
 import tech.cryptonomic.conseil.common.tezos.Tables
 import tech.cryptonomic.conseil.common.tezos.Tables.BlocksRow
-import endpoints.algebra
+import endpoints4s.algebra
 import tech.cryptonomic.conseil.api.routes.validation.Validation.QueryValidating
 
 /** Trait containing endpoints definition */

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataHelpers.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosDataHelpers.scala
@@ -1,8 +1,8 @@
 package tech.cryptonomic.conseil.api.routes.platform.data.tezos
 
 import akka.http.scaladsl.server.Route
-import endpoints.akkahttp.server.Endpoints
-import endpoints.algebra.Documentation
+import endpoints4s.akkahttp.server.Endpoints
+import endpoints4s.algebra.Documentation
 import tech.cryptonomic.conseil.api.routes.validation.Validation.QueryValidating
 import tech.cryptonomic.conseil.api.routes.platform.data.ApiServerJsonSchema
 import tech.cryptonomic.conseil.api.routes.platform.data.ApiValidation.defaultValidated

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosFilterFromQueryString.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/data/tezos/TezosFilterFromQueryString.scala
@@ -1,6 +1,6 @@
 package tech.cryptonomic.conseil.api.routes.platform.data.tezos
 
-import endpoints.algebra
+import endpoints4s.algebra
 import tech.cryptonomic.conseil.api.routes.platform.data.ApiFilter.Sorting
 import tech.cryptonomic.conseil.api.routes.platform.data.ApiFilterQueryString
 

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/PlatformDiscovery.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/PlatformDiscovery.scala
@@ -3,8 +3,8 @@ package tech.cryptonomic.conseil.api.routes.platform.discovery
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
-import endpoints.akkahttp
-import endpoints.algebra.Documentation
+import endpoints4s.akkahttp
+import endpoints4s.algebra.Documentation
 import tech.cryptonomic.conseil.common.io.Logging.ConseilLogSupport
 import tech.cryptonomic.conseil.api.metadata.MetadataService
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.AttributesValidationError

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/PlatformDiscoveryEndpoints.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/PlatformDiscoveryEndpoints.scala
@@ -1,6 +1,6 @@
 package tech.cryptonomic.conseil.api.routes.platform.discovery
 
-import endpoints.algebra
+import endpoints4s.algebra
 import tech.cryptonomic.conseil.api.routes.validation.AttributesQueryValidation
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.AttributesValidationError
 import tech.cryptonomic.conseil.common.generic.chain.PlatformDiscoveryTypes

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/PlatformDiscoveryJsonSchemas.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/PlatformDiscoveryJsonSchemas.scala
@@ -1,6 +1,6 @@
 package tech.cryptonomic.conseil.api.routes.platform.discovery
 
-import endpoints.generic
+import endpoints4s.generic
 import tech.cryptonomic.conseil.common.generic.chain.PlatformDiscoveryTypes._
 
 /** Trait containing metadata endpoints JSON schemas */

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/validation/AttributesQueryValidation.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/validation/AttributesQueryValidation.scala
@@ -1,7 +1,7 @@
 package tech.cryptonomic.conseil.api.routes.validation
 
-import endpoints.algebra
-import endpoints.algebra.Documentation
+import endpoints4s.algebra
+import endpoints4s.algebra.Documentation
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.AttributesValidationError
 
 /** Trait adding validation for querying attributes  */

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/validation/Validation.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/validation/Validation.scala
@@ -1,7 +1,7 @@
 package tech.cryptonomic.conseil.api.routes.validation
 
-import endpoints.algebra
-import endpoints.algebra.Documentation
+import endpoints4s.algebra
+import endpoints4s.algebra.Documentation
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.QueryValidationError
 
 /** Trait adding validation for query  */

--- a/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataHelpersTest.scala
+++ b/conseil-api/src/test/scala/tech/cryptonomic/conseil/api/routes/platform/data/ApiDataHelpersTest.scala
@@ -5,7 +5,7 @@ import java.time.Instant
 import tech.cryptonomic.conseil.common.testkit.ConseilSpec
 import tech.cryptonomic.conseil.common.generic.chain.DataTypes.{OutputType, QueryResponseWithOutput}
 import ujson.{Value => Json}
-import endpoints.akkahttp.server.Endpoints
+import endpoints4s.akkahttp.server.Endpoints
 
 class ApiDataHelpersTest extends ConseilSpec {
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,9 @@ object Dependencies {
     val slickEffect = "0.3.0"
     val postgres = "42.1.4"
 
-    val endpoints = "0.15.0"
+    val endpoints4s = "1.3.0"
+    val endpoints4sBackCompatible = "1.1.0"
+    val endpoints4sAkkaServer = "4.0.0"
     val cats = "2.1.1"
     val catsEffect = "2.1.3"
     val mouse = "0.25"
@@ -95,11 +97,11 @@ object Dependencies {
   private val postgres = Seq("org.postgresql" % "postgresql" % Versions.postgres)
 
   private val endpoints = Seq(
-    "org.julienrf" %% "endpoints-algebra"             % Versions.endpoints,
-    "org.julienrf" %% "endpoints-openapi"             % Versions.endpoints,
-    "org.julienrf" %% "endpoints-json-schema-generic" % Versions.endpoints,
-    "org.julienrf" %% "endpoints-json-schema-circe"   % Versions.endpoints,
-    "org.julienrf" %% "endpoints-akka-http-server"    % Versions.endpoints
+    "org.endpoints4s" %% "algebra"             % Versions.endpoints4s,
+    "org.endpoints4s" %% "openapi"             % Versions.endpoints4sBackCompatible,
+    "org.endpoints4s" %% "json-schema-generic" % Versions.endpoints4sBackCompatible,
+    "org.endpoints4s" %% "json-schema-circe"   % Versions.endpoints4sBackCompatible,
+    "org.endpoints4s" %% "akka-http-server"    % Versions.endpoints4sAkkaServer
   )
 
   private val cats = Seq(


### PR DESCRIPTION
As part of #1020 we decided to upgrade the version of the `endpoints4s` library which has meanwhile moved from the author's repo to the official one. The newest library version, namely `1.5.0` seems to not be entirely compatible with our current codebase, hence, for the time being, we've used `1.3.0`.

This PR also fixes all the related imports regarding `endpoints4s`.