### PR TITLE
Fix for attribute values pre-caching taking too long

### DIFF
--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/ConseilApi.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/ConseilApi.scala
@@ -232,6 +232,11 @@ class ConseilApi(config: CombinedConfiguration)(implicit system: ActorSystem)
         case Failure(exception) => logger.error("Pre-caching attributes failed", exception)
         case Success(_) => logger.info("Pre-caching attributes successful!")
       }
+
+      cachedDiscoveryOperations.initAttributeValuesCache(visibleNetworks).onComplete {
+        case Failure(exception) => logger.error("Pre-caching attribute values failed", exception)
+        case Success(_) => logger.info("Pre-caching attribute values successful!")
+      }
     } else {
       throw NoNetworkEnabledError(
         """|Pre-caching can't be done, because there is no enabled block-chain defined.

--- a/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/GenericPlatformDiscoveryOperations.scala
+++ b/conseil-api/src/main/scala/tech/cryptonomic/conseil/api/routes/platform/discovery/GenericPlatformDiscoveryOperations.scala
@@ -17,7 +17,6 @@ import tech.cryptonomic.conseil.common.metadata._
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 import cats.effect.unsafe.implicits.global
-import tech.cryptonomic.conseil.common.io.Logging.ConseilLogSupport
 
 /** Companion object providing apply method implementation */
 object GenericPlatformDiscoveryOperations {


### PR DESCRIPTION
Problem with Conseil startup was attribute values pre-caching. 
The solution is to allow pre-caching of attribute values run in the background and not block startup of the API. During this time attribute values are not available, but rest of the API is. I think it is a fair middle ground.