### PR TITLE
Fork handling bugfix

### DIFF
--- a/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/forks/BacktracingForkProcessor.scala
+++ b/conseil-lorre/src/main/scala/tech/cryptonomic/conseil/indexer/tezos/forks/BacktracingForkProcessor.scala
@@ -57,10 +57,10 @@ class BacktracingForkProcessor(
             if (indexedBlock.forall(_.hash == chainBlock.hash.value)) {
               -1
             } else {
-              logger.debug(
+              logger.info(
                 s"Hashes don't match: ${chainBlock.header.level} ${indexedBlock.map(_.hash)} && ${chainBlock.hash.value}"
               )
-              l
+              level - l
             }
           }
       }.sequence


### PR DESCRIPTION
The problem was with my testing as I was using only limited number of blocks. I managed to reproduce the issue when I fetched whole testnet. 
Lorre was trying to invalidate whole DB because it was using wrong level of the block for invalidation.
Instead using `headLevel - index` of the block fetched I had just `index`. I fixed it and change one log level to `info` instead of `debug`.