### PR TITLE
Fix for typo in implicit operation results

### DIFF
--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosTypes.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/tezos/TezosTypes.scala
@@ -111,7 +111,7 @@ object TezosTypes {
       storage: Option[Micheline],
       balance_updates: List[OperationMetadata.BalanceUpdate],
       consumed_gas: PositiveBigNumber,
-      consumed_miligas: PositiveBigNumber,
+      consumed_milligas: PositiveBigNumber,
       storage_size: PositiveBigNumber
   )
 


### PR DESCRIPTION
fixed typo in implicit operation results, which caused missing cycle/period information