### PR TITLE
Fix for docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ RUN apt-get update && apt-get install -y apt-transport-https libpq5 ca-certifica
     apt-get update && \
     apt-get install -y sbt
 RUN adduser --disabled-password --gecos '' builduser && su builduser
-USER builduser
+RUN mkdir -p /src/target
+RUN chmod 777 /src/target
+
 COPY --chown=builduser:builduser ./docker /src/docker
 COPY --chown=builduser:builduser ./project/build.properties /src/project/
 COPY --chown=builduser:builduser ./project/plugins.sbt /src/project/
@@ -23,6 +25,8 @@ COPY --chown=builduser:builduser ./conseil-api/src /src/conseil-api/src
 COPY --chown=builduser:builduser ./conseil-lorre/src /src/conseil-lorre/src
 COPY --chown=builduser:builduser ./build.sbt /src
 COPY --chown=builduser:builduser ./publishing.sbt /src
+RUN chown -R builduser:builduser /src
+USER builduser
 WORKDIR /src
 RUN sbt clean assembly -J-Xss32m -J-Xmx2G
 


### PR DESCRIPTION
So the problem was with update of sbt to vesrion 1.5.8. Latest is 1.6.2, but it has an issue when it does not start correctly Conseil API(it starts in the background). 1.5.x though does not show exactly what's wrong with the build. So I've had to look into 1.4.x output which showed what's wrong and then made necessary changes to the Dockerfile - apparently after update of sbt it couldn't access certain files inside the docker.
 