### PR TITLE
Metadata updates for Conseil Lima

### DIFF
--- a/conseil-api/src/main/resources/metadata.conf
+++ b/conseil-api/src/main/resources/metadata.conf
@@ -71,6 +71,10 @@ metadata-configuration {
         include "metadata/tezos.kathmandunet.conf"
         visible: true
       }
+      limanet {
+          include "metadata/tezos.limanet.conf"
+          visible: true
+        }
     }
   }
   bitcoin {

--- a/conseil-api/src/main/resources/metadata/tezos.limanet.conf
+++ b/conseil-api/src/main/resources/metadata/tezos.limanet.conf
@@ -1,0 +1,3413 @@
+{
+  entities {
+    accounts_checkpoint {
+      description: "Internal table to keep track of account sync process"
+      visible: false
+    }
+    processed_chain_events {
+      description: "Internal table to keep track of account sync process"
+      visible: false
+    }
+    accounts {
+      display-name-plural: "Accounts"
+      display-name: "Account"
+      visible: true,
+      attributes {
+        account_id {
+          description: "Sometimes referred to as 'public key hash', the address is a unique account identifier"
+          display-name: "Address"
+          placeholder: "tz1..."
+          visible: true
+          data-type: "accountAddress"
+          display-priority: 0
+          display-order: 0
+          cache-config {
+            cached: true,
+            min-match-length: 4,
+            max-result-size: 100
+          }
+          value-map: {
+            "tz1ck2Dg17CaAT592JQhCDrsMzbvfEzr4urZ": "Taco Klepto"
+            "tz1aPzpnmcXpp4ukou11pDgEuNHAsMT2hUUv": "Taco Hoarder"
+            "tz1VwmmesDxud2BJEyDKUTV5T5VEP8tGBKGD": "Mainnet Faucet"
+            "tz1Z9MxKUBcbA6SKyKu9VLif8PeiQ5fkpCeo": "@tezosnoob (Legacy)"
+            "tz2PhQ4Pq5S77YRjXMMpZetXSrSCrfKAvngB": "@tezosnoob"
+            "tz2V2T51d8pg2D7pGSD6LdHpua72v7CSAEpP": "@tezosnftfaucet"
+            "tz1RaGb8tWxUh194btmAiXT9Tkk6pGBMZVL8": "USDtz Mother"
+            "tz1djRgXXWWJiY1rpMECCxr5d9ZBqWewuiU1": "Galleon Support"
+            "tz1cPGs7kKJ4NmAB5XTB1dubK4cfDoFffHq5": "STKR AirDrop"
+            "tz1SiPXX4MYGNJNDsRc7n8hkvUqFzg8xqF9m": "Binance A"
+            "tz1eogbwM5NdoojKEvvSnjYGcJapZgADRK3m": "Binance B"
+            "tz1ch7nvDDAchbAPfTio3yBsdvN1SZJZj1wY": "Binance C"
+            "tz1Q3jvYU9knekDYJfyvj3GjUy6898MNjvb2": "Binance D"
+            "tz1d6qqVYwPLLvzZ8X37ATHr4Hi2TcBXQmSZ": "Binance E"
+            "tz1XTQWJZnDFpYPh13LyZcWSSuxEmWRjNxWn": "Binance F"
+            "tz1c5wM9826YcUNQ8a17z9eUYpKQ3oW3zfmJ": "Kaiko Price Oracle Updater A"
+            "tz1QSbd179w1Xp9WTaCwcBt4xxvBpZEtxbxJ": "Harbinger Coinbase Pro Oracle Updater A"
+            "tz2L9474hvA2EXyNLi4u3YnqrKVf3GzeZ8tb": "Harbinger Coinbase Pro Oracle Updater B"
+            "tz1cYfMsbsGhxPqDovmaQHDByTeqiRTygEpc": "Upbit A"
+            "tz1MRssJTFokjJ4WHAY63wFTufQ8qpxZJtvU": "Upbit B"
+            "tz1bDXD6nNSrebqmAnnKKwnX1QdePSMCj4MX": "Kraken A"
+            "tz1YpWsMwc4gSyjtxEF3JbmN6YrGiDidaSmg": "Kraken B"
+            "tz1NH4A2kRyFQUYhyi9aL8jrrySQUrCgNsX9": "Kraken C"
+            "tz1cgJLxcS8ZTgq5dXPtojJJR7Bp8fKDyxPK": "Kraken D"
+            "tz1e9ZH87proooFwLidjvE8fhusWfeDf3bgk": "Kraken E"
+            "tz1ejivVeR6WxqzphH31EJPm87jyYu6HVXXw": "worldartday2021"
+            "tz1bkMZKrPYUWvVmP4yw4EHv6PTAA76b6pcJ": "Smartlink ICO"
+            "tz1dMYz5pcXYXnfH5gjr652iSDq9zc2SrqRi": "Tezos India Covid Charity"
+            "tz1ecr3NoPwvbJQSQXFJrk1cYGcDsJmmKEG5": "Hicathon"
+            "tz1WC3dUzy19mbkGwz4J3KhuSonE7AQxbZuF": "@KidMograph"
+            "tz1gqaKjfQBhUMCE6LhbkpuittRiWv5Z6w38": "@jjjjjjjjjjohn"
+            "tz1UBZUkXpKGhYsP5KtzDNqLLchwF4uHrGjw": "@hicetnunc2000"
+
+            "KT1ChNsEFxwyCbJyWGSL3KdjeXE28AY1Kaog": "TCF Baker Registry"
+            "KT1GfAzvH7aUtVPbqRw6WbYMbd77dFPErQUg": "StakerDAO Manager"
+            "KT1EctCuorV2NfVb1XTQgvzJ88MQtWP8cMMv": "StakerDAO Token (Legacy)"
+            "KT1LN4LPSqTMS7Sd2CJw4bbDGRkMv2t68Fy9": "USDtz Token"
+            "KT1PWx2mnDueood7fEmfbBDKx1D9BAnnXitn": "tzBTC"
+            "KT1Jr5t9UvGiqkvvsuUbPJHaYx24NzdUwNW9": "Harbinger Storage: Coinbase Pro"
+            "KT1AdbYiPYb5hDuEuVrfxmFehtnBCXv4Np7r": "Harbinger Normalizer: Coinbase Pro"
+            "KT1Mx5sFU4BZqnAaJRpMzqaPbd2qMCFmcqea": "Harbinger Storage: Binance"
+            "KT1SpD9Xh3PcmBGwbZPhVmHUM8shTwYhQFBa": "Harbinger Normalizer: Binance"
+            "KT1Jud6STRGZs6hSfgZsaeztbkzfwC3JswJP": "Harbinger Storage: Gemini"
+            "KT1JywdJbaVW5HtsYh4XNNuHcVL2vE6sYh7W": "Harbinger Normalizer: Gemini"
+            "KT1G3UMEkhxso5cdx2fvoJRJu5nUjBWKMrET": "Harbinger Storage: OKEx"
+            "KT1J623FNZ6an8NHkWFbtvm5bKXgFzhBc5Zf": "Harbinger Normalizer: OKEx"
+            "KT1DrJV8vhkdLEj76h1H9Q4irZDqAkMPo1Qf": "Compromised Dexter tzBTC Pool"
+            "KT1Puc9St8wdNoGtLiD2WXaHbWU7styaxYhD": "Compromised Dexter USDtz Pool"
+            "KT19kgnqC5VWoxktLRdRUERbyUPku9YioE8W": "Kaiko Price Oracle"
+            "KT19at7rQUvyjxnZ2fBv7D9zc8rkyG7gAoU8": "ETHtz Token"
+            "KT19c8n5mWrqpxMcR3J687yssHxotj88nGhZ": "Compromised Dexter ETHtz Pool"
+            "KT1VYsVfmobT7rsMVivvZ4J8i3bPiqz12NaH": "wXTZ Token"
+            "KT1V4Vp7zhynCNuaBjWMpNU535Xm2sgqkz6M": "wXTZ Core"
+            "KT1FMSwqX2W2p1CCJeJNy2rvYEYEYjRiUza3": "Tezex Swap Contract"
+            "KT1PDrBE59Zmxnb8vXRgRAG1XmvTMTs5EDHU": "Dexter ETHtz Pool"
+            "KT1Tr2eG3eVmPRbymrbU2UppUmKjFPXomGG9": "Dexter USDtz Pool"
+            "KT1BGQR7t4izzKZ7eRodKWTodAsM23P38v7N": "Dexter tzBTC Pool"
+            "KT1D56HQfMmwdopmFLTwNHFJSs6Dsg2didFo": "Dexter wXTZ Pool"
+            "KT1H28iie4mW9LmmJeYLjH6zkC8wwSmfHf5P": "TzButton Round 2"
+            "KT1K9gCRgaLRFKTErYt1wVxA3Frb9FjasjTV": "Kolibri Token"
+            "KT1AbYeDbjjcAnV1QK7EZUUdqku77CdkTuv6": "Dexter kUSD Pool"
+            "KT1Hkg5qeNhfwpKW4fXvq7HGZB9z2EnmCCA9": "hic et nunc Art House (Legacy v1)"
+            "KT1HbQepzV1nVGg8QVznG7z4RcHseD5kwqBn": "hic et nunc Art House v2"
+            "KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton": "hic et nunc NFT"
+            "KT1AFA2mwNUMNd4SsujE1YYp29vd8BZejyKW": "hic et nunc hDAO"
+            "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU": "tzcolors Auction House"
+            "KT1FyaDqiMQWg7Exo7VUiXAgZbd2kCzo3d4s": "tzcolors NFT"
+            "KT1VG2WtYdSWz5E7chTeAdDPZNy2MpP8pTfL": "Atomex"
+            "KT1VgXHLXRgh6J5iGw4zkk7vUfjLoPhRnt9L": "RAMP DeFi rStake Manager"
+            "KT1MEouXPpCx9eFJYnxfAWpFA7NxhW3rDgUN": "BLND Token"
+            "KT1AEfeckNbdEYwaMKkytBwPJPycz7jdSGea": "Staker Governance Token (STKR)"
+            "KT1JdufSdfg3WyxWJcCRNsBFV9V3x9TQBkJ2": "Kolibri Oven Proxy"
+            "KT1Ty2uAmF5JxWyeGrVpk17MEyzVB8cXs8aJ": "Kolibri Minter"
+            "KT1Ldn1XWQmk7J4pYgGFjjwV57Ew8NYvcNtJ": "Kolibri Oven Registry"
+            "KT1TybhR7XraG75JFYKSrh7KnxukMBT5dor6": "OBJKT-hDAO Curation"
+            "KT1Mgy95DVzqVBNYhsW93cyHuB57Q94UFhrh": "Kolibri Oven Factory"
+            "KT1AxaBxkFLCUi3f8rdDAAxBKHfzY8LfKDRA": "kUSD Liquidation Pool"
+            "KT1EH8yKXkRoxNkULRB1dSuwhkKyi5LJH82o": "Tezos Mandala"
+            "KT1QZt5o2eU2ymEpUW8EFhybaLpd9cWfqfUL": "Kalamint IPFS Registry"
+            "KT1EpGgjQs73QfFJs9z7m1Mxm5MTnpC2tqse": "Kalamint Art House"
+            "KT1A5P4ejnLix13jtadsfV9GCnXLMNnab8UT": "KALAM Token"
+            "KT1HvpCCHvC9c4iNzAa6rx4MqNsmPRJf6CEw": "Alchememist Auction"
+            "KT1BwxoxUJEnGcrWtfz2CiCZ19KN1xiN7dNF": "Project Uanon Rewards Distributor"
+            "KT1AUaGsGAkiYgH5wXvQ2tR8JV5dTkenM8XN": "Project Uanon NFT Distributor"
+            "KT1VJsKdNFYueffX6xcfe6Gg9eJA6RUnFpYr": "Project Uanon Puzzle Oracle"
+            "KT1EpQVwqLGSH7vMCWKJnq6Uxi851sEDbhWL": "Atomex FA1.2"
+            "KT1NmoofGosSaWFKgAbt7AMTqnV1xfqeAhLT": "RAMP DeFi rStake Creator"
+            "KT1UmxSSUQ5716tRa2RLNSAkiSG6TWbzZ7GL": "tezostaco.shop"
+            "KT1JBThDEqyqrEHimhxoUBCSnsKAqFcuHMkP": "NFTz.fun NFT"
+            "KT1MWxucqexguPjhqEyk4XndE1M5tHnhNhH7": "QuipuSwap 1.0 USDtz Pool"
+            "KT1CiSKXR68qYSxnbzjwvfeMCRburaSDonT2": "QuipuSwap 1.0 kUSD Pool"
+            "KT1NABnnQ4pUTJHUwFLiVM2uuEu1RXihAVmB": "QuipuSwap 1.0 wXTZ Pool"
+            "KT1N1wwNPqT5jGhM91GQ2ae5uY8UzFaXHMJS": "QuipuSwap 1.0 tzBTC Pool"
+            "KT1DX1kpCEfEg5nG3pXSSwvtkjTr6ZNYuxP4": "QuipuSwap 1.0 ETHtz Pool"
+            "KT1R5Fp415CJxSxxXToUj6QvxP1LHaYXaxV6": "QuipuSwap 1.0 STKR Pool"
+            "KT1V41fGzkdTJki4d11T1Rp9yPkCmDhB7jph": "QuipuSwap 1.0 hDAO Pool"
+            "KT1T4wNjJtNqZ9XCKSZqR5BXsuGczTxhV9Vu": "QuipuSwap 1.0 USDS Pool"
+            "KT1WxgZ1ZSfMgmsSDDcUn8Xn577HwnQ7e1Lb": "QuipuSwap 1.1 USDtz Pool"
+            "KT1K4EwTpbvYN9agJdjpyJm4ZZdhpUNKB3F6": "QuipuSwap 1.1 kUSD Pool"
+            "KT1W3VGRUjvS869r4ror8kdaxqJAZUbPyjMT": "QuipuSwap 1.1 wXTZ Pool"
+            "KT1WBLrLE2vG8SedBqiSJFm4VVAZZBytJYHc": "QuipuSwap 1.1 tzBTC Pool"
+            "KT1Evsp2yA19Whm24khvFPcwimK6UaAJu8Zo": "QuipuSwap 1.1 ETHtz Pool"
+            "KT1BMEEPX7MWzwwadW3NCSZe9XGmFJ7rs7Dr": "QuipuSwap 1.1 STKR Pool"
+            "KT1Qm3urGqkRsWsovGzNb2R81c3dSfxpteHG": "QuipuSwap 1.1 hDAO Pool"
+            "KT1H4NVBGeHXRh1voDv5PPC1Xb6M7xJFQcW5": "QuipuSwap 1.1 USDS Pool"
+            "KT1QxLqukyfohPV5kPkw97Rs6cw1DDDvYgbB": "QuipuSwap 1.2 hDAO Pool"
+            "KT1KFszq8UFCcWxnXuhZPUyHT9FK3gjmSKm6": "QuipuSwap 1.2 USDS Pool"
+            "KT1PrRTVNgxkRgyqqNQvwTiVhd55dqyxXJ6n": "QuipuSwap sDAO AMM"
+            "KT1WDe2vJCDqz5euKupppQsioPcakUd45Tfo": "QuipuSwap rSAL AMM"
+            "KT1DssMzoSr8fnUUq1WxeSuHfLG4gzS7pgge": "QuipuSwap bDAO AMM"
+            "KT1WYQj3HEt3sxdsV4dMLA8RKzUnYAzXgguS": "QuipuSwap GUTS AMM"
+            "KT1WtFb1mTsFRd1n1nAYMdrE2Ud9XREz5hjK": "QuipuSwap QLkUSD AMM"
+            "KT1BgezWwHBxA9NrczwK9x3zfgFnUkc7JJ4b": "QuipuSwap Hedgehoge AMM"
+            "KT1Lpysr4nzcFegC9ci9kjoqVidwoanEmJWt": "QuipuSwap wLINK AMM"
+            "KT1GsTjbWkTgtsWenM6oWuTuft3Qb46p2x4c": "Quipuswap wHT AMM"
+            "KT1UMAE2PBskeQayP5f2ZbGiVYF7h8bZ2gyp": "Quipuswap wBUSD AMM"
+            "KT1MpRQvn2VRR26VJFPYUGcB8qqxBbXgk5xe": "Quipuswap wLEO AMM"
+            "KT1AN7BBmeSUN5eDDQLEhWmXv1gn4exc5k8R": "Quipuswap wHUSD AMM"
+            "KT1Lvtxpg4MiT2Bs38XGxwh3LGi5MkCENp4v": "Quipuswap wAAVE AMM"
+            "KT1SzCtZYesqXt57qHymr3Hj37zPQT47JN6x": "Quipuswap wFTT AMM"
+            "KT1GSjkSg6MFmEMnTJSk6uyYpWXaEYFahrS4": "Quipuswap wCRO AMM"
+            "KT1DA8NH6UqCiSZhEg5KboxosMqLghwwvmTe": "Quipuswap wCOMP AMM"
+            "KT1PQ8TMzGMfViRq4tCMFKD2QF5zwJnY67Xn": "Quipuswap wDAI AMM"
+            "KT1DksKXvCBJN7Mw6frGj6y6F3CbABWZVpj1": "Quipuswap wWBTC AMM"
+            "KT1FG63hhFtMEEEtmBSX2vuFmP87t9E7Ab4t": "Quipuswap WRAP AMM"
+            "KT1X1LgNkQShpF9nRLYw3Dgdy4qp38MX617z": "Quipuswap PLENTY AMM"
+            "KT1NXdxJkCiPkhwPvaT9CytFowuUoNcwGM1p": "Quipuswap SOIL AMM"
+            "KT1J3wTYb4xk5BsSBkg6ML55bX1xq7desS34": "Quipuswap KALAM AMM"
+            "KT1RRgK6eXvCWCiEGWhRZCSVGzhDzwXEEjS4": "Quipuswap CRUNCHY AMM"
+            "KT1DuYujxrmgepwSDHtADthhKBje9BosUs1w": "Quipuswap wWETH AMM"
+            "KT1Q93ftAUzvfMGPwC78nX8eouL1VzmHPd4d": "Quipuswap FLAME AMM"
+            "KT1U2hs5eNdeCpHouAvQXGMzGFGJowbhjqmo": "Quipuswap wUSDC AMM"
+            "KT1T4pfr6NL8dUiz8ibesjEvH2Ne3k6AuXgn": "Quipuswap wUSDT AMM"
+            "KT1RsfuBee5o7GtYrdB7bzQ1M6oVgyBnxY4S": "Quipuswap wMATIC AMM"
+            "KT1Ti3nJT85vNn81Dy5VyNzgufkAorUoZ96q": "Quipuswap wUNI AMM"
+            "KT1Ca5FGSeFLH3ugstc5p56gJDMPeraBcDqE": "Quipuswap wPAX AMM"
+            "KT1X3zxdTzPB9DgVzA3ad6dgZe9JEamoaeRy": "QuipuSwap QUIPU AMM"
+            "KT1K8A8DLUTVuHaDBCZiG6AJdvKJbtH8dqmN": "QuipuSwap PAUL AMM"
+            "KT1Gdix8LoDoQng7YqdPNhdP5V7JRX8FqWvM": "QuipuSwap SMAK AMM"
+            "KT1FHiJmJUgZMPtv5F8M4ZEa6cb1D9Lf758T": "QuipuSwap crDAO AMM"
+            "KT1EtjRRCBC2exyCRXz8UfV7jz7svnkqi7di": "QuipuSwap uUSD AMM"
+            "KT1PL1YciLdwMbydt21Ax85iZXXyGSrKT2BE": "QuipuSwap YOU AMM"
+            "KT1NEa7CmaLaWgHNi6LkRi5Z1f4oHfdzRdGA": "QuipuSwap kDAO AMM"
+            "KT1JyPE1BWdYoRGBvvKhEPbcVRd3C9NCCwQC": "QuipuSwap GOT AMM"
+            "KT1Wa8yqRBpFCusJWgcQyjhRz7hUQAmFxW7j": "FLAME Token"
+            "KT1KPoyzkj82Sbnafm6pfesZKEhyCpXwQfMc": "fDAO"
+            "KT1Ph8ptSU4rf7PPg2YBMR6LTpr6rc4MMyrq": "Catz Token"
+            "KT1K7whn5yHucGXMN7ymfKiX5r534QeaJM29": "QuipuSwap 1.0 FA1.2 Pool Factory"
+            "KT1MMLb2FVrrE9Do74J3FH1RNNc4QhDuVCNX": "QuipuSwap 1.0 FA2 Pool Factory"
+            "KT1Lw8hCoaBrHeTeMXbqHPG4sS4K1xn7yKcD": "QuipuSwap 1.1 FA1.2 Pool Factory"
+            "KT1SwH9P1Tx8a58Mm6qBExQFTcy2rwZyZiXS": "Quipuswap 1.1 FA2 Pool Factory"
+            "KT1PvEyN1xCFCgorN92QCfYjw3axS6jawCiJ": "Quipuswap 1.2 FA2 AMM Factory"
+            "KT1REEb5VxWRjcHm5GzDMwErMmNFftsE5Gpf": "Stably USD"
+            "KT1J5dqegz1qYaYc7X3KjynYL9St1wcZ8ZyV": "Maelstrom Mixer"
+            "KT19ovJhcsUn4YU8Q5L3BGovKSixfbWcecEA": "Salsa"
+            "KT1DLif2x9BtK6pUq9ZfFVVyW5wN2kau9rkW": "WRAP Quorum"
+            "KT1GUNKmkrgtMQjJp3XxcmCj6HZBhkUmMbge": "Bazaar DAO"
+            "KT1LRboPna9yQY9BrjtQYDS1DVxhKESK4VVd": "WRAP Token"
+            "KT1G1cCRNBgQ48mVDjopHjEmTN5Sbtar8nn9": "Hedgehoge Token"
+            "KT1BHCumksALJQJ8q8to2EPigPW6qpyTr7Ng": "Crunchy.network Token"
+            "KT1XPFjZqCULSnqfKaaYy8hJjeY63UNSGwXg": "crDAO"
+            "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS": "Tezos Domains Registry"
+            "KT1CaSP4dn8wasbMsfdtGiCPgYFW7bvnPRRT": "Tezos Domains Auction"
+            "KT1P8n2qzJjwMPbHJfi4o8xu6Pe3gaU3u2A3": "Tezos Domains Committer",
+            "KT191reDVKrLxU9rjTSxg53wRqj6zh8pnHgr": "Tezos Domains Sales",
+            "KT1TnTr6b2YxSx2xUQ8Vz3MoWy771ta66yGx": "Tezos Domains Claim Reverse Record",
+            "KT1J9VpjiH5cmcsskNb8gEXpBtjD4zrAx4Vo": "Tezos Domains Update Reverse Record",
+            "KT1CozhoKRtWSoEvyk7mXrPNFxawMcmXvZtM": "Hicathon Token"
+            "KT1Nbc9cmx19qFrYYFpkiDoojVYL8UZJYVcj": "GUTS Gaming Token"
+            "KT1TtaMcoSx5cZrvaVBWsFoeZ1L15cxo5AEy": "SOIL Token"
+            "KT1GRSvLoikDsXujKgZPsGLX8k8VvR2Tq95b": "Plenty Token"
+            "KT1UDe1YP963CQSb5xN7cQ1X8NJ2pUyjGw5T": "Plenty 1.0 Token Pool"
+            "KT1J7v85udA8GnaBupacgY9mMvrb8zQdYb3E": "Plenty 1.0 ETHtz Pool"
+            "KT1Vs8gqh7YskPnUQMfmjogZh3A5ZLpqQGcg": "Plenty 1.0 hDAO Pool"
+            "KT1JCkdS3x5hTWdrTQdzK6vEkeAdQzsm2wzf": "Plenty 1.0 wLINK Pool"
+            "KT1TNzH1KiVsWh9kpFrWACrDNnfK4ihvGAZs": "Plenty 1.0 wMATIC Pool"
+            "KT1K5cgrw1A8WTiizZ5b6TxNdFnBq9AtyQ7X": "Plenty 1.0 USDtz Pool"
+            "KT1BfQLAsQNX8BjSBzgjTLx3GTd3qhwLoWNz": "Plenty 1.0 QuipuSwap Liquidity Farm"
+            "KT1JQAZqShNMakSNXc2cgTzdAWZFemGcU6n1": "Plenty 1.1 QuipuSwap Liquidity Farm"
+            "KT1QqjR4Fj9YegB37PQEqXUPHmFbhz6VJtwE": "Plenty 1.1 Token Pool"
+            "KT19asUVzBNidHgTHp8MP31YSphooMb3piWR": "Plenty 1.1 ETHtz Pool"
+            "KT1Ga15wxGR5oWK1vBG2GXbjYM6WqPgpfRSP": "Plenty 1.1 hDAO Pool"
+            "KT1MBqc3GHpApBXaBZyvY63LF6eoFyTWtySn": "Plenty 1.1 USDtz Pool"
+            "KT1KyxPitU1xNbTriondmAFtPEcFhjSLV1hz": "Plenty 1.1 wLINK Pool"
+            "KT1XherecVvrE6X4PV5RTwdEKNzA294ZE9T9": "Plenty 1.1 wMATIC Pool"
+            "KT1KJhxkCpZNwAFQURDoJ79hGqQgSC9UaWpG": "Plenty wBUSD LP Farm"
+            "KT1VCrmywPNf8ZHH95HKHvYA4bBQJPa8g2sr": "Plenty USDtz LP Farm"
+            "KT1M82a7arHVwcwaswnNUUuCnQ45xjjGKNd1": "Plenty wWBTC LP Farm"
+            "KT1La1qZiJtDRcd9ek8w5KYD47i9MQqAQHmP": "Plenty wWBTC LP Token"
+            "KT1UqnQ6b1EwQgYiKss4mDL7aktAHnkdctTQ": "Plenty wLINK LP Farm"
+            "KT1UP9XHQigWMqNXYp9YXaCS1hV9jJkCF4h4": "Plenty wMATIC LP Farm"
+            "KT1PuPNtDFLR6U7e7vDuxunDoKasVT6kMSkz": "Plenty wUSDC AMM"
+            "KT1D36ZG99YuhoCRZXLL86tQYAbv36bCq9XM": "Plenty USDtz AMM"
+            "KT18qSo4Ch2Mfq4jP3eME7SWHB8B8EDTtVBu": "Plenty USDtz LP Token"
+            "KT1XXAavg3tTj12W1ADvd3EEnm1pu6XTmiEF": "Plenty wBUSD AMM"
+            "KT1UC3vcVZ4K9b39uQxaMNA2N1RuJXKLCnoA": "PLENTY wBUSD LP Token"
+            "KT19Dskaofi6ZTkrw3Tq4pK7fUqHqCz4pTZ3": "Plenty wWBTC AMM"
+            "KT1XVrXmWY9AdVri6KpxKo4CWxizKajmgzMt": "Plenty wLINK Swap"
+            "KT1VeNQa4mucRj36qAJ9rTzm4DTJKfemVaZT": "Plenty wMATIC AMM"
+            "KT18fp5rcTW7mbWDmzFwjLDUhs5MeJmagDSZ": "Wrap Token Family"
+            "KT1KENVgwsrAnXZHkm5MptHWhMYiXeG5hwa3": "Wrap wLink Farm"
+            "KT1LXQT3b39wLSiFQ1rHatzALzeKsRGmd8gr": "Wrap wAAVE Farm"
+            "KT1Stv6ATejBZ2uD9eMm5HyQ3nrNrC32zpRL": "Wrap wBUSD Farm"
+            "KT1FQBbU7uNkHSq4oLyiTyBFTZ7KfTWGLpcv": "Wrap wCEL Farm"
+            "KT1NSKpB8ppqABLAEDozUmcLv3QUceN5uHQi": "Wrap wCOMP Farm"
+            "KT1HLJ9E4nd8a6DnKdrZNXiEHihk5nyJJDoR": "Wrap wCRO Farm"
+            "KT1UfeNuqT3F6ntYwucDGPHwHdYa1pQbWfST": "Wrap wDAI Farm"
+            "KT1KY55T9jVZwFaCpRcj62LQNwoVYgtRHG6F": "Wrap wFTT Farm"
+            "KT1U9pATbqyDL3ZXzTQnPN2LnaGN78UnpzUw": "Wrap wHT Farm"
+            "KT1BKu6MnA86QF7JDUPj8anAEPDJNDsUYs3v": "Wrap wHUSD Farm"
+            "KT1N7RC3hLLsKgmKhjnYBiVxY2jfYcohZzwR": "Wrap wLEO Farm"
+            "KT1GCNfU4RQ85VgQF3fsj69Lgw8Ucz7RGoph": "Wrap wMATIC Farm"
+            "KT19ohHrCtSv5u4RzU3SySZJPKGhcovkf9sS": "Wrap wMKR Farm"
+            "KT1K5oY3YC16AgcxPYBDty96xyzVPa89X3yh": "Wrap wOKB Farm"
+            "KT1UxnT4id9zKz1tgK1UxwpigFi5ny7vTCu9": "Wrap wPAX Farm"
+            "KT1Ls37uwiU2vD7sSBRmUV7ccdNuvgRTxtCQ": "Wrap wSUSHI Farm"
+            "KT1UeEeeSfSd7uDWpbxBTBkBBpVeDrcqcUr7": "Wrap wUNI Farm"
+            "KT1HVrGpv4GUoSR6qCmkxmHzAFtwfKxzfcop": "Wrap wUSDC Farm"
+            "KT1DQg57yTJ7QKxzk6AkPtDGvZYTM5pX4GYE": "Wrap wUSDT Farm"
+            "KT1SZVLvLDQvqx6qMbF8oXZe2tfP7bJMASy2": "Wrap wWBTC Farm"
+            "KT1J82G1XVAA4oqjC44qskihdWerrneNVHnn": "Wrap wWETH Farm"
+            "KT1AnsHEdYKEdM62QCNpZGc5PfpXhftcdu22": "Wrap Token Farm"
+            "KT1QY4siBbWg9qpj52fEzrWdWfkbFcwwjfoA": "Wrap LP Farm"
+            "KT1T9zQKY259fbCt6tKHFnrMHEePgmsWAJYW": "Wrap wLINK LP Farm"
+            "KT1AxiZu1CtCMg5g5YiPL145cDx9axdwAexX": "Wrap wWBTC LP Farm"
+            "KT1BN1Si6u8ndd46RbbES5cNGojyRK6T8Md8": "Wrap wWETH LP Farm"
+            "KT1NvQJYeMCdEtzF45bs3UNpMmjfY97u2qW2": "Wrap wAAVE LP Farm"
+            "KT19hzFPbMW9cYgUhLNghytkWEymMKsPrdfX": "PixelPotus v1"
+            "KT1WGDVRnff4rmGzJUbdCRAJBmYt12BrPzdD": "PixelPotus v2"
+            "KT1KY2x1XrWykYd2dbBNXfE6tVUU3eYNB4wo": "PixelPotus Market"
+            "KT1My1wDZHDGweCrJnQJi3wcFaS67iksirvj": "hic et nunc SUBJKT"
+            "KT1TwzD6zV3WeJ39ukuqxcfK2fJCnhvrdN1X": "SMAK Token"
+            "KT1VHd7ysjnvxEzwtjBAmYAmasvVCfPpSkiG": "Green Salsa Token"
+            "KT193D4vozYnhGJQVtw7CoxxqphqUEEwK6Vb": "QuipuSwap DAO Token"
+            "KT1KnuE87q1EKjPozJ5sRAjQA24FPsP57CE3": "Crunchy Farms v1"
+            "KT1FvqJwEDWb1Gwc55Jd1jjTHRVWbYKUUpyq": "objkt.com Market"
+            "KT1XjcRq5MLAzMKQ3UHsrue2SeU2NbxUrzmU": "objkt.com English Auction"
+            "KT1DdxmJujm3u2ZNkYwV24qLBJ6iR7sc58B9": "Tezzardz Crowdsale"
+            "KT1LHHLso8zQWQWg1HUukajdxxbkGfNoHjh6": "Tezzardz NFT"
+            "KT19DUSZw7mfeEATrbWVPHRrWNVbNnmfFAE6": "PAUL Token"
+            "KT1Xobej4mc6XgEjDoJoHtTKgbD1ELMvcQuL": "YOU Governance Token"
+            "KT1Lz5S39TMHEA7izhQn8Z1mQoddm6v1jTwH": "Youves Reward Pool"
+            "KT1FFE2LC5JpVakVjHm5mM36QVp2p3ZzH4hH": "Youves Vault Originator"
+            "KT1RkQaK5X84deBAT6sXJ2VLs7zN4pM7Y3si": "Youves uUSD Options"
+            "KT1XRPEPXbZK25r3Htzp2o1x7xdMMmfocKNW": "uUSD Token"
+            "KT1RC22chBZGJtWv82e5pSeyqyBLEyDRqobz": "Ubinetic uUSD Price Oracle"
+            "KT1TxqZ8QtKvLu3V3JH7Gx58n7Co8pgtpQU5": "Granada tzBTC AMM"
+            "KT1BijKznvGCkU4iFEgdfSaEQgnbRViMh97f": "Flame Poker"
+            "KT1GioMCKwRyWoQpdrwxvsPVEsFJkkLyquVZ": "GOT Token"
+            "KT1Cq3pyv6QEXugsAC2iyXr7ecFqN7fJVTnA": "Tezotopia Resources"
+            "KT1PSUKkif8KZzSeWdPewWMkx61QBR8VuXsm": "Tezotopia Market"
+            "KT1HGL8vx7DP4xETVikL4LUYvFxSV19DxdFN": "aka NFT Market"
+            "KT19JYndHaesXpvUfiwgg8BtE41HKkjjGMRC": "Rocket Tokens"
+            "KT1H5KJDxuM9DURSfttepebb6Cn7GbvAAT45": "MAG Token"
+            "KT1FVbyctinHvVJNyMWeueCzXFFX2MCqsYDj": "tzPunks NFT"
+
+            "tz1gk3TDbU7cJuiBRMhwQXVvgDnjsxuWhcEA": "Airfoil"
+            "tz1MJx9vhaNRSimcuXPK2rW4fLccQnDAnVKJ": "AirGap"
+            "tz3e75hU4EhDU3ukyJueh5v6UvEHzGwkg3yC": "At James"
+            "tz1ei4WtWEMEJekSv8qDnu9PExG6Q8HgRGr3": "Bake Tz"
+            "tz1NortRftucvAkD1J58L32EhSVrQEWJCEnB": "Bake'n'Rolls"
+            "tz1S8MNvuFEUsWgjHvi3AxibRBf388NhT1q2": "Binance Baker"
+            "tz1KtGwriE7VuLwT3LwuvU9Nv4wAxP7XZ57d": "Bitfinex"
+            "tz1SYq214SCBy9naR6cvycQsYcUGpBqQAE8d": "Coinone Baker"
+            "tz1eEnQhbwf6trb8Q8mPb2RaPkNk2rN7BKi8": "Chorus One"
+            "tz1MXFrtZoaXckE41bjUCSjAjAap3AFDSr3N": "Everstake (Legacy)"
+            "tz1TzaNn7wSQSP5gYPXCnNzBCpyMiidCq1PX": "Flippin' tacos"
+            "tz3RDC3Jdn4j15J7bBHZd29EUee9gVB1CxD9": "Foundation Baker 1"
+            "tz3bvNMQ95vfAYtG8193ymshqjSvmxiCUuR5": "Foundation Baker 2"
+            "tz3RB4aoyjov4KEVRbuhvQ1CKJgBJMWhaeB8": "Foundation Baker 3"
+            "tz3bTdwZinP8U1JmSweNzVKhmwafqWmFWRfk": "Foundation Baker 4"
+            "tz3NExpXn9aPNZPorRE4SdjJ2RGrfbJgMAaV": "Foundation Baker 5"
+            "tz3UoffC7FG7zfpmvmjUmUeAaHvzdcUvAj6r": "Foundation Baker 6"
+            "tz3WMqdzXqRWXwyvj5Hp2H7QEepaUuS7vd9K": "Foundation Baker 7"
+            "tz3VEZ4k6a4Wx42iyev6i2aVAptTRLEAivNN": "Foundation Baker 8"
+            "tz1NpWrAyDL9k2Lmnyxcgr9xuJakbBxdq7FB": "Gate.io"
+            "tz1WCd2jm4uSt4vntk4vSuUWoZQGhLcDuR9q": "Happy Tezos"
+            "tz1gfArv665EUkSg2ojMBzcbfwuPxAvqPvjo": "Kraken"
+            "tz1X1fpAZtwQk94QXUgZwfgsvkQgyc2KHp9d": "ownBLOCK (Legacy)"
+            "tz1hTFcQk2KJRPzZyHkCwbj7E1zY1xBkiHsk": "ownBLOCK"
+            "tz1dkP8pW6UzamUysFx3WqHZGQMNCZsEaeH6": "ownBLOCK Payouts"
+            "tz1P2Po7YM526ughEsRbY4oR9zaUPDZjxFrb": "P2P Validator"
+            "tz1KtvGSYU5hdKD288a1koTBURWYuADJGrLE": "\u00D8 Crypto Pool (Legacy)"
+            "tz1Yju7jmmsaUiG9qQLoYv35v5pHgnWoLWbt": "Polychain Labs 1"
+            "tz2TSvNTh2epDMhZHrw73nV9piBX7kLZ9K9m": "Polychain Labs 2"
+            "tz1Y42aKCk53vMbaJNpf1hBg1rznGdBxHJ5C": "Tezos Berlin"
+            "tz1Vyuu4EJ5Nym4JcrfRLnp3hpaq1DSEp1Ke": "POS Bakerz"
+            "tz1b7YSEeNRqgmjuX4d4aiai2sQTF4A7WBZf": "Tezos Japan (Legacy)"
+            "tz1ijdEfmUoQXJfSiKCLRioeCfSrKP3sVsff": "Tezos Japan (Legacy B)"
+            "tz1aDiEJf9ztRrAJEXZfcG3CKimoKsGhwVAi": "Tezos Japan"
+            "tz1PPUo28B8BroqmVCMMNDudG4ShA2bzicrU": "Tezos Korea"
+            "tz1b3SaPHFSw51r92ARcV5mGyYbSSsdFd5Gz": "Tezos MX"
+            "tz1Kf25fX1VdmYGSEzwFy1wNmkbSEZ2V83sY": "Tezos Seoul"
+            "tz1RAzdkp1x5ZDqms4ZUrSdfJuUYGH9JTPK2": "Tezos Spanish"
+            "tz1Lh9jeLSWDHYy8AshvG2dpNQseDaHg7cms": "Tezos Spanish (Legacy)"
+            "tz1hAYfexyzPGG6RhZZMpDvAHifubsbb6kgn": "Tezos Suisse"
+            "tz1VYQpZvjVhv1CdcENuCNWJQXu1TWBJ8KTD": "Tezos Tokyo"
+            "tz1R6Ej25VSerE3MkSoEEeBjKHCDTFbpKuSX": "TezosSEAsia"
+            "tz1Lh9jeLSWDHYy8AshvG2dpNQseDaHg7cms": "TezosSpanish"
+            "tz1PesW5khQNhy4revu2ETvMtWPtuVyH2XkZ": "Tz Dutch"
+            "tz1Pwgj6j55akKCyvTwwr9X4np1RskSXpQY4": "Validators.com"
+            "tz1g8vkmcde6sWKaG2NN9WKzCkDM6Rziq194": "StakeNow"
+            "tz1WnfXMPaNTBmH7DBPwqCWs9cPDJdkGBTZ8": "TezosHODL"
+            "tz2FCNBrERXtaTtNX6iimR1UJ5JSDxvdHM93": "stakefish"
+            "tz3QCNyySViKHmeSr45kzDxzchys7NiXCWoa": "Proofofbake.com"
+            "tz1abmz7jiCV2GH2u81LRrGgAFFgvQgiDiaf": "Tessellated Geometry"
+            "tz1TDSmoZXwVevLTEvKCTHWpomG76oC9S2fJ": "Tezos Capital Legacy"
+            "tz1UdeKoMJivgqRgRUNzroMwRJYmJY8BtaWe": "alphaTezos"
+            "tz1RSWMYKGAykpizFteowByYMueCYv9TMn1L": "Tezos Alliance"
+            "tz1Zhv3RkfU2pHrmaiDyxp7kFZpZrUCu1CiF": "TzBake"
+            "tz1Vd1rXpV8hTHbFXCXN3c3qzCsgcU5BZw1e": "TzNode"
+            "tz1fZ767VDbqx4DeKiFswPSHh513f51mKEUZ": "Tezos Bakery"
+            "tz1TqUDvdck5UrPSgdjJu8RPHafet5vyWQFk": "Tezos Bakery Payouts"
+            "tz1aKxnrzx5PXZJe7unufEswVRCMU9yafmfb": "Tezos Canada"
+            "tz1WGpyzJ1WdZQyKgFN1MY1d7KExGzipFmPJ": "Tezos Canada Payouts"
+            "tz1S5WxdZR5f9NzsPXhr7L9L1vrEb5spZFur": "Baking Benjamins"
+            "tz1V3yg82mcrPJbegqVCPn6bC8w1CSTRp3f8": "Staking Shop"
+            "tz1hxtCEcD7idQJEDiJEq37vBkoRcwF6KC2X": "Staking Shop Payouts"
+            "tz1cYufsxHXJcvANhvS55h3aY32a9BAFB494": "Bakery IL"
+            "tz1iVCqjMRG7MfBoFnVjbLQyeLAeJQfLxXze": "Bakery IL Payouts"
+            "tz1WBfwbT66FC6BTLexc2BoyCCBM9LG7pnVW": "888XTZ"
+            "tz1U638Z3xWRiXDDKx2S125MCCaAeGDdA896": "Tezos France"
+            "tz1Zrqm4TkJwqTxm5TiyVFh6taXG4Wrq7tko": "Bake'n'Rolls Payouts"
+            "tz1aRoaRhSpRYvFdyvgWLL6TGyRoGF51wDjM": "Everstake"
+            "tz1W1en9UpMCH4ZJL8wQCh8JDKCZARyVx2co": "Everstake Payouts"
+            "tz1XXayQohB8XRXN7kMoHbf2NFwNiH3oMRQQ": "Bit Cat"
+            "tz1Wy5Ph1FkD1ypUjpFpsHLXLEXDAeCRkZce": "Bit Cat Payouts"
+            "tz1cZfFQpcYhwDp7y1njZXDsZqCrn2NqmVof": "Tezos Rio"
+            "tz1Y2bfsQAYHrWZpM1AwomYMw2KEtaJ5VMfU": "Tezos Rio Payouts"
+            "tz3bEQoFCZEEfZMskefZ8q8e4eiHH1pssRax": "Ceibo XTZ"
+            "tz1ceiboANJ72iqG1g9Xig8vW74JJijv4mb8": "Ceibo XTZ Payouts"
+            "tz1PFeoTuFen8jAMRHajBySNyCwLmY5RqF9M": "Paradigm Bakery"
+            "tz1fb7c66UwePkkfDXz4ajFaBP9hVNLdS7JJ": "Tezos NU"
+            "tz1VfoA5qPksECBkvr2EUuT6u5VgLCi3vTPV": "Tezos NU Payouts"
+            "tz1fUjvVhJrHLZCbhPNvDRckxApqbkievJHN": "Tezzieland"
+            "tz1WntXgznbivRjyhE7Y5jEzoebAhMPB2iJa": "Tezzieland Payouts"
+            "tz1VceyYUpq1gk5dtp6jXQRtCtY8hm5DKt72": "TeZetetic"
+            "tz1S1Aew75hMrPUymqenKfHo8FspppXKpW7h": "Tezos Mars"
+            "tz1bRaSjKZrSrSeQHBDiCqjKXqtZYZM1t8FW": "Imma Baker"
+            "tz1bLwpPfr3xqy1gWBF4sGvv8bLJyPHR11kx": "Tezos Hot Bakery"
+            "tz1ZcTRk5uxD86EFEn1vvNffWWqJy7q5eVhc": "ATEZA"
+            "tz1UJvHTgpVzcKWhTazGxVcn5wsHru5Gietg": "Tezry"
+            "tz1MQJPGNMijnXnVoBENFz9rUhaPt3S7rWoz": "Tezmania"
+            "tz1eCzNtidHvVgeRzQ38C81FPcYnxMsCEL6Z": "TezLoom"
+            "tz1Q8QkSBS63ZQnH3fBTiAMPes9R666Rn6Sc": "YieldWallet"
+            "tz1LnWa4AiFCjMezTgSNa65QFoo7DQGEWgEU": "Tezeract"
+            "tz1NEKxGEHsFufk87CVZcrqWu8o22qh46GK6": "Money Every 3 Days"
+            "tz1NkFRjmkqqcGkAhqe78fdgemDNKXvL7Bod": "BakeMyStake"
+            "tz1SohptP53wDPZhzTWzDUFAUcWF6DMBpaJV": "Hayek Lab"
+            "tz1d6Fx42mYgVFnHUW8T8A7WBfJ6nD9pVok8": "MyTezosBaking"
+            "tz1fJHFn6sWEd3NnBPngACuw2dggTv6nQZ7g": "Baking Team"
+            "tz1iJ4qgGTzyhaYEzd1RnC6duEkLBd1nzexh": "Tz Envoy"
+            "tz1UsFcWtY6BxchK1L9619oXBzy3C2JCrRut": "Baking Tezos 4U"
+            "tz1QXrzaHrGACVn15UiCg33aLCJ6npWdQb3J": "Moku"
+            "tz1QGtMpkbdSM8Y1eHTru3WY51sXhFikbaAC": "TezosNigeria_001"
+            "tz1Vc9XAD7iphycJoRwE1Nxx5krB9C7XyBu5": "\u00D8 Crypto Pool"
+            "tz1irJKkXS2DBWkU1NnmFQx1c1L7pbGg4yhk": "Coinbase Custody"
+            "tz1VQnqCCqX4K5sP3FNkVSNKTdCAMJDd3E1n": "PosDog"
+            "tz1RCFbB9GpALpsZtu6J58sb74dm8qe6XBzv": "Staked"
+            "tz1KfEsrtDaA1sX7vdM4qmEPWuSytuqCDp5j": "XTZ Master"
+            "tz1isXamBXpTUgbByQ6gXgZQg4GWNW7r6rKE": "Tez Whale"
+            "tz1Ldzz6k1BHdhuKvAtMRX7h5kJSMHESMHLC": "PayTezos"
+            "tz1UvkANVPWppVgMkLnvN7BwYZsCP7vm6NVd": "Neokta Labs"
+            "tz1YhNsiRRU8aHNGg7NK3uuP6UDAyacJernB": "Tez Baguette"
+            "tz3adcvQaKXTCg12zbninqo3q8ptKKtDFTLv": "Tezzigator"
+            "tz1RV1MBbZMR68tacosb7Mwj6LkbPSUS1er1": "Baking Tacos"
+            "tz1W5VkdB5s7ENMESVBtwyt9kyvLqPcUczRT": "Tezgate"
+            "tz1PWCDnz783NNGGQjEFFsHtrcK5yBW4E2rm": "Melange"
+            "tz1V2FYediKBAEaTpXXJBSjuQpjkyCzrTSiE": "Stake House"
+            "tz1Scdr2HsZiQjc7bHMeBbmDRXYVvdhjJbBh": "Figment"
+            "tz1VmiY38m3y95HqQLjMwqnMS7sdMfGomzKi": "Lucid Mining"
+            "tz1WctSwL49BZtdWAQ75NY6vr4xsAx6oKdah": "Tezos Wake n' Bake"
+            "tz1PeZx7FXy7QRuMREGXGxeipb24RsMMzUNe": "Tezos Panda"
+            "tz1bHzftcTKZMTZgLLtnrXydCm6UEqf4ivca": "Tezos Vote"
+            "tz1S8e9GgdZG78XJRB3NqabfWeM37GnhZMWQ": "0xb1 PlusMinus"
+            "tz1LmaFsWRkjr7QMCx5PtV6xTUz3AmEpKQiF": "Blockpower Staking"
+            "tz1RjoHc98dBoqaH2jawF62XNKh7YsHwbkEv": "OKEx Baker"
+            "tz1cX93Q3KsiTADpCC4f12TBvAmS5tw7CW19": "Tz Bakery"
+            "tz1VHFxUuBhwopxC9YC9gm5s2MHBHLyCtvN1": "HyperBlocks"
+            "tz1aiYKXmSRckyJ9EybKmpVry373rfyngJU8": "View Nodes"
+            "tz1STeamwbp68THcny9zk3LsbG3H36DMvbRK": "StakingTeam"
+            "tz1hUSVvSq4YbZcREBqKHf6eXM1yvXuGYUNZ": "Metablock Baker"
+            "tz1Tnjaxk6tbAeC2TmMApPh8UsrEVQvhHvx5": "Crypto Delegate"
+            "tz1LBEKXaxQbd5Gtzbc1ATCwc3pppu81aWGc": "Tez-Baking"
+            "tz1dbfppLAAxXZNtf2SDps7rch3qfUznKSoK": "Coinhouse"
+            "tz1dRKU4FQ9QRRQPdaH4zCR6gmCmXfcvcgtB": "Spice"
+            "tz1Z2jXfEXL7dXhs6bsLmyLFLfmAkXBzA9WE": "Tezos Boutique"
+            "tz1dNVDWPf3Q59SdJqnjdnu277iyvReiRS9M": "Steak and Bake"
+            "tz1Zcxkfa5jKrRbBThG765GP29bUCU3C4ok5": "Tezz City"
+            "tz1Lhf4J9Qxoe3DZ2nfe8FGDnvVj7oKjnMY6": "Tez Baker"
+            "tz1XhnCdVENzgko5x1MMswLHSoQbJ5NPwLZ6": "Anonstake"
+            "tz1WpeqFaBG9Jm73Dmgqamy8eF8NWLz9JCoY": "Staking Facilities"
+            "tz1iZEKy4LaAjnTmn2RuGDf2iqdAQKnRi8kY": "Tezzigator (Legacy)"
+            "tz1MkjfzHNF3kk7PMUDVsaTrF8iRD6fpHftR": "LuxBaker"
+            "tz1hWB6QV5GBQKdEJN8EowHhLJyCMPhH18sA": "Tezos Cameroun"
+          }
+        }
+        block_id {
+          description: "Most recent account activity"
+          display-name: "Block Hash"
+          data-type: "hash"
+          visible: true
+          display-priority: 2
+          display-order: 8
+          reference: {
+            entity: "blocks"
+            key: "hash"
+          }
+        }
+        manager {
+          visible: true
+          data-type: "accountAddress"
+          display-priority: 0
+          display-order: 2
+          reference: {
+            entity: "accounts"
+            key: "account_id"
+          }
+        }
+        spendable {
+          visible: true
+          cache-config {
+            cached: true
+          }
+        }
+        delegate_setable {
+          display-priority: 3
+          display-order: 10
+          display-name: "Delegatable"
+          visible: true
+        }
+        delegate_value {
+          display-name: "Delegate"
+          visible: true
+          data-type: "accountAddress"
+          reference: {
+            entity: "accounts"
+            key: "account_id"
+          }
+          value-map: {
+            "tz1gk3TDbU7cJuiBRMhwQXVvgDnjsxuWhcEA": "Airfoil"
+            "tz1MJx9vhaNRSimcuXPK2rW4fLccQnDAnVKJ": "AirGap"
+            "tz3e75hU4EhDU3ukyJueh5v6UvEHzGwkg3yC": "At James"
+            "tz1ei4WtWEMEJekSv8qDnu9PExG6Q8HgRGr3": "Bake Tz"
+            "tz1NortRftucvAkD1J58L32EhSVrQEWJCEnB": "Bake'n'Rolls"
+            "tz1S8MNvuFEUsWgjHvi3AxibRBf388NhT1q2": "Binance Baker"
+            "tz1KtGwriE7VuLwT3LwuvU9Nv4wAxP7XZ57d": "Bitfinex"
+            "tz1SYq214SCBy9naR6cvycQsYcUGpBqQAE8d": "Coinone Baker"
+            "tz1eEnQhbwf6trb8Q8mPb2RaPkNk2rN7BKi8": "Chorus One"
+            "tz1MXFrtZoaXckE41bjUCSjAjAap3AFDSr3N": "Everstake (Legacy)"
+            "tz1TzaNn7wSQSP5gYPXCnNzBCpyMiidCq1PX": "Flippin' tacos"
+            "tz3RDC3Jdn4j15J7bBHZd29EUee9gVB1CxD9": "Foundation Baker 1"
+            "tz3bvNMQ95vfAYtG8193ymshqjSvmxiCUuR5": "Foundation Baker 2"
+            "tz3RB4aoyjov4KEVRbuhvQ1CKJgBJMWhaeB8": "Foundation Baker 3"
+            "tz3bTdwZinP8U1JmSweNzVKhmwafqWmFWRfk": "Foundation Baker 4"
+            "tz3NExpXn9aPNZPorRE4SdjJ2RGrfbJgMAaV": "Foundation Baker 5"
+            "tz3UoffC7FG7zfpmvmjUmUeAaHvzdcUvAj6r": "Foundation Baker 6"
+            "tz3WMqdzXqRWXwyvj5Hp2H7QEepaUuS7vd9K": "Foundation Baker 7"
+            "tz3VEZ4k6a4Wx42iyev6i2aVAptTRLEAivNN": "Foundation Baker 8"
+            "tz1NpWrAyDL9k2Lmnyxcgr9xuJakbBxdq7FB": "Gate.io"
+            "tz1WCd2jm4uSt4vntk4vSuUWoZQGhLcDuR9q": "Happy Tezos"
+            "tz1gfArv665EUkSg2ojMBzcbfwuPxAvqPvjo": "Kraken"
+            "tz1X1fpAZtwQk94QXUgZwfgsvkQgyc2KHp9d": "ownBLOCK (Legacy)"
+            "tz1hTFcQk2KJRPzZyHkCwbj7E1zY1xBkiHsk": "ownBLOCK"
+            "tz1dkP8pW6UzamUysFx3WqHZGQMNCZsEaeH6": "ownBLOCK Payouts"
+            "tz1P2Po7YM526ughEsRbY4oR9zaUPDZjxFrb": "P2P Validator"
+            "tz1KtvGSYU5hdKD288a1koTBURWYuADJGrLE": "\u00D8 Crypto Pool (Legacy)"
+            "tz1Yju7jmmsaUiG9qQLoYv35v5pHgnWoLWbt": "Polychain Labs 1"
+            "tz2TSvNTh2epDMhZHrw73nV9piBX7kLZ9K9m": "Polychain Labs 2"
+            "tz1Y42aKCk53vMbaJNpf1hBg1rznGdBxHJ5C": "Tezos Berlin"
+            "tz1Vyuu4EJ5Nym4JcrfRLnp3hpaq1DSEp1Ke": "POS Bakerz"
+            "tz1b7YSEeNRqgmjuX4d4aiai2sQTF4A7WBZf": "Tezos Japan (Legacy)"
+            "tz1ijdEfmUoQXJfSiKCLRioeCfSrKP3sVsff": "Tezos Japan (Legacy B)"
+            "tz1aDiEJf9ztRrAJEXZfcG3CKimoKsGhwVAi": "Tezos Japan"
+            "tz1PPUo28B8BroqmVCMMNDudG4ShA2bzicrU": "Tezos Korea"
+            "tz1b3SaPHFSw51r92ARcV5mGyYbSSsdFd5Gz": "Tezos MX"
+            "tz1Kf25fX1VdmYGSEzwFy1wNmkbSEZ2V83sY": "Tezos Seoul"
+            "tz1RAzdkp1x5ZDqms4ZUrSdfJuUYGH9JTPK2": "Tezos Spanish"
+            "tz1Lh9jeLSWDHYy8AshvG2dpNQseDaHg7cms": "Tezos Spanish (Legacy)"
+            "tz1hAYfexyzPGG6RhZZMpDvAHifubsbb6kgn": "Tezos Suisse"
+            "tz1VYQpZvjVhv1CdcENuCNWJQXu1TWBJ8KTD": "Tezos Tokyo"
+            "tz1R6Ej25VSerE3MkSoEEeBjKHCDTFbpKuSX": "TezosSEAsia"
+            "tz1Lh9jeLSWDHYy8AshvG2dpNQseDaHg7cms": "TezosSpanish"
+            "tz1PesW5khQNhy4revu2ETvMtWPtuVyH2XkZ": "Tz Dutch"
+            "tz1Pwgj6j55akKCyvTwwr9X4np1RskSXpQY4": "Validators.com"
+            "tz1g8vkmcde6sWKaG2NN9WKzCkDM6Rziq194": "StakeNow"
+            "tz1WnfXMPaNTBmH7DBPwqCWs9cPDJdkGBTZ8": "TezosHODL"
+            "tz2FCNBrERXtaTtNX6iimR1UJ5JSDxvdHM93": "stakefish"
+            "tz3QCNyySViKHmeSr45kzDxzchys7NiXCWoa": "Proofofbake.com"
+            "tz1abmz7jiCV2GH2u81LRrGgAFFgvQgiDiaf": "Tessellated Geometry"
+            "tz1TDSmoZXwVevLTEvKCTHWpomG76oC9S2fJ": "Tezos Capital Legacy"
+            "tz1UdeKoMJivgqRgRUNzroMwRJYmJY8BtaWe": "alphaTezos"
+            "tz1RSWMYKGAykpizFteowByYMueCYv9TMn1L": "Tezos Alliance"
+            "tz1Zhv3RkfU2pHrmaiDyxp7kFZpZrUCu1CiF": "TzBake"
+            "tz1Vd1rXpV8hTHbFXCXN3c3qzCsgcU5BZw1e": "TzNode"
+            "tz1fZ767VDbqx4DeKiFswPSHh513f51mKEUZ": "Tezos Bakery"
+            "tz1TqUDvdck5UrPSgdjJu8RPHafet5vyWQFk": "Tezos Bakery Payouts"
+            "tz1aKxnrzx5PXZJe7unufEswVRCMU9yafmfb": "Tezos Canada"
+            "tz1WGpyzJ1WdZQyKgFN1MY1d7KExGzipFmPJ": "Tezos Canada Payouts"
+            "tz1S5WxdZR5f9NzsPXhr7L9L1vrEb5spZFur": "Baking Benjamins"
+            "tz1V3yg82mcrPJbegqVCPn6bC8w1CSTRp3f8": "Staking Shop"
+            "tz1hxtCEcD7idQJEDiJEq37vBkoRcwF6KC2X": "Staking Shop Payouts"
+            "tz1cYufsxHXJcvANhvS55h3aY32a9BAFB494": "Bakery IL"
+            "tz1iVCqjMRG7MfBoFnVjbLQyeLAeJQfLxXze": "Bakery IL Payouts"
+            "tz1WBfwbT66FC6BTLexc2BoyCCBM9LG7pnVW": "888XTZ"
+            "tz1U638Z3xWRiXDDKx2S125MCCaAeGDdA896": "Tezos France"
+            "tz1Zrqm4TkJwqTxm5TiyVFh6taXG4Wrq7tko": "Bake'n'Rolls Payouts"
+            "tz1aRoaRhSpRYvFdyvgWLL6TGyRoGF51wDjM": "Everstake"
+            "tz1W1en9UpMCH4ZJL8wQCh8JDKCZARyVx2co": "Everstake Payouts"
+            "tz1XXayQohB8XRXN7kMoHbf2NFwNiH3oMRQQ": "Bit Cat"
+            "tz1Wy5Ph1FkD1ypUjpFpsHLXLEXDAeCRkZce": "Bit Cat Payouts"
+            "tz1cZfFQpcYhwDp7y1njZXDsZqCrn2NqmVof": "Tezos Rio"
+            "tz1Y2bfsQAYHrWZpM1AwomYMw2KEtaJ5VMfU": "Tezos Rio Payouts"
+            "tz3bEQoFCZEEfZMskefZ8q8e4eiHH1pssRax": "Ceibo XTZ"
+            "tz1ceiboANJ72iqG1g9Xig8vW74JJijv4mb8": "Ceibo XTZ Payouts"
+            "tz1PFeoTuFen8jAMRHajBySNyCwLmY5RqF9M": "Paradigm Bakery"
+            "tz1fb7c66UwePkkfDXz4ajFaBP9hVNLdS7JJ": "Tezos NU"
+            "tz1VfoA5qPksECBkvr2EUuT6u5VgLCi3vTPV": "Tezos NU Payouts"
+            "tz1fUjvVhJrHLZCbhPNvDRckxApqbkievJHN": "Tezzieland"
+            "tz1WntXgznbivRjyhE7Y5jEzoebAhMPB2iJa": "Tezzieland Payouts"
+            "tz1VceyYUpq1gk5dtp6jXQRtCtY8hm5DKt72": "TeZetetic"
+            "tz1S1Aew75hMrPUymqenKfHo8FspppXKpW7h": "Tezos Mars"
+            "tz1bRaSjKZrSrSeQHBDiCqjKXqtZYZM1t8FW": "Imma Baker"
+            "tz1bLwpPfr3xqy1gWBF4sGvv8bLJyPHR11kx": "Tezos Hot Bakery"
+            "tz1ZcTRk5uxD86EFEn1vvNffWWqJy7q5eVhc": "ATEZA"
+            "tz1UJvHTgpVzcKWhTazGxVcn5wsHru5Gietg": "Tezry"
+            "tz1MQJPGNMijnXnVoBENFz9rUhaPt3S7rWoz": "Tezmania"
+            "tz1eCzNtidHvVgeRzQ38C81FPcYnxMsCEL6Z": "TezLoom"
+            "tz1Q8QkSBS63ZQnH3fBTiAMPes9R666Rn6Sc": "YieldWallet"
+            "tz1LnWa4AiFCjMezTgSNa65QFoo7DQGEWgEU": "Tezeract"
+            "tz1NEKxGEHsFufk87CVZcrqWu8o22qh46GK6": "Money Every 3 Days"
+            "tz1NkFRjmkqqcGkAhqe78fdgemDNKXvL7Bod": "BakeMyStake"
+            "tz1SohptP53wDPZhzTWzDUFAUcWF6DMBpaJV": "Hayek Lab"
+            "tz1d6Fx42mYgVFnHUW8T8A7WBfJ6nD9pVok8": "MyTezosBaking"
+            "tz1fJHFn6sWEd3NnBPngACuw2dggTv6nQZ7g": "Baking Team"
+            "tz1iJ4qgGTzyhaYEzd1RnC6duEkLBd1nzexh": "Tz Envoy"
+            "tz1UsFcWtY6BxchK1L9619oXBzy3C2JCrRut": "Baking Tezos 4U"
+            "tz1QXrzaHrGACVn15UiCg33aLCJ6npWdQb3J": "Moku"
+            "tz1QGtMpkbdSM8Y1eHTru3WY51sXhFikbaAC": "TezosNigeria_001"
+            "tz1Vc9XAD7iphycJoRwE1Nxx5krB9C7XyBu5": "\u00D8 Crypto Pool"
+            "tz1irJKkXS2DBWkU1NnmFQx1c1L7pbGg4yhk": "Coinbase Custody"
+            "tz1VQnqCCqX4K5sP3FNkVSNKTdCAMJDd3E1n": "PosDog"
+            "tz1RCFbB9GpALpsZtu6J58sb74dm8qe6XBzv": "Staked"
+            "tz1KfEsrtDaA1sX7vdM4qmEPWuSytuqCDp5j": "XTZ Master"
+            "tz1isXamBXpTUgbByQ6gXgZQg4GWNW7r6rKE": "Tez Whale"
+            "tz1Ldzz6k1BHdhuKvAtMRX7h5kJSMHESMHLC": "PayTezos"
+            "tz1UvkANVPWppVgMkLnvN7BwYZsCP7vm6NVd": "Neokta Labs"
+            "tz1YhNsiRRU8aHNGg7NK3uuP6UDAyacJernB": "Tez Baguette"
+            "tz3adcvQaKXTCg12zbninqo3q8ptKKtDFTLv": "Tezzigator"
+            "tz1RV1MBbZMR68tacosb7Mwj6LkbPSUS1er1": "Baking Tacos"
+            "tz1W5VkdB5s7ENMESVBtwyt9kyvLqPcUczRT": "Tezgate"
+            "tz1PWCDnz783NNGGQjEFFsHtrcK5yBW4E2rm": "Melange"
+            "tz1V2FYediKBAEaTpXXJBSjuQpjkyCzrTSiE": "Stake House"
+            "tz1Scdr2HsZiQjc7bHMeBbmDRXYVvdhjJbBh": "Figment"
+            "tz1VmiY38m3y95HqQLjMwqnMS7sdMfGomzKi": "Lucid Mining"
+            "tz1WctSwL49BZtdWAQ75NY6vr4xsAx6oKdah": "Tezos Wake n' Bake"
+            "tz1PeZx7FXy7QRuMREGXGxeipb24RsMMzUNe": "Tezos Panda"
+            "tz1bHzftcTKZMTZgLLtnrXydCm6UEqf4ivca": "Tezos Vote"
+            "tz1S8e9GgdZG78XJRB3NqabfWeM37GnhZMWQ": "0xb1 PlusMinus"
+            "tz1LmaFsWRkjr7QMCx5PtV6xTUz3AmEpKQiF": "Blockpower Staking"
+            "tz1RjoHc98dBoqaH2jawF62XNKh7YsHwbkEv": "OKEx Baker"
+            "tz1cX93Q3KsiTADpCC4f12TBvAmS5tw7CW19": "Tz Bakery"
+            "tz1VHFxUuBhwopxC9YC9gm5s2MHBHLyCtvN1": "HyperBlocks"
+            "tz1aiYKXmSRckyJ9EybKmpVry373rfyngJU8": "View Nodes"
+            "tz1STeamwbp68THcny9zk3LsbG3H36DMvbRK": "StakingTeam"
+            "tz1hUSVvSq4YbZcREBqKHf6eXM1yvXuGYUNZ": "Metablock Baker"
+            "tz1Tnjaxk6tbAeC2TmMApPh8UsrEVQvhHvx5": "Crypto Delegate"
+            "tz1LBEKXaxQbd5Gtzbc1ATCwc3pppu81aWGc": "Tez-Baking"
+            "tz1dbfppLAAxXZNtf2SDps7rch3qfUznKSoK": "Coinhouse"
+            "tz1dRKU4FQ9QRRQPdaH4zCR6gmCmXfcvcgtB": "Spice"
+            "tz1Z2jXfEXL7dXhs6bsLmyLFLfmAkXBzA9WE": "Tezos Boutique"
+            "tz1dNVDWPf3Q59SdJqnjdnu277iyvReiRS9M": "Steak and Bake"
+            "tz1Zcxkfa5jKrRbBThG765GP29bUCU3C4ok5": "Tezz City"
+            "tz1Lhf4J9Qxoe3DZ2nfe8FGDnvVj7oKjnMY6": "Tez Baker"
+            "tz1XhnCdVENzgko5x1MMswLHSoQbJ5NPwLZ6": "Anonstake"
+            "tz1WpeqFaBG9Jm73Dmgqamy8eF8NWLz9JCoY": "Staking Facilities"
+            "tz1iZEKy4LaAjnTmn2RuGDf2iqdAQKnRi8kY": "Tezzigator (Legacy)"
+            "tz1MkjfzHNF3kk7PMUDVsaTrF8iRD6fpHftR": "LuxBaker"
+            "tz1hWB6QV5GBQKdEJN8EowHhLJyCMPhH18sA": "Tezos Cameroun"
+          }
+        }
+        counter {
+          visible: true
+          display-priority: 2
+        }
+        script {
+          display-priority: 1
+          display-order: 3
+          visible: true
+        }
+        storage {
+          display-priority: 1
+          display-order: 4
+          visible: true
+        }
+        balance {
+          display-priority: 0
+          display-order: 1
+          visible: true
+          scale: 6,
+          data-type: "currency"
+          currency-symbol-code: 42793
+        }
+        block_level {
+          display-priority: 1
+          display-order: 9
+          visible: true
+          display-name: "Block Level"
+          data-type: "int"
+          reference: {
+            entity: "blocks"
+            key: "level"
+          }
+        }
+        is_baker {
+          display-name: "Is Baker"
+          visible: true
+        }
+        is_activated {
+          visible: true
+        }
+      }
+    }
+    accounts_history {
+      display-name-plural: "Account History"
+      display-name: "Account History"
+      temporal-partition: "account_id"
+      visible: true,
+      attributes {
+        account_id {
+          description: "Sometimes referred to as 'public key hash', the address is a unique account identifier"
+          display-name: "Address"
+          placeholder: "tz1..."
+          visible: true
+          data-type: "accountAddress"
+          display-priority: 0
+          display-order: 0
+          reference: {
+            entity: "accounts"
+            key: "account_id"
+          }
+          cache-config {
+            cached: true,
+            min-match-length: 4,
+            max-result-size: 100
+          }
+        }
+        block_id {
+          description: "Most recent account activity"
+          display-name: "Block Hash"
+          data-type: "hash"
+          visible: true
+          display-priority: 2
+          display-order: 8
+          reference: {
+            entity: "blocks"
+            key: "hash"
+          }
+        }
+        delegate_value {
+          display-name: "Delegate"
+          visible: true
+          data-type: "accountAddress"
+          reference: {
+            entity: "accounts"
+            key: "account_id"
+          }
+          value-map: {
+            "tz1gk3TDbU7cJuiBRMhwQXVvgDnjsxuWhcEA": "Airfoil"
+            "tz1MJx9vhaNRSimcuXPK2rW4fLccQnDAnVKJ": "AirGap"
+            "tz3e75hU4EhDU3ukyJueh5v6UvEHzGwkg3yC": "At James"
+            "tz1ei4WtWEMEJekSv8qDnu9PExG6Q8HgRGr3": "Bake Tz"
+            "tz1NortRftucvAkD1J58L32EhSVrQEWJCEnB": "Bake'n'Rolls"
+            "tz1S8MNvuFEUsWgjHvi3AxibRBf388NhT1q2": "Binance Baker"
+            "tz1KtGwriE7VuLwT3LwuvU9Nv4wAxP7XZ57d": "Bitfinex"
+            "tz1SYq214SCBy9naR6cvycQsYcUGpBqQAE8d": "Coinone Baker"
+            "tz1eEnQhbwf6trb8Q8mPb2RaPkNk2rN7BKi8": "Chorus One"
+            "tz1MXFrtZoaXckE41bjUCSjAjAap3AFDSr3N": "Everstake (Legacy)"
+            "tz1TzaNn7wSQSP5gYPXCnNzBCpyMiidCq1PX": "Flippin' tacos"
+            "tz3RDC3Jdn4j15J7bBHZd29EUee9gVB1CxD9": "Foundation Baker 1"
+            "tz3bvNMQ95vfAYtG8193ymshqjSvmxiCUuR5": "Foundation Baker 2"
+            "tz3RB4aoyjov4KEVRbuhvQ1CKJgBJMWhaeB8": "Foundation Baker 3"
+            "tz3bTdwZinP8U1JmSweNzVKhmwafqWmFWRfk": "Foundation Baker 4"
+            "tz3NExpXn9aPNZPorRE4SdjJ2RGrfbJgMAaV": "Foundation Baker 5"
+            "tz3UoffC7FG7zfpmvmjUmUeAaHvzdcUvAj6r": "Foundation Baker 6"
+            "tz3WMqdzXqRWXwyvj5Hp2H7QEepaUuS7vd9K": "Foundation Baker 7"
+            "tz3VEZ4k6a4Wx42iyev6i2aVAptTRLEAivNN": "Foundation Baker 8"
+            "tz1NpWrAyDL9k2Lmnyxcgr9xuJakbBxdq7FB": "Gate.io"
+            "tz1WCd2jm4uSt4vntk4vSuUWoZQGhLcDuR9q": "Happy Tezos"
+            "tz1gfArv665EUkSg2ojMBzcbfwuPxAvqPvjo": "Kraken"
+            "tz1X1fpAZtwQk94QXUgZwfgsvkQgyc2KHp9d": "ownBLOCK (Legacy)"
+            "tz1hTFcQk2KJRPzZyHkCwbj7E1zY1xBkiHsk": "ownBLOCK"
+            "tz1dkP8pW6UzamUysFx3WqHZGQMNCZsEaeH6": "ownBLOCK Payouts"
+            "tz1P2Po7YM526ughEsRbY4oR9zaUPDZjxFrb": "P2P Validator"
+            "tz1KtvGSYU5hdKD288a1koTBURWYuADJGrLE": "\u00D8 Crypto Pool (Legacy)"
+            "tz1Yju7jmmsaUiG9qQLoYv35v5pHgnWoLWbt": "Polychain Labs 1"
+            "tz2TSvNTh2epDMhZHrw73nV9piBX7kLZ9K9m": "Polychain Labs 2"
+            "tz1Y42aKCk53vMbaJNpf1hBg1rznGdBxHJ5C": "Tezos Berlin"
+            "tz1Vyuu4EJ5Nym4JcrfRLnp3hpaq1DSEp1Ke": "POS Bakerz"
+            "tz1b7YSEeNRqgmjuX4d4aiai2sQTF4A7WBZf": "Tezos Japan (Legacy)"
+            "tz1ijdEfmUoQXJfSiKCLRioeCfSrKP3sVsff": "Tezos Japan (Legacy B)"
+            "tz1aDiEJf9ztRrAJEXZfcG3CKimoKsGhwVAi": "Tezos Japan"
+            "tz1PPUo28B8BroqmVCMMNDudG4ShA2bzicrU": "Tezos Korea"
+            "tz1b3SaPHFSw51r92ARcV5mGyYbSSsdFd5Gz": "Tezos MX"
+            "tz1Kf25fX1VdmYGSEzwFy1wNmkbSEZ2V83sY": "Tezos Seoul"
+            "tz1RAzdkp1x5ZDqms4ZUrSdfJuUYGH9JTPK2": "Tezos Spanish"
+            "tz1Lh9jeLSWDHYy8AshvG2dpNQseDaHg7cms": "Tezos Spanish (Legacy)"
+            "tz1hAYfexyzPGG6RhZZMpDvAHifubsbb6kgn": "Tezos Suisse"
+            "tz1VYQpZvjVhv1CdcENuCNWJQXu1TWBJ8KTD": "Tezos Tokyo"
+            "tz1R6Ej25VSerE3MkSoEEeBjKHCDTFbpKuSX": "TezosSEAsia"
+            "tz1Lh9jeLSWDHYy8AshvG2dpNQseDaHg7cms": "TezosSpanish"
+            "tz1PesW5khQNhy4revu2ETvMtWPtuVyH2XkZ": "Tz Dutch"
+            "tz1Pwgj6j55akKCyvTwwr9X4np1RskSXpQY4": "Validators.com"
+            "tz1g8vkmcde6sWKaG2NN9WKzCkDM6Rziq194": "StakeNow"
+            "tz1WnfXMPaNTBmH7DBPwqCWs9cPDJdkGBTZ8": "TezosHODL"
+            "tz2FCNBrERXtaTtNX6iimR1UJ5JSDxvdHM93": "stakefish"
+            "tz3QCNyySViKHmeSr45kzDxzchys7NiXCWoa": "Proofofbake.com"
+            "tz1abmz7jiCV2GH2u81LRrGgAFFgvQgiDiaf": "Tessellated Geometry"
+            "tz1TDSmoZXwVevLTEvKCTHWpomG76oC9S2fJ": "Tezos Capital Legacy"
+            "tz1UdeKoMJivgqRgRUNzroMwRJYmJY8BtaWe": "alphaTezos"
+            "tz1RSWMYKGAykpizFteowByYMueCYv9TMn1L": "Tezos Alliance"
+            "tz1Zhv3RkfU2pHrmaiDyxp7kFZpZrUCu1CiF": "TzBake"
+            "tz1Vd1rXpV8hTHbFXCXN3c3qzCsgcU5BZw1e": "TzNode"
+            "tz1fZ767VDbqx4DeKiFswPSHh513f51mKEUZ": "Tezos Bakery"
+            "tz1TqUDvdck5UrPSgdjJu8RPHafet5vyWQFk": "Tezos Bakery Payouts"
+            "tz1aKxnrzx5PXZJe7unufEswVRCMU9yafmfb": "Tezos Canada"
+            "tz1WGpyzJ1WdZQyKgFN1MY1d7KExGzipFmPJ": "Tezos Canada Payouts"
+            "tz1S5WxdZR5f9NzsPXhr7L9L1vrEb5spZFur": "Baking Benjamins"
+            "tz1V3yg82mcrPJbegqVCPn6bC8w1CSTRp3f8": "Staking Shop"
+            "tz1hxtCEcD7idQJEDiJEq37vBkoRcwF6KC2X": "Staking Shop Payouts"
+            "tz1cYufsxHXJcvANhvS55h3aY32a9BAFB494": "Bakery IL"
+            "tz1iVCqjMRG7MfBoFnVjbLQyeLAeJQfLxXze": "Bakery IL Payouts"
+            "tz1WBfwbT66FC6BTLexc2BoyCCBM9LG7pnVW": "888XTZ"
+            "tz1U638Z3xWRiXDDKx2S125MCCaAeGDdA896": "Tezos France"
+            "tz1Zrqm4TkJwqTxm5TiyVFh6taXG4Wrq7tko": "Bake'n'Rolls Payouts"
+            "tz1aRoaRhSpRYvFdyvgWLL6TGyRoGF51wDjM": "Everstake"
+            "tz1W1en9UpMCH4ZJL8wQCh8JDKCZARyVx2co": "Everstake Payouts"
+            "tz1XXayQohB8XRXN7kMoHbf2NFwNiH3oMRQQ": "Bit Cat"
+            "tz1Wy5Ph1FkD1ypUjpFpsHLXLEXDAeCRkZce": "Bit Cat Payouts"
+            "tz1cZfFQpcYhwDp7y1njZXDsZqCrn2NqmVof": "Tezos Rio"
+            "tz1Y2bfsQAYHrWZpM1AwomYMw2KEtaJ5VMfU": "Tezos Rio Payouts"
+            "tz3bEQoFCZEEfZMskefZ8q8e4eiHH1pssRax": "Ceibo XTZ"
+            "tz1ceiboANJ72iqG1g9Xig8vW74JJijv4mb8": "Ceibo XTZ Payouts"
+            "tz1PFeoTuFen8jAMRHajBySNyCwLmY5RqF9M": "Paradigm Bakery"
+            "tz1fb7c66UwePkkfDXz4ajFaBP9hVNLdS7JJ": "Tezos NU"
+            "tz1VfoA5qPksECBkvr2EUuT6u5VgLCi3vTPV": "Tezos NU Payouts"
+            "tz1fUjvVhJrHLZCbhPNvDRckxApqbkievJHN": "Tezzieland"
+            "tz1WntXgznbivRjyhE7Y5jEzoebAhMPB2iJa": "Tezzieland Payouts"
+            "tz1VceyYUpq1gk5dtp6jXQRtCtY8hm5DKt72": "TeZetetic"
+            "tz1S1Aew75hMrPUymqenKfHo8FspppXKpW7h": "Tezos Mars"
+            "tz1bRaSjKZrSrSeQHBDiCqjKXqtZYZM1t8FW": "Imma Baker"
+            "tz1bLwpPfr3xqy1gWBF4sGvv8bLJyPHR11kx": "Tezos Hot Bakery"
+            "tz1ZcTRk5uxD86EFEn1vvNffWWqJy7q5eVhc": "ATEZA"
+            "tz1UJvHTgpVzcKWhTazGxVcn5wsHru5Gietg": "Tezry"
+            "tz1MQJPGNMijnXnVoBENFz9rUhaPt3S7rWoz": "Tezmania"
+            "tz1eCzNtidHvVgeRzQ38C81FPcYnxMsCEL6Z": "TezLoom"
+            "tz1Q8QkSBS63ZQnH3fBTiAMPes9R666Rn6Sc": "YieldWallet"
+            "tz1LnWa4AiFCjMezTgSNa65QFoo7DQGEWgEU": "Tezeract"
+            "tz1NEKxGEHsFufk87CVZcrqWu8o22qh46GK6": "Money Every 3 Days"
+            "tz1NkFRjmkqqcGkAhqe78fdgemDNKXvL7Bod": "BakeMyStake"
+            "tz1SohptP53wDPZhzTWzDUFAUcWF6DMBpaJV": "Hayek Lab"
+            "tz1d6Fx42mYgVFnHUW8T8A7WBfJ6nD9pVok8": "MyTezosBaking"
+            "tz1fJHFn6sWEd3NnBPngACuw2dggTv6nQZ7g": "Baking Team"
+            "tz1iJ4qgGTzyhaYEzd1RnC6duEkLBd1nzexh": "Tz Envoy"
+            "tz1UsFcWtY6BxchK1L9619oXBzy3C2JCrRut": "Baking Tezos 4U"
+            "tz1QXrzaHrGACVn15UiCg33aLCJ6npWdQb3J": "Moku"
+            "tz1QGtMpkbdSM8Y1eHTru3WY51sXhFikbaAC": "TezosNigeria_001"
+            "tz1Vc9XAD7iphycJoRwE1Nxx5krB9C7XyBu5": "\u00D8 Crypto Pool"
+            "tz1irJKkXS2DBWkU1NnmFQx1c1L7pbGg4yhk": "Coinbase Custody"
+            "tz1VQnqCCqX4K5sP3FNkVSNKTdCAMJDd3E1n": "PosDog"
+            "tz1RCFbB9GpALpsZtu6J58sb74dm8qe6XBzv": "Staked"
+            "tz1KfEsrtDaA1sX7vdM4qmEPWuSytuqCDp5j": "XTZ Master"
+            "tz1isXamBXpTUgbByQ6gXgZQg4GWNW7r6rKE": "Tez Whale"
+            "tz1Ldzz6k1BHdhuKvAtMRX7h5kJSMHESMHLC": "PayTezos"
+            "tz1UvkANVPWppVgMkLnvN7BwYZsCP7vm6NVd": "Neokta Labs"
+            "tz1YhNsiRRU8aHNGg7NK3uuP6UDAyacJernB": "Tez Baguette"
+            "tz3adcvQaKXTCg12zbninqo3q8ptKKtDFTLv": "Tezzigator"
+            "tz1RV1MBbZMR68tacosb7Mwj6LkbPSUS1er1": "Baking Tacos"
+            "tz1W5VkdB5s7ENMESVBtwyt9kyvLqPcUczRT": "Tezgate"
+            "tz1PWCDnz783NNGGQjEFFsHtrcK5yBW4E2rm": "Melange"
+            "tz1V2FYediKBAEaTpXXJBSjuQpjkyCzrTSiE": "Stake House"
+            "tz1Scdr2HsZiQjc7bHMeBbmDRXYVvdhjJbBh": "Figment"
+            "tz1VmiY38m3y95HqQLjMwqnMS7sdMfGomzKi": "Lucid Mining"
+            "tz1WctSwL49BZtdWAQ75NY6vr4xsAx6oKdah": "Tezos Wake n' Bake"
+            "tz1PeZx7FXy7QRuMREGXGxeipb24RsMMzUNe": "Tezos Panda"
+            "tz1bHzftcTKZMTZgLLtnrXydCm6UEqf4ivca": "Tezos Vote"
+            "tz1S8e9GgdZG78XJRB3NqabfWeM37GnhZMWQ": "0xb1 PlusMinus"
+            "tz1LmaFsWRkjr7QMCx5PtV6xTUz3AmEpKQiF": "Blockpower Staking"
+            "tz1RjoHc98dBoqaH2jawF62XNKh7YsHwbkEv": "OKEx Baker"
+            "tz1cX93Q3KsiTADpCC4f12TBvAmS5tw7CW19": "Tz Bakery"
+            "tz1VHFxUuBhwopxC9YC9gm5s2MHBHLyCtvN1": "HyperBlocks"
+            "tz1aiYKXmSRckyJ9EybKmpVry373rfyngJU8": "View Nodes"
+            "tz1STeamwbp68THcny9zk3LsbG3H36DMvbRK": "StakingTeam"
+            "tz1hUSVvSq4YbZcREBqKHf6eXM1yvXuGYUNZ": "Metablock Baker"
+            "tz1Tnjaxk6tbAeC2TmMApPh8UsrEVQvhHvx5": "Crypto Delegate"
+            "tz1LBEKXaxQbd5Gtzbc1ATCwc3pppu81aWGc": "Tez-Baking"
+            "tz1dbfppLAAxXZNtf2SDps7rch3qfUznKSoK": "Coinhouse"
+            "tz1dRKU4FQ9QRRQPdaH4zCR6gmCmXfcvcgtB": "Spice"
+            "tz1Z2jXfEXL7dXhs6bsLmyLFLfmAkXBzA9WE": "Tezos Boutique"
+            "tz1dNVDWPf3Q59SdJqnjdnu277iyvReiRS9M": "Steak and Bake"
+            "tz1Zcxkfa5jKrRbBThG765GP29bUCU3C4ok5": "Tezz City"
+            "tz1Lhf4J9Qxoe3DZ2nfe8FGDnvVj7oKjnMY6": "Tez Baker"
+            "tz1XhnCdVENzgko5x1MMswLHSoQbJ5NPwLZ6": "Anonstake"
+            "tz1WpeqFaBG9Jm73Dmgqamy8eF8NWLz9JCoY": "Staking Facilities"
+            "tz1iZEKy4LaAjnTmn2RuGDf2iqdAQKnRi8kY": "Tezzigator (Legacy)"
+            "tz1MkjfzHNF3kk7PMUDVsaTrF8iRD6fpHftR": "LuxBaker"
+            "tz1hWB6QV5GBQKdEJN8EowHhLJyCMPhH18sA": "Tezos Cameroun"
+          }
+        }
+        counter {
+          visible: true
+          display-priority: 2
+        }
+        storage {
+          display-priority: 1
+          display-order: 4
+          visible: true
+        }
+        balance {
+          display-priority: 0
+          display-order: 1
+          visible: true
+          scale: 6,
+          data-type: "currency"
+          currencySymbolCode: 42793
+        }
+        cycle {
+          display-name: "Cycle"
+          visible: true
+        }
+        block_level {
+          display-priority: 1
+          display-order: 9
+          visible: true
+          display-name: "Block Level"
+          data-type: "int"
+          reference: {
+            entity: "blocks"
+            key: "level"
+          }
+          temporal-column: true
+        }
+        asof {
+          visible: true
+          data-format: "YYYY MMM DD, HH:mm"
+          temporal-column: true
+        }
+        is_baker {
+          display-name: "Is Baker"
+          visible: true
+        }
+        is_activated {
+          visible: true
+        }
+        is_active_baker {
+          visible: true
+        }
+      }
+    }
+    balance_updates {
+      display-name-plural: "Balance Updates"
+      display-name: "Balance Update"
+      visible: true
+      attributes {
+        id {
+          visible: false
+          reference: {
+            entity: "operations"
+            key: "operation_id"
+          }
+        }
+        source {
+          visible: true
+          value-map: {
+            "block": "Block",
+            "operation": "Operation",
+            "operation_result": "Operation Result"
+          }
+        }
+        source_id {
+          visible: false
+        }
+        source_hash {
+          visible: true
+          data-type: "hash"
+          display-name: "Source Hash"
+        }
+        kind {
+          visible: true
+          cache-config {
+            cached: true
+          }
+        }
+        account_id {
+          display-name: "Account"
+          visible: true
+          data-type: "accountAddress"
+          reference: {
+            entity: "accounts"
+            key: "account_id"
+          }
+        }
+        change {
+          visible: true
+          scale: 6,
+          data-type: "currency"
+          currency-symbol-code: 42793
+        }
+        level {
+          data-type: "int"
+          visible: true
+        }
+        category {
+          visible: true
+        }
+        operation_group_hash {
+          display-name: "Op Group Hash"
+          visible: true
+          data-type: "hash"
+          reference: {
+            entity: "operations"
+            key: "operation_group_hash"
+          }
+        }
+        block_id {
+          display-name: "Block Hash"
+          data-type: "hash"
+          visible: true
+        }
+        block_level {
+          display-name: "Block Level"
+          data-type: "int"
+          visible: true
+        }
+        cycle {
+          visible: true
+        }
+        period {
+          visible: true
+        }
+      }
+    }
+    big_maps {
+      display-name-plural: "Big Maps"
+      display-name: "Big Map"
+      visible: true
+      attributes {
+        big_map_id {
+          display-priority: 0
+          display-order: 0
+          display-name: "Id"
+          data-type: "int"
+          visible: true
+        }
+        key_type {
+          display-priority: 0
+          display-order: 1
+          visible: true
+        }
+        value_type {
+          display-priority: 0
+          display-order: 2
+          visible: true
+        }
+      }
+    }
+    metadata {
+      visible: true
+      attributes {
+        address {
+          visible: true
+        }
+        raw_metadata {
+          visible: true
+        }
+        name {
+          visible: true
+        }
+        description {
+          visible: true
+        }
+        last_updated {
+          visible: true
+        }
+      }
+    }
+    nfts {
+      visible: true
+      attributes {
+        contract_address {
+          visible: true
+        }
+        op_group_hash {
+          visible: true
+        }
+        block_level {
+          visible: true
+        }
+        timestamp {
+          visible: true
+          data-format: "YYYY MMM DD, HH:mm"
+        }
+        contract_name {
+          visible: true
+        }
+        asset_type {
+          visible: true
+        }
+        asset_location {
+          visible: true
+        }
+        raw_metadata {
+          visible: true
+        }
+      }
+    }
+    big_map_contents {
+      display-name-plural: "Big Map Contents"
+      display-name: "Big Map Content"
+      visible: true
+      attributes {
+        big_map_id {
+          display-priority: 0
+          display-order: 3
+          display-name: "Map Id"
+          data-type: "int"
+          visible: true
+          reference: {
+            entity: "big_maps"
+            key: "big_map_id"
+          }
+        }
+        key {
+          display-priority: 0
+          display-order: 0
+          visible: true
+        }
+        key_hash {
+          display-priority: 0
+          display-order: 1
+          visible: true
+        }
+        operation_group_id {
+          data-type: "hash"
+          display-priority: 0
+          display-order: 2
+          visible: true
+        }
+        value {
+          display-priority: 0
+          display-order: 3
+          visible: true
+        }
+        block_level {
+          display-priority: 0
+          display-order: 4
+          display-name: "Block Level"
+          data-type: "int"
+          visible: true
+        }
+        timestamp {
+          display-priority: 0
+          display-order: 5
+          data-format: "YYYY MMM DD, HH:mm"
+          visible: true
+        }
+        cycle {
+          display-priority: 0
+          display-order: 6
+          visible: true
+        }
+        period {
+          display-priority: 0
+          display-order: 7
+          visible: true
+        }
+      }
+    }
+    big_map_contents_history {
+      display-name-plural: "Big Map Contents"
+      display-name: "Big Map Content"
+      visible: true
+      attributes {
+        big_map_id {
+          display-priority: 0
+          display-order: 3
+          display-name: "Map Id"
+          data-type: "int"
+          visible: true
+          reference: {
+            entity: "big_maps"
+            key: "big_map_id"
+          }
+        }
+        key {
+          display-priority: 0
+          display-order: 0
+          visible: true
+        }
+        key_hash {
+          display-priority: 0
+          display-order: 1
+          visible: true
+        }
+        operation_group_id {
+          data-type: "hash"
+          display-priority: 0
+          display-order: 2
+          visible: true
+        }
+        value {
+          display-priority: 0
+          display-order: 3
+          visible: true
+        }
+        block_level {
+          display-priority: 0
+          display-order: 4
+          display-name: "Block Level"
+          data-type: "int"
+          visible: true
+          temporal-column: true
+        }
+        timestamp {
+          display-priority: 0
+          display-order: 5
+          data-format: "YYYY MMM DD, HH:mm"
+          visible: true
+          temporal-column: true
+        }
+        cycle {
+          display-priority: 0
+          display-order: 6
+          visible: true
+        }
+        period {
+          display-priority: 0
+          display-order: 7
+          visible: true
+        }
+      }
+    }
+    originated_account_maps {
+      display-name-plural: "Contract Big Maps"
+      display-name: "Contract Big Maps"
+      visible: true
+      attributes {
+        big_map_id {
+          display-priority: 0
+          display-order: 0
+          display-name: "Map id"
+          data-type: "int"
+          visible: true
+          reference: {
+            entity: "big_maps"
+            key: "big_map_id"
+          }
+        }
+        account_id {
+          display-priority: 0
+          display-order: 1
+          data-type: "accountaddress"
+          visible: true
+          reference: {
+            entity: "accounts"
+            key: "account_id"
+          }
+        }
+      }
+    }
+    blocks {
+      display-name-plural: "Blocks"
+      display-name: "Block"
+      visible: true
+      attributes {
+        level {
+          display-priority: 0
+          display-order: 1
+          data-type: "int"
+          visible: true
+        }
+        proto {
+          display-name: "Protocol Index"
+          visible: true
+        }
+        predecessor {
+          display-priority: 0
+          display-order: 3
+          display-name: "Predecessor Hash"
+          data-type: "hash"
+          visible: true
+          reference: {
+            entity: "blocks"
+            key: "hash"
+          }
+        }
+        timestamp {
+          display-priority: 0
+          display-order: 2
+          data-format: "YYYY MMM DD, HH:mm"
+          visible: true
+        }
+        fitness {
+          visible: true
+        }
+        context {
+          visible: true
+          data-type: "hash"
+        }
+        signature {
+          visible: true
+          data-type: "hash"
+        }
+        protocol {
+          display-name: "Protocol Hash"
+          data-type: "hash"
+          visible: true
+          value-map: {
+            "PtHangz2aRngywmSRGGvrcTyMbbdpWdpFKuS4uMWxg2RaH9i1qx": "Hangzhou Actual"
+            "PtGRANADsDU8R9daYKAgWnQYAJ64omN1o3KMGVCykShA97vQbvV": "Granada"
+            "PsFLorenaUUuikDWvMDr6fGBRG8kt3e3D3fHoXK1j1BFRxeSH4i": "Florence"
+            "PtEdo2ZkT9oKpimTah6x2embF25oss54njMuPzkJTEi5RqfdZFA": "Edo Actual"
+            "PsDELPH1Kxsxt8f9eWbxQeRxkjfbxoqM52jvs5Y5fBxWWh4ifpo": "Delphi"
+            "PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb": "Carthage 2.0"
+            "PsBabyM1eUXZseaJdmXFApDSBqj8YBfwELoxZHHW77EMcAbbwAS": "Babylon 2.1"
+            "Pt24m4xiPbLDhVgVfABUjirbmda3yohdN82Sp9FeuAXJ4eV9otd": "Athens A"
+            "PsddFKi32cMJ2qPjf43Qv5GDWLDPZb3T3bF6fLKiF5HtvHNU7aP": "Alpha 3"
+            "PsYLVpVvgbLhAhoqAkMFUo6gudkJ9weNXhUYCiLDzcUpFpkk8Wt": "Alpha 2"
+            "PtCJ7pwoxe8JasnHY8YonnLYjcVHmhiARPJvqcC6VfHT5s8k8sY": "Alpha 1"
+            "Ps9mPmXaRzmzk35gbAYNCAw6UXdE2qoABTHbN2oEEc1qM7CwT9P": "Bootstrap"
+            "PrihK96nBAFSxVL1GLJTVhu9YnzkMFiBeuJRPA8NwuZVZCE1L6i": "Genesis"
+          }
+        }
+        chain_id {
+          display-name: "Chain Id"
+          visible: true
+        }
+        hash {
+          display-priority: 0
+          display-order: 0
+          display-name: "Block Hash"
+          data-type: "hash"
+          visible: true
+          cache-config {
+            cached: true,
+            min-match-length: 4,
+            max-result-size: 100
+          }
+        }
+        operations_hash {
+          display-priority: 1
+          display-order: 5
+          display-name: "Operations Hash"
+          visible: true
+          data-type: "hash"
+        }
+        period_kind {
+          display-name: "Voting Period"
+          visible: true
+        }
+        current_expected_quorum {
+          display-name: "Expected Quorum"
+          visible: true
+        }
+        active_proposal {
+          display-name: "Active Proposal"
+          visible: true
+          data-type: "hash"
+        }
+        baker {
+          visible: true
+          data-type: "accountAddress"
+          reference: {
+            entity: "accounts"
+            key: "account_id"
+          }
+          cache-config {
+            cached: true,
+            min-match-length: 4,
+            max-result-size: 10
+          }
+          value-map: {
+            "tz1gk3TDbU7cJuiBRMhwQXVvgDnjsxuWhcEA": "Airfoil"
+            "tz1MJx9vhaNRSimcuXPK2rW4fLccQnDAnVKJ": "AirGap"
+            "tz3e75hU4EhDU3ukyJueh5v6UvEHzGwkg3yC": "At James"
+            "tz1ei4WtWEMEJekSv8qDnu9PExG6Q8HgRGr3": "Bake Tz"
+            "tz1NortRftucvAkD1J58L32EhSVrQEWJCEnB": "Bake'n'Rolls"
+            "tz1S8MNvuFEUsWgjHvi3AxibRBf388NhT1q2": "Binance Baker"
+            "tz1KtGwriE7VuLwT3LwuvU9Nv4wAxP7XZ57d": "Bitfinex"
+            "tz1SYq214SCBy9naR6cvycQsYcUGpBqQAE8d": "Coinone Baker"
+            "tz1eEnQhbwf6trb8Q8mPb2RaPkNk2rN7BKi8": "Chorus One"
+            "tz1MXFrtZoaXckE41bjUCSjAjAap3AFDSr3N": "Everstake (Legacy)"
+            "tz1TzaNn7wSQSP5gYPXCnNzBCpyMiidCq1PX": "Flippin' tacos"
+            "tz3RDC3Jdn4j15J7bBHZd29EUee9gVB1CxD9": "Foundation Baker 1"
+            "tz3bvNMQ95vfAYtG8193ymshqjSvmxiCUuR5": "Foundation Baker 2"
+            "tz3RB4aoyjov4KEVRbuhvQ1CKJgBJMWhaeB8": "Foundation Baker 3"
+            "tz3bTdwZinP8U1JmSweNzVKhmwafqWmFWRfk": "Foundation Baker 4"
+            "tz3NExpXn9aPNZPorRE4SdjJ2RGrfbJgMAaV": "Foundation Baker 5"
+            "tz3UoffC7FG7zfpmvmjUmUeAaHvzdcUvAj6r": "Foundation Baker 6"
+            "tz3WMqdzXqRWXwyvj5Hp2H7QEepaUuS7vd9K": "Foundation Baker 7"
+            "tz3VEZ4k6a4Wx42iyev6i2aVAptTRLEAivNN": "Foundation Baker 8"
+            "tz1NpWrAyDL9k2Lmnyxcgr9xuJakbBxdq7FB": "Gate.io"
+            "tz1WCd2jm4uSt4vntk4vSuUWoZQGhLcDuR9q": "Happy Tezos"
+            "tz1gfArv665EUkSg2ojMBzcbfwuPxAvqPvjo": "Kraken"
+            "tz1X1fpAZtwQk94QXUgZwfgsvkQgyc2KHp9d": "ownBLOCK (Legacy)"
+            "tz1hTFcQk2KJRPzZyHkCwbj7E1zY1xBkiHsk": "ownBLOCK"
+            "tz1dkP8pW6UzamUysFx3WqHZGQMNCZsEaeH6": "ownBLOCK Payouts"
+            "tz1P2Po7YM526ughEsRbY4oR9zaUPDZjxFrb": "P2P Validator"
+            "tz1KtvGSYU5hdKD288a1koTBURWYuADJGrLE": "\u00D8 Crypto Pool (Legacy)"
+            "tz1Yju7jmmsaUiG9qQLoYv35v5pHgnWoLWbt": "Polychain Labs 1"
+            "tz2TSvNTh2epDMhZHrw73nV9piBX7kLZ9K9m": "Polychain Labs 2"
+            "tz1Y42aKCk53vMbaJNpf1hBg1rznGdBxHJ5C": "Tezos Berlin"
+            "tz1Vyuu4EJ5Nym4JcrfRLnp3hpaq1DSEp1Ke": "POS Bakerz"
+            "tz1b7YSEeNRqgmjuX4d4aiai2sQTF4A7WBZf": "Tezos Japan (Legacy)"
+            "tz1ijdEfmUoQXJfSiKCLRioeCfSrKP3sVsff": "Tezos Japan (Legacy B)"
+            "tz1aDiEJf9ztRrAJEXZfcG3CKimoKsGhwVAi": "Tezos Japan"
+            "tz1PPUo28B8BroqmVCMMNDudG4ShA2bzicrU": "Tezos Korea"
+            "tz1b3SaPHFSw51r92ARcV5mGyYbSSsdFd5Gz": "Tezos MX"
+            "tz1Kf25fX1VdmYGSEzwFy1wNmkbSEZ2V83sY": "Tezos Seoul"
+            "tz1RAzdkp1x5ZDqms4ZUrSdfJuUYGH9JTPK2": "Tezos Spanish"
+            "tz1Lh9jeLSWDHYy8AshvG2dpNQseDaHg7cms": "Tezos Spanish (Legacy)"
+            "tz1hAYfexyzPGG6RhZZMpDvAHifubsbb6kgn": "Tezos Suisse"
+            "tz1VYQpZvjVhv1CdcENuCNWJQXu1TWBJ8KTD": "Tezos Tokyo"
+            "tz1R6Ej25VSerE3MkSoEEeBjKHCDTFbpKuSX": "TezosSEAsia"
+            "tz1Lh9jeLSWDHYy8AshvG2dpNQseDaHg7cms": "TezosSpanish"
+            "tz1PesW5khQNhy4revu2ETvMtWPtuVyH2XkZ": "Tz Dutch"
+            "tz1Pwgj6j55akKCyvTwwr9X4np1RskSXpQY4": "Validators.com"
+            "tz1g8vkmcde6sWKaG2NN9WKzCkDM6Rziq194": "StakeNow"
+            "tz1WnfXMPaNTBmH7DBPwqCWs9cPDJdkGBTZ8": "TezosHODL"
+            "tz2FCNBrERXtaTtNX6iimR1UJ5JSDxvdHM93": "stakefish"
+            "tz3QCNyySViKHmeSr45kzDxzchys7NiXCWoa": "Proofofbake.com"
+            "tz1abmz7jiCV2GH2u81LRrGgAFFgvQgiDiaf": "Tessellated Geometry"
+            "tz1TDSmoZXwVevLTEvKCTHWpomG76oC9S2fJ": "Tezos Capital Legacy"
+            "tz1UdeKoMJivgqRgRUNzroMwRJYmJY8BtaWe": "alphaTezos"
+            "tz1RSWMYKGAykpizFteowByYMueCYv9TMn1L": "Tezos Alliance"
+            "tz1Zhv3RkfU2pHrmaiDyxp7kFZpZrUCu1CiF": "TzBake"
+            "tz1Vd1rXpV8hTHbFXCXN3c3qzCsgcU5BZw1e": "TzNode"
+            "tz1fZ767VDbqx4DeKiFswPSHh513f51mKEUZ": "Tezos Bakery"
+            "tz1TqUDvdck5UrPSgdjJu8RPHafet5vyWQFk": "Tezos Bakery Payouts"
+            "tz1aKxnrzx5PXZJe7unufEswVRCMU9yafmfb": "Tezos Canada"
+            "tz1WGpyzJ1WdZQyKgFN1MY1d7KExGzipFmPJ": "Tezos Canada Payouts"
+            "tz1S5WxdZR5f9NzsPXhr7L9L1vrEb5spZFur": "Baking Benjamins"
+            "tz1V3yg82mcrPJbegqVCPn6bC8w1CSTRp3f8": "Staking Shop"
+            "tz1hxtCEcD7idQJEDiJEq37vBkoRcwF6KC2X": "Staking Shop Payouts"
+            "tz1cYufsxHXJcvANhvS55h3aY32a9BAFB494": "Bakery IL"
+            "tz1iVCqjMRG7MfBoFnVjbLQyeLAeJQfLxXze": "Bakery IL Payouts"
+            "tz1WBfwbT66FC6BTLexc2BoyCCBM9LG7pnVW": "888XTZ"
+            "tz1U638Z3xWRiXDDKx2S125MCCaAeGDdA896": "Tezos France"
+            "tz1Zrqm4TkJwqTxm5TiyVFh6taXG4Wrq7tko": "Bake'n'Rolls Payouts"
+            "tz1aRoaRhSpRYvFdyvgWLL6TGyRoGF51wDjM": "Everstake"
+            "tz1W1en9UpMCH4ZJL8wQCh8JDKCZARyVx2co": "Everstake Payouts"
+            "tz1XXayQohB8XRXN7kMoHbf2NFwNiH3oMRQQ": "Bit Cat"
+            "tz1Wy5Ph1FkD1ypUjpFpsHLXLEXDAeCRkZce": "Bit Cat Payouts"
+            "tz1cZfFQpcYhwDp7y1njZXDsZqCrn2NqmVof": "Tezos Rio"
+            "tz1Y2bfsQAYHrWZpM1AwomYMw2KEtaJ5VMfU": "Tezos Rio Payouts"
+            "tz3bEQoFCZEEfZMskefZ8q8e4eiHH1pssRax": "Ceibo XTZ"
+            "tz1ceiboANJ72iqG1g9Xig8vW74JJijv4mb8": "Ceibo XTZ Payouts"
+            "tz1PFeoTuFen8jAMRHajBySNyCwLmY5RqF9M": "Paradigm Bakery"
+            "tz1fb7c66UwePkkfDXz4ajFaBP9hVNLdS7JJ": "Tezos NU"
+            "tz1VfoA5qPksECBkvr2EUuT6u5VgLCi3vTPV": "Tezos NU Payouts"
+            "tz1fUjvVhJrHLZCbhPNvDRckxApqbkievJHN": "Tezzieland"
+            "tz1WntXgznbivRjyhE7Y5jEzoebAhMPB2iJa": "Tezzieland Payouts"
+            "tz1VceyYUpq1gk5dtp6jXQRtCtY8hm5DKt72": "TeZetetic"
+            "tz1S1Aew75hMrPUymqenKfHo8FspppXKpW7h": "Tezos Mars"
+            "tz1bRaSjKZrSrSeQHBDiCqjKXqtZYZM1t8FW": "Imma Baker"
+            "tz1bLwpPfr3xqy1gWBF4sGvv8bLJyPHR11kx": "Tezos Hot Bakery"
+            "tz1ZcTRk5uxD86EFEn1vvNffWWqJy7q5eVhc": "ATEZA"
+            "tz1UJvHTgpVzcKWhTazGxVcn5wsHru5Gietg": "Tezry"
+            "tz1MQJPGNMijnXnVoBENFz9rUhaPt3S7rWoz": "Tezmania"
+            "tz1eCzNtidHvVgeRzQ38C81FPcYnxMsCEL6Z": "TezLoom"
+            "tz1Q8QkSBS63ZQnH3fBTiAMPes9R666Rn6Sc": "YieldWallet"
+            "tz1LnWa4AiFCjMezTgSNa65QFoo7DQGEWgEU": "Tezeract"
+            "tz1NEKxGEHsFufk87CVZcrqWu8o22qh46GK6": "Money Every 3 Days"
+            "tz1NkFRjmkqqcGkAhqe78fdgemDNKXvL7Bod": "BakeMyStake"
+            "tz1SohptP53wDPZhzTWzDUFAUcWF6DMBpaJV": "Hayek Lab"
+            "tz1d6Fx42mYgVFnHUW8T8A7WBfJ6nD9pVok8": "MyTezosBaking"
+            "tz1fJHFn6sWEd3NnBPngACuw2dggTv6nQZ7g": "Baking Team"
+            "tz1iJ4qgGTzyhaYEzd1RnC6duEkLBd1nzexh": "Tz Envoy"
+            "tz1UsFcWtY6BxchK1L9619oXBzy3C2JCrRut": "Baking Tezos 4U"
+            "tz1QXrzaHrGACVn15UiCg33aLCJ6npWdQb3J": "Moku"
+            "tz1QGtMpkbdSM8Y1eHTru3WY51sXhFikbaAC": "TezosNigeria_001"
+            "tz1Vc9XAD7iphycJoRwE1Nxx5krB9C7XyBu5": "\u00D8 Crypto Pool"
+            "tz1irJKkXS2DBWkU1NnmFQx1c1L7pbGg4yhk": "Coinbase Custody"
+            "tz1VQnqCCqX4K5sP3FNkVSNKTdCAMJDd3E1n": "PosDog"
+            "tz1RCFbB9GpALpsZtu6J58sb74dm8qe6XBzv": "Staked"
+            "tz1KfEsrtDaA1sX7vdM4qmEPWuSytuqCDp5j": "XTZ Master"
+            "tz1isXamBXpTUgbByQ6gXgZQg4GWNW7r6rKE": "Tez Whale"
+            "tz1Ldzz6k1BHdhuKvAtMRX7h5kJSMHESMHLC": "PayTezos"
+            "tz1UvkANVPWppVgMkLnvN7BwYZsCP7vm6NVd": "Neokta Labs"
+            "tz1YhNsiRRU8aHNGg7NK3uuP6UDAyacJernB": "Tez Baguette"
+            "tz3adcvQaKXTCg12zbninqo3q8ptKKtDFTLv": "Tezzigator"
+            "tz1RV1MBbZMR68tacosb7Mwj6LkbPSUS1er1": "Baking Tacos"
+            "tz1W5VkdB5s7ENMESVBtwyt9kyvLqPcUczRT": "Tezgate"
+            "tz1PWCDnz783NNGGQjEFFsHtrcK5yBW4E2rm": "Melange"
+            "tz1V2FYediKBAEaTpXXJBSjuQpjkyCzrTSiE": "Stake House"
+            "tz1Scdr2HsZiQjc7bHMeBbmDRXYVvdhjJbBh": "Figment"
+            "tz1VmiY38m3y95HqQLjMwqnMS7sdMfGomzKi": "Lucid Mining"
+            "tz1WctSwL49BZtdWAQ75NY6vr4xsAx6oKdah": "Tezos Wake n' Bake"
+            "tz1PeZx7FXy7QRuMREGXGxeipb24RsMMzUNe": "Tezos Panda"
+            "tz1bHzftcTKZMTZgLLtnrXydCm6UEqf4ivca": "Tezos Vote"
+            "tz1S8e9GgdZG78XJRB3NqabfWeM37GnhZMWQ": "0xb1 PlusMinus"
+            "tz1LmaFsWRkjr7QMCx5PtV6xTUz3AmEpKQiF": "Blockpower Staking"
+            "tz1RjoHc98dBoqaH2jawF62XNKh7YsHwbkEv": "OKEx Baker"
+            "tz1cX93Q3KsiTADpCC4f12TBvAmS5tw7CW19": "Tz Bakery"
+            "tz1VHFxUuBhwopxC9YC9gm5s2MHBHLyCtvN1": "HyperBlocks"
+            "tz1aiYKXmSRckyJ9EybKmpVry373rfyngJU8": "View Nodes"
+            "tz1STeamwbp68THcny9zk3LsbG3H36DMvbRK": "StakingTeam"
+            "tz1hUSVvSq4YbZcREBqKHf6eXM1yvXuGYUNZ": "Metablock Baker"
+            "tz1Tnjaxk6tbAeC2TmMApPh8UsrEVQvhHvx5": "Crypto Delegate"
+            "tz1LBEKXaxQbd5Gtzbc1ATCwc3pppu81aWGc": "Tez-Baking"
+            "tz1dbfppLAAxXZNtf2SDps7rch3qfUznKSoK": "Coinhouse"
+            "tz1dRKU4FQ9QRRQPdaH4zCR6gmCmXfcvcgtB": "Spice"
+            "tz1Z2jXfEXL7dXhs6bsLmyLFLfmAkXBzA9WE": "Tezos Boutique"
+            "tz1dNVDWPf3Q59SdJqnjdnu277iyvReiRS9M": "Steak and Bake"
+            "tz1Zcxkfa5jKrRbBThG765GP29bUCU3C4ok5": "Tezz City"
+            "tz1Lhf4J9Qxoe3DZ2nfe8FGDnvVj7oKjnMY6": "Tez Baker"
+            "tz1XhnCdVENzgko5x1MMswLHSoQbJ5NPwLZ6": "Anonstake"
+            "tz1WpeqFaBG9Jm73Dmgqamy8eF8NWLz9JCoY": "Staking Facilities"
+            "tz1iZEKy4LaAjnTmn2RuGDf2iqdAQKnRi8kY": "Tezzigator (Legacy)"
+            "tz1MkjfzHNF3kk7PMUDVsaTrF8iRD6fpHftR": "LuxBaker"
+            "tz1hWB6QV5GBQKdEJN8EowHhLJyCMPhH18sA": "Tezos Cameroun"
+          }
+        }
+        consumed_gas {
+          display-name: "Consumed Gas"
+          visible: true
+        }
+        meta_level {
+          visible: false
+        }
+        meta_level_position {
+          visible: false
+        }
+        meta_cycle {
+          display-name: "Cycle"
+          visible: true
+        }
+        meta_cycle_position {
+          visible: true
+          display-name: "Cycle Position"
+        }
+        meta_voting_period {
+          display-name: "Period Index"
+          visible: true
+        }
+        meta_voting_period_position {
+          display-name: "Period Position"
+          visible: true
+        }
+        priority {
+          visible: true
+        }
+        utc_year: {
+          visible: true
+        }
+        utc_month: {
+          visible: true
+        }
+        utc_day: {
+          visible: true
+        }
+        utc_time: {
+          visible: true
+        }
+      }
+    }
+    fees {
+      display-name-plural: "Fees"
+      display-name: "Fee"
+      visible: true
+      attributes {
+        low {
+          visible: true
+          scale: 6,
+          data-type: "currency"
+          currency-symbol-code: 42793
+        }
+        medium {
+          visible: true
+          scale: 6,
+          data-type: "currency"
+          currency-symbol-code: 42793
+        }
+        high {
+          visible: true
+          scale: 6,
+          data-type: "currency"
+          currency-symbol-code: 42793
+        }
+        timestamp {
+          visible: true
+          data-format: "YYYY MMM DD, HH:mm"
+        }
+        kind {
+          visible: true
+        }
+        level {
+          data-type: "int"
+          visible: true
+        }
+        cycle {
+          visible: true
+        }
+      }
+    }
+    operation_groups {
+      display-name-plural: "Operation Groups"
+      display-name: "Operation Group"
+      visible: true
+      attributes {
+        protocol {
+          visible: true
+          data-type: "hash"
+          value-map: {
+            "Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A": "Ithaca 2.0"
+            "PsiThaCaT47Zboaw71QWScM8sXeMM7bbQFncK9FLqYc6EKdpjVP": "Ithaca"
+            "PtHangz2aRngywmSRGGvrcTyMbbdpWdpFKuS4uMWxg2RaH9i1qx": "Hangzhou Actual"
+            "PsCUKj6wydGtDNGPRdxasZDs4esZcVD9tf44MMiVy46FkD9q1h9": "Hanghouz-USDtz-LB"
+            "PtHangzHogokSuiMHemCuowEavgYTP8J5qQ9fQS793MHYFpCY3r": "Hangzhou"
+            "PtGRANADsDU8R9daYKAgWnQYAJ64omN1o3KMGVCykShA97vQbvV": "Granada"
+            "PsFLorenaUUuikDWvMDr6fGBRG8kt3e3D3fHoXK1j1BFRxeSH4i": "Florence"
+            "PtEdo2ZkT9oKpimTah6x2embF25oss54njMuPzkJTEi5RqfdZFA": "Edo 2.0"
+            "PtEdoTezd3RHSC31mpxxo1npxFjoWWcFgQtxapi51Z8TLu6v6Uq": "Edo"
+            "PsDELPH1Kxsxt8f9eWbxQeRxkjfbxoqM52jvs5Y5fBxWWh4ifpo": "Delphi"
+            "PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb": "Carthage 2.0"
+            "PtCarthavAMoXqbjBPVgDCRd5LgT7qqKWUPXnYii3xCaHRBMfHH": "Carthage"
+            "PsBabyM1eUXZseaJdmXFApDSBqj8YBfwELoxZHHW77EMcAbbwAS": "Babylon 2.1"
+            "PsBABY5HQTSkA4297zNHfsZNKtxULfL18y95qb3m53QJiXGmrbU": "Babylon 2.0"
+            "PsBABY5nk4JhdEv1N1pZbt6m6ccB9BfNqa23iKZcHBh23jmRS9f": "Babylon"
+            "PtdRxBHvc91c2ea2evV6wkoqnzW7TadTg9aqS9jAn2GbcPGtumD": "Brest A"
+            "Psd1ynUBhMZAeajwcZJAeq5NrxorM6UCU4GJqxZ7Bx2e9vUWB6z": "Athens B"
+            "Pt24m4xiPbLDhVgVfABUjirbmda3yohdN82Sp9FeuAXJ4eV9otd": "Athens A"
+          }
+        }
+        chain_id {
+          visible: true
+        }
+        hash {
+          visible: true
+          data-type: "hash"
+          reference: {
+            entity: "operations"
+            key: "operation_group_hash"
+          }
+        }
+        branch {
+          visible: true
+          data-type: "hash"
+        }
+        signature {
+          visible: true
+          data-type: "hash"
+        }
+        block_level: {
+          visible: true
+          display-name: "Block Level"
+          data-type: "int"
+          reference: {
+            entity: "blocks"
+            key: "level"
+          }
+        }
+        block_id {
+          display-name: "Block Hash"
+          data-type: "hash"
+          visible: true
+          reference: {
+            entity: "blocks"
+            key: "hash"
+          }
+        }
+      }
+    }
+    operations {
+      display-name-plural: "Operations"
+      display-name: "Operation"
+      visible: true
+      attributes {
+        operation_id: {
+          visible: false
+        }
+        operation_group_hash: {
+          visible: true
+          display-name: "Op Group Hash"
+          data-type: "hash"
+        }
+        kind: {
+          visible: true
+          cache-config {
+            cached: true,
+            min-match-length: 1,
+            max-result-size: 100
+          }
+        }
+        cycle: {
+          visible: true
+        }
+        level: {
+          visible: true
+          data-type: "int"
+          reference: {
+            entity: "blocks"
+            key: "level"
+          }
+        }
+        delegate: {
+          visible: true
+          data-type: "accountAddress"
+          reference: {
+            entity: "accounts"
+            key: "account_id"
+          }
+        }
+        slots: {
+          visible: true
+        }
+        nonce: {
+          visible: true
+        }
+        pkh: {
+          visible: true
+          data-type: "accountAddress"
+          reference: {
+            entity: "accounts"
+            key: "account_id"
+          }
+        }
+        secret: {
+          visible: true
+        }
+        source: {
+          visible: true
+          data-type: "accountAddress"
+          reference {
+            entity: "accounts"
+            key: "account_id"
+          }
+          cache-config {
+            cached: true,
+            min-match-length: 4,
+            max-result-size: 100
+          }
+          value-map: {
+            "tz1ck2Dg17CaAT592JQhCDrsMzbvfEzr4urZ": "Taco Klepto"
+            "tz1aPzpnmcXpp4ukou11pDgEuNHAsMT2hUUv": "Taco Hoarder"
+            "tz1VwmmesDxud2BJEyDKUTV5T5VEP8tGBKGD": "Mainnet Faucet"
+            "tz1Z9MxKUBcbA6SKyKu9VLif8PeiQ5fkpCeo": "@tezosnoob (Legacy)"
+            "tz2PhQ4Pq5S77YRjXMMpZetXSrSCrfKAvngB": "@tezosnoob"
+            "tz2V2T51d8pg2D7pGSD6LdHpua72v7CSAEpP": "@tezosnftfaucet"
+            "tz1RaGb8tWxUh194btmAiXT9Tkk6pGBMZVL8": "USDtz Mother"
+            "tz1djRgXXWWJiY1rpMECCxr5d9ZBqWewuiU1": "Galleon Support"
+            "tz1cPGs7kKJ4NmAB5XTB1dubK4cfDoFffHq5": "STKR AirDrop"
+            "tz1SiPXX4MYGNJNDsRc7n8hkvUqFzg8xqF9m": "Binance A"
+            "tz1eogbwM5NdoojKEvvSnjYGcJapZgADRK3m": "Binance B"
+            "tz1ch7nvDDAchbAPfTio3yBsdvN1SZJZj1wY": "Binance C"
+            "tz1Q3jvYU9knekDYJfyvj3GjUy6898MNjvb2": "Binance D"
+            "tz1d6qqVYwPLLvzZ8X37ATHr4Hi2TcBXQmSZ": "Binance E"
+            "tz1XTQWJZnDFpYPh13LyZcWSSuxEmWRjNxWn": "Binance F"
+            "tz1c5wM9826YcUNQ8a17z9eUYpKQ3oW3zfmJ": "Kaiko Price Oracle Updater A"
+            "tz1QSbd179w1Xp9WTaCwcBt4xxvBpZEtxbxJ": "Harbinger Coinbase Pro Oracle Updater A"
+            "tz2L9474hvA2EXyNLi4u3YnqrKVf3GzeZ8tb": "Harbinger Coinbase Pro Oracle Updater B"
+            "tz1cYfMsbsGhxPqDovmaQHDByTeqiRTygEpc": "Upbit A"
+            "tz1MRssJTFokjJ4WHAY63wFTufQ8qpxZJtvU": "Upbit B"
+            "tz1bDXD6nNSrebqmAnnKKwnX1QdePSMCj4MX": "Kraken A"
+            "tz1YpWsMwc4gSyjtxEF3JbmN6YrGiDidaSmg": "Kraken B"
+            "tz1NH4A2kRyFQUYhyi9aL8jrrySQUrCgNsX9": "Kraken C"
+            "tz1cgJLxcS8ZTgq5dXPtojJJR7Bp8fKDyxPK": "Kraken D"
+            "tz1e9ZH87proooFwLidjvE8fhusWfeDf3bgk": "Kraken E"
+            "tz1ejivVeR6WxqzphH31EJPm87jyYu6HVXXw": "worldartday2021"
+            "tz1bkMZKrPYUWvVmP4yw4EHv6PTAA76b6pcJ": "Smartlink ICO"
+            "tz1dMYz5pcXYXnfH5gjr652iSDq9zc2SrqRi": "Tezos India Covid Charity"
+            "tz1ecr3NoPwvbJQSQXFJrk1cYGcDsJmmKEG5": "Hicathon"
+            "tz1WC3dUzy19mbkGwz4J3KhuSonE7AQxbZuF": "@KidMograph"
+            "tz1gqaKjfQBhUMCE6LhbkpuittRiWv5Z6w38": "@jjjjjjjjjjohn"
+            "tz1UBZUkXpKGhYsP5KtzDNqLLchwF4uHrGjw": "@hicetnunc2000"
+
+            "tz1gk3TDbU7cJuiBRMhwQXVvgDnjsxuWhcEA": "Airfoil"
+            "tz1MJx9vhaNRSimcuXPK2rW4fLccQnDAnVKJ": "AirGap"
+            "tz3e75hU4EhDU3ukyJueh5v6UvEHzGwkg3yC": "At James"
+            "tz1ei4WtWEMEJekSv8qDnu9PExG6Q8HgRGr3": "Bake Tz"
+            "tz1NortRftucvAkD1J58L32EhSVrQEWJCEnB": "Bake'n'Rolls"
+            "tz1S8MNvuFEUsWgjHvi3AxibRBf388NhT1q2": "Binance Baker"
+            "tz1KtGwriE7VuLwT3LwuvU9Nv4wAxP7XZ57d": "Bitfinex"
+            "tz1SYq214SCBy9naR6cvycQsYcUGpBqQAE8d": "Coinone Baker"
+            "tz1eEnQhbwf6trb8Q8mPb2RaPkNk2rN7BKi8": "Chorus One"
+            "tz1MXFrtZoaXckE41bjUCSjAjAap3AFDSr3N": "Everstake (Legacy)"
+            "tz1TzaNn7wSQSP5gYPXCnNzBCpyMiidCq1PX": "Flippin' tacos"
+            "tz3RDC3Jdn4j15J7bBHZd29EUee9gVB1CxD9": "Foundation Baker 1"
+            "tz3bvNMQ95vfAYtG8193ymshqjSvmxiCUuR5": "Foundation Baker 2"
+            "tz3RB4aoyjov4KEVRbuhvQ1CKJgBJMWhaeB8": "Foundation Baker 3"
+            "tz3bTdwZinP8U1JmSweNzVKhmwafqWmFWRfk": "Foundation Baker 4"
+            "tz3NExpXn9aPNZPorRE4SdjJ2RGrfbJgMAaV": "Foundation Baker 5"
+            "tz3UoffC7FG7zfpmvmjUmUeAaHvzdcUvAj6r": "Foundation Baker 6"
+            "tz3WMqdzXqRWXwyvj5Hp2H7QEepaUuS7vd9K": "Foundation Baker 7"
+            "tz3VEZ4k6a4Wx42iyev6i2aVAptTRLEAivNN": "Foundation Baker 8"
+            "tz1NpWrAyDL9k2Lmnyxcgr9xuJakbBxdq7FB": "Gate.io"
+            "tz1WCd2jm4uSt4vntk4vSuUWoZQGhLcDuR9q": "Happy Tezos"
+            "tz1gfArv665EUkSg2ojMBzcbfwuPxAvqPvjo": "Kraken"
+            "tz1X1fpAZtwQk94QXUgZwfgsvkQgyc2KHp9d": "ownBLOCK (Legacy)"
+            "tz1hTFcQk2KJRPzZyHkCwbj7E1zY1xBkiHsk": "ownBLOCK"
+            "tz1dkP8pW6UzamUysFx3WqHZGQMNCZsEaeH6": "ownBLOCK Payouts"
+            "tz1P2Po7YM526ughEsRbY4oR9zaUPDZjxFrb": "P2P Validator"
+            "tz1KtvGSYU5hdKD288a1koTBURWYuADJGrLE": "\u00D8 Crypto Pool (Legacy)"
+            "tz1Yju7jmmsaUiG9qQLoYv35v5pHgnWoLWbt": "Polychain Labs 1"
+            "tz2TSvNTh2epDMhZHrw73nV9piBX7kLZ9K9m": "Polychain Labs 2"
+            "tz1Y42aKCk53vMbaJNpf1hBg1rznGdBxHJ5C": "Tezos Berlin"
+            "tz1Vyuu4EJ5Nym4JcrfRLnp3hpaq1DSEp1Ke": "POS Bakerz"
+            "tz1b7YSEeNRqgmjuX4d4aiai2sQTF4A7WBZf": "Tezos Japan (Legacy)"
+            "tz1ijdEfmUoQXJfSiKCLRioeCfSrKP3sVsff": "Tezos Japan (Legacy B)"
+            "tz1aDiEJf9ztRrAJEXZfcG3CKimoKsGhwVAi": "Tezos Japan"
+            "tz1PPUo28B8BroqmVCMMNDudG4ShA2bzicrU": "Tezos Korea"
+            "tz1b3SaPHFSw51r92ARcV5mGyYbSSsdFd5Gz": "Tezos MX"
+            "tz1Kf25fX1VdmYGSEzwFy1wNmkbSEZ2V83sY": "Tezos Seoul"
+            "tz1RAzdkp1x5ZDqms4ZUrSdfJuUYGH9JTPK2": "Tezos Spanish"
+            "tz1Lh9jeLSWDHYy8AshvG2dpNQseDaHg7cms": "Tezos Spanish (Legacy)"
+            "tz1hAYfexyzPGG6RhZZMpDvAHifubsbb6kgn": "Tezos Suisse"
+            "tz1VYQpZvjVhv1CdcENuCNWJQXu1TWBJ8KTD": "Tezos Tokyo"
+            "tz1R6Ej25VSerE3MkSoEEeBjKHCDTFbpKuSX": "TezosSEAsia"
+            "tz1Lh9jeLSWDHYy8AshvG2dpNQseDaHg7cms": "TezosSpanish"
+            "tz1PesW5khQNhy4revu2ETvMtWPtuVyH2XkZ": "Tz Dutch"
+            "tz1Pwgj6j55akKCyvTwwr9X4np1RskSXpQY4": "Validators.com"
+            "tz1g8vkmcde6sWKaG2NN9WKzCkDM6Rziq194": "StakeNow"
+            "tz1WnfXMPaNTBmH7DBPwqCWs9cPDJdkGBTZ8": "TezosHODL"
+            "tz2FCNBrERXtaTtNX6iimR1UJ5JSDxvdHM93": "stakefish"
+            "tz3QCNyySViKHmeSr45kzDxzchys7NiXCWoa": "Proofofbake.com"
+            "tz1abmz7jiCV2GH2u81LRrGgAFFgvQgiDiaf": "Tessellated Geometry"
+            "tz1TDSmoZXwVevLTEvKCTHWpomG76oC9S2fJ": "Tezos Capital Legacy"
+            "tz1UdeKoMJivgqRgRUNzroMwRJYmJY8BtaWe": "alphaTezos"
+            "tz1RSWMYKGAykpizFteowByYMueCYv9TMn1L": "Tezos Alliance"
+            "tz1Zhv3RkfU2pHrmaiDyxp7kFZpZrUCu1CiF": "TzBake"
+            "tz1Vd1rXpV8hTHbFXCXN3c3qzCsgcU5BZw1e": "TzNode"
+            "tz1fZ767VDbqx4DeKiFswPSHh513f51mKEUZ": "Tezos Bakery"
+            "tz1TqUDvdck5UrPSgdjJu8RPHafet5vyWQFk": "Tezos Bakery Payouts"
+            "tz1aKxnrzx5PXZJe7unufEswVRCMU9yafmfb": "Tezos Canada"
+            "tz1WGpyzJ1WdZQyKgFN1MY1d7KExGzipFmPJ": "Tezos Canada Payouts"
+            "tz1S5WxdZR5f9NzsPXhr7L9L1vrEb5spZFur": "Baking Benjamins"
+            "tz1V3yg82mcrPJbegqVCPn6bC8w1CSTRp3f8": "Staking Shop"
+            "tz1hxtCEcD7idQJEDiJEq37vBkoRcwF6KC2X": "Staking Shop Payouts"
+            "tz1cYufsxHXJcvANhvS55h3aY32a9BAFB494": "Bakery IL"
+            "tz1iVCqjMRG7MfBoFnVjbLQyeLAeJQfLxXze": "Bakery IL Payouts"
+            "tz1WBfwbT66FC6BTLexc2BoyCCBM9LG7pnVW": "888XTZ"
+            "tz1U638Z3xWRiXDDKx2S125MCCaAeGDdA896": "Tezos France"
+            "tz1Zrqm4TkJwqTxm5TiyVFh6taXG4Wrq7tko": "Bake'n'Rolls Payouts"
+            "tz1aRoaRhSpRYvFdyvgWLL6TGyRoGF51wDjM": "Everstake"
+            "tz1W1en9UpMCH4ZJL8wQCh8JDKCZARyVx2co": "Everstake Payouts"
+            "tz1XXayQohB8XRXN7kMoHbf2NFwNiH3oMRQQ": "Bit Cat"
+            "tz1Wy5Ph1FkD1ypUjpFpsHLXLEXDAeCRkZce": "Bit Cat Payouts"
+            "tz1cZfFQpcYhwDp7y1njZXDsZqCrn2NqmVof": "Tezos Rio"
+            "tz1Y2bfsQAYHrWZpM1AwomYMw2KEtaJ5VMfU": "Tezos Rio Payouts"
+            "tz3bEQoFCZEEfZMskefZ8q8e4eiHH1pssRax": "Ceibo XTZ"
+            "tz1ceiboANJ72iqG1g9Xig8vW74JJijv4mb8": "Ceibo XTZ Payouts"
+            "tz1PFeoTuFen8jAMRHajBySNyCwLmY5RqF9M": "Paradigm Bakery"
+            "tz1fb7c66UwePkkfDXz4ajFaBP9hVNLdS7JJ": "Tezos NU"
+            "tz1VfoA5qPksECBkvr2EUuT6u5VgLCi3vTPV": "Tezos NU Payouts"
+            "tz1fUjvVhJrHLZCbhPNvDRckxApqbkievJHN": "Tezzieland"
+            "tz1WntXgznbivRjyhE7Y5jEzoebAhMPB2iJa": "Tezzieland Payouts"
+            "tz1VceyYUpq1gk5dtp6jXQRtCtY8hm5DKt72": "TeZetetic"
+            "tz1S1Aew75hMrPUymqenKfHo8FspppXKpW7h": "Tezos Mars"
+            "tz1bRaSjKZrSrSeQHBDiCqjKXqtZYZM1t8FW": "Imma Baker"
+            "tz1bLwpPfr3xqy1gWBF4sGvv8bLJyPHR11kx": "Tezos Hot Bakery"
+            "tz1ZcTRk5uxD86EFEn1vvNffWWqJy7q5eVhc": "ATEZA"
+            "tz1UJvHTgpVzcKWhTazGxVcn5wsHru5Gietg": "Tezry"
+            "tz1MQJPGNMijnXnVoBENFz9rUhaPt3S7rWoz": "Tezmania"
+            "tz1eCzNtidHvVgeRzQ38C81FPcYnxMsCEL6Z": "TezLoom"
+            "tz1Q8QkSBS63ZQnH3fBTiAMPes9R666Rn6Sc": "YieldWallet"
+            "tz1LnWa4AiFCjMezTgSNa65QFoo7DQGEWgEU": "Tezeract"
+            "tz1NEKxGEHsFufk87CVZcrqWu8o22qh46GK6": "Money Every 3 Days"
+            "tz1NkFRjmkqqcGkAhqe78fdgemDNKXvL7Bod": "BakeMyStake"
+            "tz1SohptP53wDPZhzTWzDUFAUcWF6DMBpaJV": "Hayek Lab"
+            "tz1d6Fx42mYgVFnHUW8T8A7WBfJ6nD9pVok8": "MyTezosBaking"
+            "tz1fJHFn6sWEd3NnBPngACuw2dggTv6nQZ7g": "Baking Team"
+            "tz1iJ4qgGTzyhaYEzd1RnC6duEkLBd1nzexh": "Tz Envoy"
+            "tz1UsFcWtY6BxchK1L9619oXBzy3C2JCrRut": "Baking Tezos 4U"
+            "tz1QXrzaHrGACVn15UiCg33aLCJ6npWdQb3J": "Moku"
+            "tz1QGtMpkbdSM8Y1eHTru3WY51sXhFikbaAC": "TezosNigeria_001"
+            "tz1Vc9XAD7iphycJoRwE1Nxx5krB9C7XyBu5": "\u00D8 Crypto Pool"
+            "tz1irJKkXS2DBWkU1NnmFQx1c1L7pbGg4yhk": "Coinbase Custody"
+            "tz1VQnqCCqX4K5sP3FNkVSNKTdCAMJDd3E1n": "PosDog"
+            "tz1RCFbB9GpALpsZtu6J58sb74dm8qe6XBzv": "Staked"
+            "tz1KfEsrtDaA1sX7vdM4qmEPWuSytuqCDp5j": "XTZ Master"
+            "tz1isXamBXpTUgbByQ6gXgZQg4GWNW7r6rKE": "Tez Whale"
+            "tz1Ldzz6k1BHdhuKvAtMRX7h5kJSMHESMHLC": "PayTezos"
+            "tz1UvkANVPWppVgMkLnvN7BwYZsCP7vm6NVd": "Neokta Labs"
+            "tz1YhNsiRRU8aHNGg7NK3uuP6UDAyacJernB": "Tez Baguette"
+            "tz3adcvQaKXTCg12zbninqo3q8ptKKtDFTLv": "Tezzigator"
+            "tz1RV1MBbZMR68tacosb7Mwj6LkbPSUS1er1": "Baking Tacos"
+            "tz1W5VkdB5s7ENMESVBtwyt9kyvLqPcUczRT": "Tezgate"
+            "tz1PWCDnz783NNGGQjEFFsHtrcK5yBW4E2rm": "Melange"
+            "tz1V2FYediKBAEaTpXXJBSjuQpjkyCzrTSiE": "Stake House"
+            "tz1Scdr2HsZiQjc7bHMeBbmDRXYVvdhjJbBh": "Figment"
+            "tz1VmiY38m3y95HqQLjMwqnMS7sdMfGomzKi": "Lucid Mining"
+            "tz1WctSwL49BZtdWAQ75NY6vr4xsAx6oKdah": "Tezos Wake n' Bake"
+            "tz1PeZx7FXy7QRuMREGXGxeipb24RsMMzUNe": "Tezos Panda"
+            "tz1bHzftcTKZMTZgLLtnrXydCm6UEqf4ivca": "Tezos Vote"
+            "tz1S8e9GgdZG78XJRB3NqabfWeM37GnhZMWQ": "0xb1 PlusMinus"
+            "tz1LmaFsWRkjr7QMCx5PtV6xTUz3AmEpKQiF": "Blockpower Staking"
+            "tz1RjoHc98dBoqaH2jawF62XNKh7YsHwbkEv": "OKEx Baker"
+            "tz1cX93Q3KsiTADpCC4f12TBvAmS5tw7CW19": "Tz Bakery"
+            "tz1VHFxUuBhwopxC9YC9gm5s2MHBHLyCtvN1": "HyperBlocks"
+            "tz1aiYKXmSRckyJ9EybKmpVry373rfyngJU8": "View Nodes"
+            "tz1STeamwbp68THcny9zk3LsbG3H36DMvbRK": "StakingTeam"
+            "tz1hUSVvSq4YbZcREBqKHf6eXM1yvXuGYUNZ": "Metablock Baker"
+            "tz1Tnjaxk6tbAeC2TmMApPh8UsrEVQvhHvx5": "Crypto Delegate"
+            "tz1LBEKXaxQbd5Gtzbc1ATCwc3pppu81aWGc": "Tez-Baking"
+            "tz1dbfppLAAxXZNtf2SDps7rch3qfUznKSoK": "Coinhouse"
+            "tz1dRKU4FQ9QRRQPdaH4zCR6gmCmXfcvcgtB": "Spice"
+            "tz1Z2jXfEXL7dXhs6bsLmyLFLfmAkXBzA9WE": "Tezos Boutique"
+            "tz1dNVDWPf3Q59SdJqnjdnu277iyvReiRS9M": "Steak and Bake"
+            "tz1Zcxkfa5jKrRbBThG765GP29bUCU3C4ok5": "Tezz City"
+            "tz1Lhf4J9Qxoe3DZ2nfe8FGDnvVj7oKjnMY6": "Tez Baker"
+            "tz1XhnCdVENzgko5x1MMswLHSoQbJ5NPwLZ6": "Anonstake"
+            "tz1WpeqFaBG9Jm73Dmgqamy8eF8NWLz9JCoY": "Staking Facilities"
+            "tz1iZEKy4LaAjnTmn2RuGDf2iqdAQKnRi8kY": "Tezzigator (Legacy)"
+            "tz1MkjfzHNF3kk7PMUDVsaTrF8iRD6fpHftR": "LuxBaker"
+            "tz1hWB6QV5GBQKdEJN8EowHhLJyCMPhH18sA": "Tezos Cameroun"
+
+            "KT1ChNsEFxwyCbJyWGSL3KdjeXE28AY1Kaog": "TCF Baker Registry"
+            "KT1GfAzvH7aUtVPbqRw6WbYMbd77dFPErQUg": "StakerDAO Manager"
+            "KT1EctCuorV2NfVb1XTQgvzJ88MQtWP8cMMv": "StakerDAO Token (Legacy)"
+            "KT1LN4LPSqTMS7Sd2CJw4bbDGRkMv2t68Fy9": "USDtz Token"
+            "KT1PWx2mnDueood7fEmfbBDKx1D9BAnnXitn": "tzBTC"
+            "KT1Jr5t9UvGiqkvvsuUbPJHaYx24NzdUwNW9": "Harbinger Storage: Coinbase Pro"
+            "KT1AdbYiPYb5hDuEuVrfxmFehtnBCXv4Np7r": "Harbinger Normalizer: Coinbase Pro"
+            "KT1Mx5sFU4BZqnAaJRpMzqaPbd2qMCFmcqea": "Harbinger Storage: Binance"
+            "KT1SpD9Xh3PcmBGwbZPhVmHUM8shTwYhQFBa": "Harbinger Normalizer: Binance"
+            "KT1Jud6STRGZs6hSfgZsaeztbkzfwC3JswJP": "Harbinger Storage: Gemini"
+            "KT1JywdJbaVW5HtsYh4XNNuHcVL2vE6sYh7W": "Harbinger Normalizer: Gemini"
+            "KT1G3UMEkhxso5cdx2fvoJRJu5nUjBWKMrET": "Harbinger Storage: OKEx"
+            "KT1J623FNZ6an8NHkWFbtvm5bKXgFzhBc5Zf": "Harbinger Normalizer: OKEx"
+            "KT1DrJV8vhkdLEj76h1H9Q4irZDqAkMPo1Qf": "Compromised Dexter tzBTC Pool"
+            "KT1Puc9St8wdNoGtLiD2WXaHbWU7styaxYhD": "Compromised Dexter USDtz Pool"
+            "KT19kgnqC5VWoxktLRdRUERbyUPku9YioE8W": "Kaiko Price Oracle"
+            "KT19at7rQUvyjxnZ2fBv7D9zc8rkyG7gAoU8": "ETHtz Token"
+            "KT19c8n5mWrqpxMcR3J687yssHxotj88nGhZ": "Compromised Dexter ETHtz Pool"
+            "KT1VYsVfmobT7rsMVivvZ4J8i3bPiqz12NaH": "wXTZ Token"
+            "KT1V4Vp7zhynCNuaBjWMpNU535Xm2sgqkz6M": "wXTZ Core"
+            "KT1FMSwqX2W2p1CCJeJNy2rvYEYEYjRiUza3": "Tezex Swap Contract"
+            "KT1PDrBE59Zmxnb8vXRgRAG1XmvTMTs5EDHU": "Dexter ETHtz Pool"
+            "KT1Tr2eG3eVmPRbymrbU2UppUmKjFPXomGG9": "Dexter USDtz Pool"
+            "KT1BGQR7t4izzKZ7eRodKWTodAsM23P38v7N": "Dexter tzBTC Pool"
+            "KT1D56HQfMmwdopmFLTwNHFJSs6Dsg2didFo": "Dexter wXTZ Pool"
+            "KT1H28iie4mW9LmmJeYLjH6zkC8wwSmfHf5P": "TzButton Round 2"
+            "KT1K9gCRgaLRFKTErYt1wVxA3Frb9FjasjTV": "Kolibri Token"
+            "KT1AbYeDbjjcAnV1QK7EZUUdqku77CdkTuv6": "Dexter kUSD Pool"
+            "KT1Hkg5qeNhfwpKW4fXvq7HGZB9z2EnmCCA9": "hic et nunc Art House"
+            "KT1HbQepzV1nVGg8QVznG7z4RcHseD5kwqBn": "hic et nunc Art House v2"
+            "KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton": "hic et nunc NFT"
+            "KT1AFA2mwNUMNd4SsujE1YYp29vd8BZejyKW": "hic et nunc hDAO"
+            "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU": "tzcolors Auction House"
+            "KT1FyaDqiMQWg7Exo7VUiXAgZbd2kCzo3d4s": "tzcolors NFT"
+            "KT1VG2WtYdSWz5E7chTeAdDPZNy2MpP8pTfL": "Atomex"
+            "KT1VgXHLXRgh6J5iGw4zkk7vUfjLoPhRnt9L": "RAMP DeFi rStake Manager"
+            "KT1MEouXPpCx9eFJYnxfAWpFA7NxhW3rDgUN": "BLND Token"
+            "KT1AEfeckNbdEYwaMKkytBwPJPycz7jdSGea": "Staker Governance Token (STKR)"
+            "KT1JdufSdfg3WyxWJcCRNsBFV9V3x9TQBkJ2": "Kolibri Oven Proxy"
+            "KT1Ty2uAmF5JxWyeGrVpk17MEyzVB8cXs8aJ": "Kolibri Minter"
+            "KT1Ldn1XWQmk7J4pYgGFjjwV57Ew8NYvcNtJ": "Kolibri Oven Registry"
+            "KT1TybhR7XraG75JFYKSrh7KnxukMBT5dor6": "OBJKT-hDAO Curation"
+            "KT1Mgy95DVzqVBNYhsW93cyHuB57Q94UFhrh": "Kolibri Oven Factory"
+            "KT1AxaBxkFLCUi3f8rdDAAxBKHfzY8LfKDRA": "kUSD Liquidation Pool"
+            "KT1EH8yKXkRoxNkULRB1dSuwhkKyi5LJH82o": "Tezos Mandala"
+            "KT1QZt5o2eU2ymEpUW8EFhybaLpd9cWfqfUL": "Kalamint IPFS Registry"
+            "KT1EpGgjQs73QfFJs9z7m1Mxm5MTnpC2tqse": "Kalamint Art House"
+            "KT1A5P4ejnLix13jtadsfV9GCnXLMNnab8UT": "KALAM Token"
+            "KT1HvpCCHvC9c4iNzAa6rx4MqNsmPRJf6CEw": "Alchememist Auction"
+            "KT1BwxoxUJEnGcrWtfz2CiCZ19KN1xiN7dNF": "Project Uanon Rewards Distributor"
+            "KT1AUaGsGAkiYgH5wXvQ2tR8JV5dTkenM8XN": "Project Uanon NFT Distributor"
+            "KT1VJsKdNFYueffX6xcfe6Gg9eJA6RUnFpYr": "Project Uanon Puzzle Oracle"
+            "KT1EpQVwqLGSH7vMCWKJnq6Uxi851sEDbhWL": "Atomex FA1.2"
+            "KT1NmoofGosSaWFKgAbt7AMTqnV1xfqeAhLT": "RAMP DeFi rStake Creator"
+            "KT1UmxSSUQ5716tRa2RLNSAkiSG6TWbzZ7GL": "tezostaco.shop"
+            "KT1JBThDEqyqrEHimhxoUBCSnsKAqFcuHMkP": "NFTz.fun NFT"
+            "KT1MWxucqexguPjhqEyk4XndE1M5tHnhNhH7": "QuipuSwap 1.0 USDtz Pool"
+            "KT1CiSKXR68qYSxnbzjwvfeMCRburaSDonT2": "QuipuSwap 1.0 kUSD Pool"
+            "KT1NABnnQ4pUTJHUwFLiVM2uuEu1RXihAVmB": "QuipuSwap 1.0 wXTZ Pool"
+            "KT1N1wwNPqT5jGhM91GQ2ae5uY8UzFaXHMJS": "QuipuSwap 1.0 tzBTC Pool"
+            "KT1DX1kpCEfEg5nG3pXSSwvtkjTr6ZNYuxP4": "QuipuSwap 1.0 ETHtz Pool"
+            "KT1R5Fp415CJxSxxXToUj6QvxP1LHaYXaxV6": "QuipuSwap 1.0 STKR Pool"
+            "KT1V41fGzkdTJki4d11T1Rp9yPkCmDhB7jph": "QuipuSwap 1.0 hDAO Pool"
+            "KT1T4wNjJtNqZ9XCKSZqR5BXsuGczTxhV9Vu": "QuipuSwap 1.0 USDS Pool"
+            "KT1WxgZ1ZSfMgmsSDDcUn8Xn577HwnQ7e1Lb": "QuipuSwap 1.1 USDtz Pool"
+            "KT1K4EwTpbvYN9agJdjpyJm4ZZdhpUNKB3F6": "QuipuSwap 1.1 kUSD Pool"
+            "KT1W3VGRUjvS869r4ror8kdaxqJAZUbPyjMT": "QuipuSwap 1.1 wXTZ Pool"
+            "KT1WBLrLE2vG8SedBqiSJFm4VVAZZBytJYHc": "QuipuSwap 1.1 tzBTC Pool"
+            "KT1Evsp2yA19Whm24khvFPcwimK6UaAJu8Zo": "QuipuSwap 1.1 ETHtz Pool"
+            "KT1BMEEPX7MWzwwadW3NCSZe9XGmFJ7rs7Dr": "QuipuSwap 1.1 STKR Pool"
+            "KT1Qm3urGqkRsWsovGzNb2R81c3dSfxpteHG": "QuipuSwap 1.1 hDAO Pool"
+            "KT1H4NVBGeHXRh1voDv5PPC1Xb6M7xJFQcW5": "QuipuSwap 1.1 USDS Pool"
+            "KT1QxLqukyfohPV5kPkw97Rs6cw1DDDvYgbB": "QuipuSwap 1.2 hDAO Pool"
+            "KT1KFszq8UFCcWxnXuhZPUyHT9FK3gjmSKm6": "QuipuSwap 1.2 USDS Pool"
+            "KT1PrRTVNgxkRgyqqNQvwTiVhd55dqyxXJ6n": "QuipuSwap sDAO Pool"
+            "KT1WDe2vJCDqz5euKupppQsioPcakUd45Tfo": "QuipuSwap rSAL Pool"
+            "KT1DssMzoSr8fnUUq1WxeSuHfLG4gzS7pgge": "QuipuSwap bDAO Pool"
+            "KT1WYQj3HEt3sxdsV4dMLA8RKzUnYAzXgguS": "QuipuSwap GUTS Pool"
+            "KT1WtFb1mTsFRd1n1nAYMdrE2Ud9XREz5hjK": "QuipuSwap QLkUSD Pool"
+            "KT1BgezWwHBxA9NrczwK9x3zfgFnUkc7JJ4b": "QuipuSwap Hedgehoge Pool"
+            "KT1Lpysr4nzcFegC9ci9kjoqVidwoanEmJWt": "QuipuSwap wLINK Pool"
+            "KT1GsTjbWkTgtsWenM6oWuTuft3Qb46p2x4c": "Quipuswap wHT Pool"
+            "KT1UMAE2PBskeQayP5f2ZbGiVYF7h8bZ2gyp": "Quipuswap wBUSD Pool"
+            "KT1MpRQvn2VRR26VJFPYUGcB8qqxBbXgk5xe": "Quipuswap wLEO Pool"
+            "KT1AN7BBmeSUN5eDDQLEhWmXv1gn4exc5k8R": "Quipuswap wHUSD Pool"
+            "KT1Lvtxpg4MiT2Bs38XGxwh3LGi5MkCENp4v": "Quipuswap wAAVE Pool"
+            "KT1SzCtZYesqXt57qHymr3Hj37zPQT47JN6x": "Quipuswap wFTT Pool"
+            "KT1GSjkSg6MFmEMnTJSk6uyYpWXaEYFahrS4": "Quipuswap wCRO Pool"
+            "KT1DA8NH6UqCiSZhEg5KboxosMqLghwwvmTe": "Quipuswap wCOMP Pool"
+            "KT1PQ8TMzGMfViRq4tCMFKD2QF5zwJnY67Xn": "Quipuswap wDAI Pool"
+            "KT1DksKXvCBJN7Mw6frGj6y6F3CbABWZVpj1": "Quipuswap wWBTC Pool"
+            "KT1FG63hhFtMEEEtmBSX2vuFmP87t9E7Ab4t": "Quipuswap WRAP Pool"
+            "KT1X1LgNkQShpF9nRLYw3Dgdy4qp38MX617z": "Quipuswap PLENTY Pool"
+            "KT1NXdxJkCiPkhwPvaT9CytFowuUoNcwGM1p": "Quipuswap SOIL Pool"
+            "KT1J3wTYb4xk5BsSBkg6ML55bX1xq7desS34": "Quipuswap KALAM Pool"
+            "KT1RRgK6eXvCWCiEGWhRZCSVGzhDzwXEEjS4": "Quipuswap CRUNCHY Pool"
+            "KT1DuYujxrmgepwSDHtADthhKBje9BosUs1w": "Quipuswap wWETH Pool"
+            "KT1Q93ftAUzvfMGPwC78nX8eouL1VzmHPd4d": "Quipuswap FLAME Pool"
+            "KT1U2hs5eNdeCpHouAvQXGMzGFGJowbhjqmo": "Quipuswap wUSDC Pool"
+            "KT1T4pfr6NL8dUiz8ibesjEvH2Ne3k6AuXgn": "Quipuswap wUSDT Pool"
+            "KT1RsfuBee5o7GtYrdB7bzQ1M6oVgyBnxY4S": "Quipuswap wMATIC Pool"
+            "KT1Ti3nJT85vNn81Dy5VyNzgufkAorUoZ96q": "Quipuswap wUNI Pool"
+            "KT1Ca5FGSeFLH3ugstc5p56gJDMPeraBcDqE": "Quipuswap wPAX Pool"
+            "KT1X3zxdTzPB9DgVzA3ad6dgZe9JEamoaeRy": "QuipuSwap QUIPU AMM"
+            "KT1K8A8DLUTVuHaDBCZiG6AJdvKJbtH8dqmN": "QuipuSwap PAUL AMM"
+            "KT1Gdix8LoDoQng7YqdPNhdP5V7JRX8FqWvM": "QuipuSwap SMAK AMM"
+            "KT1FHiJmJUgZMPtv5F8M4ZEa6cb1D9Lf758T": "QuipuSwap crDAO AMM"
+            "KT1EtjRRCBC2exyCRXz8UfV7jz7svnkqi7di": "QuipuSwap uUSD AMM"
+            "KT1PL1YciLdwMbydt21Ax85iZXXyGSrKT2BE": "QuipuSwap YOU AMM"
+            "KT1NEa7CmaLaWgHNi6LkRi5Z1f4oHfdzRdGA": "QuipuSwap kDAO AMM"
+            "KT1JyPE1BWdYoRGBvvKhEPbcVRd3C9NCCwQC": "QuipuSwap GOT AMM"
+            "KT1Wa8yqRBpFCusJWgcQyjhRz7hUQAmFxW7j": "FLAME Token"
+            "KT1KPoyzkj82Sbnafm6pfesZKEhyCpXwQfMc": "fDAO"
+            "KT1Ph8ptSU4rf7PPg2YBMR6LTpr6rc4MMyrq": "Catz Token"
+            "KT1K7whn5yHucGXMN7ymfKiX5r534QeaJM29": "QuipuSwap 1.0 FA1.2 AMM Factory"
+            "KT1MMLb2FVrrE9Do74J3FH1RNNc4QhDuVCNX": "QuipuSwap 1.0 FA2 AMM Factory"
+            "KT1Lw8hCoaBrHeTeMXbqHPG4sS4K1xn7yKcD": "QuipuSwap 1.1 FA1.2 AMM Factory"
+            "KT1SwH9P1Tx8a58Mm6qBExQFTcy2rwZyZiXS": "Quipuswap 1.1 FA2 AMM Factory"
+            "KT1PvEyN1xCFCgorN92QCfYjw3axS6jawCiJ": "Quipuswap 1.2 FA2 AMM Factory"
+            "KT1REEb5VxWRjcHm5GzDMwErMmNFftsE5Gpf": "Stably USD"
+            "KT1J5dqegz1qYaYc7X3KjynYL9St1wcZ8ZyV": "Maelstrom Mixer"
+            "KT19ovJhcsUn4YU8Q5L3BGovKSixfbWcecEA": "Salsa"
+            "KT1DLif2x9BtK6pUq9ZfFVVyW5wN2kau9rkW": "WRAP Quorum"
+            "KT1GUNKmkrgtMQjJp3XxcmCj6HZBhkUmMbge": "Bazaar DAO"
+            "KT1LRboPna9yQY9BrjtQYDS1DVxhKESK4VVd": "WRAP Token"
+            "KT1G1cCRNBgQ48mVDjopHjEmTN5Sbtar8nn9": "Hedgehoge Token"
+            "KT1BHCumksALJQJ8q8to2EPigPW6qpyTr7Ng": "Crunchy.network Token"
+            "KT1XPFjZqCULSnqfKaaYy8hJjeY63UNSGwXg": "crDAO"
+            "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS": "Tezos Domains Registry"
+            "KT1CaSP4dn8wasbMsfdtGiCPgYFW7bvnPRRT": "Tezos Domains Auction"
+            "KT1P8n2qzJjwMPbHJfi4o8xu6Pe3gaU3u2A3": "Tezos Domains Committer",
+            "KT191reDVKrLxU9rjTSxg53wRqj6zh8pnHgr": "Tezos Domains Sales",
+            "KT1TnTr6b2YxSx2xUQ8Vz3MoWy771ta66yGx": "Tezos Domains Claim Reverse Record",
+            "KT1J9VpjiH5cmcsskNb8gEXpBtjD4zrAx4Vo": "Tezos Domains Update Reverse Record",
+            "KT1CozhoKRtWSoEvyk7mXrPNFxawMcmXvZtM": "Hicathon Token"
+            "KT1Nbc9cmx19qFrYYFpkiDoojVYL8UZJYVcj": "GUTS Gaming Token"
+            "KT1TtaMcoSx5cZrvaVBWsFoeZ1L15cxo5AEy": "SOIL Token"
+            "KT1GRSvLoikDsXujKgZPsGLX8k8VvR2Tq95b": "Plenty Token"
+            "KT1UDe1YP963CQSb5xN7cQ1X8NJ2pUyjGw5T": "Plenty 1.0 Token Pool"
+            "KT1J7v85udA8GnaBupacgY9mMvrb8zQdYb3E": "Plenty 1.0 ETHtz Pool"
+            "KT1Vs8gqh7YskPnUQMfmjogZh3A5ZLpqQGcg": "Plenty 1.0 hDAO Pool"
+            "KT1JCkdS3x5hTWdrTQdzK6vEkeAdQzsm2wzf": "Plenty 1.0 wLINK Pool"
+            "KT1TNzH1KiVsWh9kpFrWACrDNnfK4ihvGAZs": "Plenty 1.0 wMATIC Pool"
+            "KT1K5cgrw1A8WTiizZ5b6TxNdFnBq9AtyQ7X": "Plenty 1.0 USDtz Pool"
+            "KT1BfQLAsQNX8BjSBzgjTLx3GTd3qhwLoWNz": "Plenty 1.0 QuipuSwap Liquidity Farm"
+            "KT1JQAZqShNMakSNXc2cgTzdAWZFemGcU6n1": "Plenty 1.1 QuipuSwap Liquidity Farm"
+            "KT1QqjR4Fj9YegB37PQEqXUPHmFbhz6VJtwE": "Plenty 1.1 Token Pool"
+            "KT19asUVzBNidHgTHp8MP31YSphooMb3piWR": "Plenty 1.1 ETHtz Pool"
+            "KT1Ga15wxGR5oWK1vBG2GXbjYM6WqPgpfRSP": "Plenty 1.1 hDAO Pool"
+            "KT1MBqc3GHpApBXaBZyvY63LF6eoFyTWtySn": "Plenty 1.1 USDtz Pool"
+            "KT1KyxPitU1xNbTriondmAFtPEcFhjSLV1hz": "Plenty 1.1 wLINK Pool"
+            "KT1XherecVvrE6X4PV5RTwdEKNzA294ZE9T9": "Plenty 1.1 wMATIC Pool"
+            "KT1KJhxkCpZNwAFQURDoJ79hGqQgSC9UaWpG": "Plenty wBUSD LP Farm"
+            "KT1VCrmywPNf8ZHH95HKHvYA4bBQJPa8g2sr": "Plenty USDtz LP Farm"
+            "KT1M82a7arHVwcwaswnNUUuCnQ45xjjGKNd1": "Plenty wWBTC LP Farm"
+            "KT1La1qZiJtDRcd9ek8w5KYD47i9MQqAQHmP": "Plenty wWBTC LP Token"
+            "KT1UqnQ6b1EwQgYiKss4mDL7aktAHnkdctTQ": "Plenty wLINK LP Farm"
+            "KT1UP9XHQigWMqNXYp9YXaCS1hV9jJkCF4h4": "Plenty wMATIC LP Farm"
+            "KT1PuPNtDFLR6U7e7vDuxunDoKasVT6kMSkz": "Plenty wUSDC AMM"
+            "KT1Kp3KVT4nHFmSuL8bvETkgQzseUYP3LDBy": "Plenty wUSDC LP Token"
+            "KT1D36ZG99YuhoCRZXLL86tQYAbv36bCq9XM": "Plenty USDtz AMM"
+            "KT18qSo4Ch2Mfq4jP3eME7SWHB8B8EDTtVBu": "Plenty USDtz LP Token"
+            "KT1XXAavg3tTj12W1ADvd3EEnm1pu6XTmiEF": "Plenty wBUSD AMM"
+            "KT1UC3vcVZ4K9b39uQxaMNA2N1RuJXKLCnoA": "PLENTY wBUSD LP Token"
+            "KT19Dskaofi6ZTkrw3Tq4pK7fUqHqCz4pTZ3": "Plenty wWBTC AMM"
+            "KT1XVrXmWY9AdVri6KpxKo4CWxizKajmgzMt": "Plenty wLINK Swap"
+            "KT1VeNQa4mucRj36qAJ9rTzm4DTJKfemVaZT": "Plenty wMATIC AMM"
+            "KT18fp5rcTW7mbWDmzFwjLDUhs5MeJmagDSZ": "Wrap Token Family"
+            "KT1KENVgwsrAnXZHkm5MptHWhMYiXeG5hwa3": "Wrap wLink Farm"
+            "KT1LXQT3b39wLSiFQ1rHatzALzeKsRGmd8gr": "Wrap wAAVE Farm"
+            "KT1Stv6ATejBZ2uD9eMm5HyQ3nrNrC32zpRL": "Wrap wBUSD Farm"
+            "KT1FQBbU7uNkHSq4oLyiTyBFTZ7KfTWGLpcv": "Wrap wCEL Farm"
+            "KT1NSKpB8ppqABLAEDozUmcLv3QUceN5uHQi": "Wrap wCOMP Farm"
+            "KT1HLJ9E4nd8a6DnKdrZNXiEHihk5nyJJDoR": "Wrap wCRO Farm"
+            "KT1UfeNuqT3F6ntYwucDGPHwHdYa1pQbWfST": "Wrap wDAI Farm"
+            "KT1KY55T9jVZwFaCpRcj62LQNwoVYgtRHG6F": "Wrap wFTT Farm"
+            "KT1U9pATbqyDL3ZXzTQnPN2LnaGN78UnpzUw": "Wrap wHT Farm"
+            "KT1BKu6MnA86QF7JDUPj8anAEPDJNDsUYs3v": "Wrap wHUSD Farm"
+            "KT1N7RC3hLLsKgmKhjnYBiVxY2jfYcohZzwR": "Wrap wLEO Farm"
+            "KT1GCNfU4RQ85VgQF3fsj69Lgw8Ucz7RGoph": "Wrap wMATIC Farm"
+            "KT19ohHrCtSv5u4RzU3SySZJPKGhcovkf9sS": "Wrap wMKR Farm"
+            "KT1K5oY3YC16AgcxPYBDty96xyzVPa89X3yh": "Wrap wOKB Farm"
+            "KT1UxnT4id9zKz1tgK1UxwpigFi5ny7vTCu9": "Wrap wPAX Farm"
+            "KT1Ls37uwiU2vD7sSBRmUV7ccdNuvgRTxtCQ": "Wrap wSUSHI Farm"
+            "KT1UeEeeSfSd7uDWpbxBTBkBBpVeDrcqcUr7": "Wrap wUNI Farm"
+            "KT1HVrGpv4GUoSR6qCmkxmHzAFtwfKxzfcop": "Wrap wUSDC Farm"
+            "KT1DQg57yTJ7QKxzk6AkPtDGvZYTM5pX4GYE": "Wrap wUSDT Farm"
+            "KT1SZVLvLDQvqx6qMbF8oXZe2tfP7bJMASy2": "Wrap wWBTC Farm"
+            "KT1J82G1XVAA4oqjC44qskihdWerrneNVHnn": "Wrap wWETH Farm"
+            "KT1AnsHEdYKEdM62QCNpZGc5PfpXhftcdu22": "Wrap Token Farm"
+            "KT1QY4siBbWg9qpj52fEzrWdWfkbFcwwjfoA": "Wrap LP Farm"
+            "KT1T9zQKY259fbCt6tKHFnrMHEePgmsWAJYW": "Wrap wLINK LP Farm"
+            "KT1AxiZu1CtCMg5g5YiPL145cDx9axdwAexX": "Wrap wWBTC LP Farm"
+            "KT1BN1Si6u8ndd46RbbES5cNGojyRK6T8Md8": "Wrap wWETH LP Farm"
+            "KT1NvQJYeMCdEtzF45bs3UNpMmjfY97u2qW2": "Wrap wAAVE LP Farm"
+            "KT19hzFPbMW9cYgUhLNghytkWEymMKsPrdfX": "PixelPotus v1"
+            "KT1WGDVRnff4rmGzJUbdCRAJBmYt12BrPzdD": "PixelPotus v2"
+            "KT1KY2x1XrWykYd2dbBNXfE6tVUU3eYNB4wo": "PixelPotus Market"
+            "KT1My1wDZHDGweCrJnQJi3wcFaS67iksirvj": "hic et nunc SUBJKT"
+            "KT1TwzD6zV3WeJ39ukuqxcfK2fJCnhvrdN1X": "SMAK Token"
+            "KT1VHd7ysjnvxEzwtjBAmYAmasvVCfPpSkiG": "Green Salsa Token"
+            "KT193D4vozYnhGJQVtw7CoxxqphqUEEwK6Vb": "QuipuSwap DAO Token"
+            "KT1KnuE87q1EKjPozJ5sRAjQA24FPsP57CE3": "Crunchy Farms v1"
+            "KT1FvqJwEDWb1Gwc55Jd1jjTHRVWbYKUUpyq": "objkt.com Market"
+            "KT1XjcRq5MLAzMKQ3UHsrue2SeU2NbxUrzmU": "objkt.com English Auction"
+            "KT1DdxmJujm3u2ZNkYwV24qLBJ6iR7sc58B9": "Tezzardz Crowdsale"
+            "KT1LHHLso8zQWQWg1HUukajdxxbkGfNoHjh6": "Tezzardz NFT"
+            "KT19DUSZw7mfeEATrbWVPHRrWNVbNnmfFAE6": "PAUL Token"
+            "KT1Xobej4mc6XgEjDoJoHtTKgbD1ELMvcQuL": "YOU Governance Token"
+            "KT1Lz5S39TMHEA7izhQn8Z1mQoddm6v1jTwH": "Youves Reward Pool"
+            "KT1FFE2LC5JpVakVjHm5mM36QVp2p3ZzH4hH": "Youves Vault Originator"
+            "KT1RkQaK5X84deBAT6sXJ2VLs7zN4pM7Y3si": "Youves uUSD Options"
+            "KT1XRPEPXbZK25r3Htzp2o1x7xdMMmfocKNW": "uUSD Token"
+            "KT1RC22chBZGJtWv82e5pSeyqyBLEyDRqobz": "Ubinetic uUSD Price Oracle"
+            "KT1TxqZ8QtKvLu3V3JH7Gx58n7Co8pgtpQU5": "Granada tzBTC AMM"
+            "KT1BijKznvGCkU4iFEgdfSaEQgnbRViMh97f": "Flame Poker"
+            "KT1GioMCKwRyWoQpdrwxvsPVEsFJkkLyquVZ": "GOT Token"
+            "KT1Cq3pyv6QEXugsAC2iyXr7ecFqN7fJVTnA": "Tezotopia Resources"
+            "KT1PSUKkif8KZzSeWdPewWMkx61QBR8VuXsm": "Tezotopia Market"
+            "KT1HGL8vx7DP4xETVikL4LUYvFxSV19DxdFN": "aka NFT Market"
+            "KT19JYndHaesXpvUfiwgg8BtE41HKkjjGMRC": "Rocket Tokens"
+            "KT1H5KJDxuM9DURSfttepebb6Cn7GbvAAT45": "MAG Token"
+            "KT1FVbyctinHvVJNyMWeueCzXFFX2MCqsYDj": "tzPunks NFT"
+            "KT1KEa8z6vWXDJrVqtMrAeDVzsvxat3kHaCE": "fxhash GENTK"
+            "KT1Xo5B7PNBAeynZPmca4bRh6LQow4og1Zb9": "fxhash Market"
+            "KT1LjmAdYQCLBjwv4S2oFkEzyHVkomAf5MrW": "Versum Items"
+            "tz1dtzgLYUHMhP6sWeFtFsHkHqyPezBBPLsZ": "fxhash Treasury"
+            "KT1XCoGnfupWk7Sp8536EfrxcP73LmT68Nyr": "fxhash Minter"
+            "KT1GyRAJNdizF1nojQz62uGYkx8WFRUJm9X5": "Versum Market"
+            "tz1TWrPXuG3T3rR9NR5EqsBegJMwiMcobjkt": "objkt Treasury"
+            "KT1ErKVqEhG9jxXgUG2KGLW3bNM7zXHX8SDF": "Unobtanium Token"
+            "KT1GA6KaLWpURnjvmnxB4wToErzM2EXHqrMo": "Gap Threads Asset Manager"
+            "KT1JWnPVJfRrQCqA2ntLZf6zgVphJ1NJCaYi": "Gap Threads Minter"
+            "KT1ViVwoVfGSCsDaxjwoovejm1aYSGz7s2TZ": "Teztopia NFT Registry"
+            "KT1Aq4wWmVanpQhq4TTfjZXB5AjFpx15iQMM": "objkt.com minter"
+            "KT1Mqx5meQbhufngJnUAGEGpa4ZRxhPSiCgB": "Tezos Domains TLDRegistrar"
+            "KT1PnUZCp3u2KzWr93pn4DD7HAJnm3rWVrgn": "WTZ Token"
+            "KT1PwoZxyv4XkPEGnTqWYvjA1UYiPTgAGyqL": "SpicySwap Router"
+            "KT18pVpRXKPY2c4U2yFEGSH3ZnhB2kL8kwXS": "Rarible NFT"
+            "KT1KRvNVubq64ttPbQarxec5XdS6ZQU4DVD2": "Materia Token"
+            "KT1NUrzs7tiT4VbNPqeTxgAFa4SXeV1f3xe9": "Versum Identity"
+            "KT1SjXiUX63QvdNMcM2m492f7kuf8JxXRLp4": "Ctez Token"
+            "KT198mqFKkiWerXLmMCw69YB1i6yzYtmGVrC": "Rarible Exchange v2"
+            "tz1MtU1ZH9cLSRjyrZXstEGxJcbRfvX4E9Ga": "Smartlink Treasury"
+            "KT1Xphnv7A1sUgRwZsecmAGFWm7WNxJz76ax": "Tez Dozen NFT"
+            "KT1D2fZiUNo6RPj3zKofH8DqDDgoV7KoyEbb": "Rarible Fill Storage"
+            "KT1M81KrJr6TxYLkZkVqcpSTNKGoya8XytWT": "ECoin Network"
+            "KT1JherLR5WrarWLPxg1e2frRhULkrsscf7i": "Tezotopia Ticket Lottery"
+            "KT1D9PA7tvuCe9XnDskd2F67XwdrT4ueqjGe": "QuipuSwap ECN AMM"
+            "KT1AFq5XorPduoYyWxs5gEyrFK6fVjJVbtCj": "akaSwap NFT"
+            "KT1HZVd9Cjc2CMe3sQvXgbxhpJkdena21pih": "Randomly Common Skeles NFT"
+            "tz1U7xSdkqfv2Q4WHp9x6e1kv8FoE31kgimv": "Gap Threads Treasury"
+            "KT1TR4qabnDU6aAUym6nauSGaRwJpoKU3efP": "SMAK Staking"
+          }
+        }
+        fee: {
+          visible: true
+          scale: 6,
+          data-type: "currency"
+          currency-symbol-code: 42793
+        }
+        counter: {
+          visible: true
+        }
+        gas_limit: {
+          visible: true
+          display-name: "Gas Limit"
+        }
+        storage_limit: {
+          visible: true
+          display-name: "Storage Limit"
+        }
+        public_key: {
+          data-type: "hash"
+          visible: true
+        }
+        amount: {
+          visible: true
+          scale: 6,
+          data-type: "currency"
+          currency-symbol-code: 42793
+        }
+        destination: {
+          visible: true
+          data-type: "accountAddress"
+          reference: {
+            entity: "accounts"
+            key: "account_id"
+          }
+          cache-config {
+            cached: true,
+            min-match-length: 4,
+            max-result-size: 100
+          }
+          value-map: {
+            "tz1ck2Dg17CaAT592JQhCDrsMzbvfEzr4urZ": "Taco Klepto"
+            "tz1aPzpnmcXpp4ukou11pDgEuNHAsMT2hUUv": "Taco Hoarder"
+            "tz1VwmmesDxud2BJEyDKUTV5T5VEP8tGBKGD": "Mainnet Faucet"
+            "tz1Z9MxKUBcbA6SKyKu9VLif8PeiQ5fkpCeo": "@tezosnoob"
+            "tz1RaGb8tWxUh194btmAiXT9Tkk6pGBMZVL8": "USDtz Mother"
+            "tz1djRgXXWWJiY1rpMECCxr5d9ZBqWewuiU1": "Galleon Support"
+            "tz1cPGs7kKJ4NmAB5XTB1dubK4cfDoFffHq5": "STKR AirDrop"
+            "tz1SiPXX4MYGNJNDsRc7n8hkvUqFzg8xqF9m": "Binance A"
+            "tz1eogbwM5NdoojKEvvSnjYGcJapZgADRK3m": "Binance B"
+            "tz1ch7nvDDAchbAPfTio3yBsdvN1SZJZj1wY": "Binance C"
+            "tz1Q3jvYU9knekDYJfyvj3GjUy6898MNjvb2": "Binance D"
+            "tz1d6qqVYwPLLvzZ8X37ATHr4Hi2TcBXQmSZ": "Binance E"
+            "tz1XTQWJZnDFpYPh13LyZcWSSuxEmWRjNxWn": "Binance F"
+            "tz1c5wM9826YcUNQ8a17z9eUYpKQ3oW3zfmJ": "Kaiko Price Oracle Updater A"
+            "tz1QSbd179w1Xp9WTaCwcBt4xxvBpZEtxbxJ": "Harbinger Coinbase Pro Oracle Updater A"
+            "tz2L9474hvA2EXyNLi4u3YnqrKVf3GzeZ8tb": "Harbinger Coinbase Pro Oracle Updater B"
+            "tz1cYfMsbsGhxPqDovmaQHDByTeqiRTygEpc": "Upbit A"
+            "tz1MRssJTFokjJ4WHAY63wFTufQ8qpxZJtvU": "Upbit B"
+            "tz1bDXD6nNSrebqmAnnKKwnX1QdePSMCj4MX": "Kraken A"
+            "tz1YpWsMwc4gSyjtxEF3JbmN6YrGiDidaSmg": "Kraken B"
+            "tz1NH4A2kRyFQUYhyi9aL8jrrySQUrCgNsX9": "Kraken C"
+            "tz1cgJLxcS8ZTgq5dXPtojJJR7Bp8fKDyxPK": "Kraken D"
+            "tz1e9ZH87proooFwLidjvE8fhusWfeDf3bgk": "Kraken E"
+            "tz1ejivVeR6WxqzphH31EJPm87jyYu6HVXXw": "worldartday2021"
+            "tz1bkMZKrPYUWvVmP4yw4EHv6PTAA76b6pcJ": "Smartlink ICO"
+            "tz1dMYz5pcXYXnfH5gjr652iSDq9zc2SrqRi": "Tezos India Covid Charity"
+            "tz1ecr3NoPwvbJQSQXFJrk1cYGcDsJmmKEG5": "Hicathon"
+            "tz1WC3dUzy19mbkGwz4J3KhuSonE7AQxbZuF": "@KidMograph"
+            "tz1gqaKjfQBhUMCE6LhbkpuittRiWv5Z6w38": "@jjjjjjjjjjohn"
+            "tz1UBZUkXpKGhYsP5KtzDNqLLchwF4uHrGjw": "@hicetnunc2000"
+
+            "KT1ChNsEFxwyCbJyWGSL3KdjeXE28AY1Kaog": "TCF Baker Registry"
+            "KT1GfAzvH7aUtVPbqRw6WbYMbd77dFPErQUg": "StakerDAO Manager"
+            "KT1EctCuorV2NfVb1XTQgvzJ88MQtWP8cMMv": "StakerDAO Token (Legacy)"
+            "KT1LN4LPSqTMS7Sd2CJw4bbDGRkMv2t68Fy9": "USDtz Token"
+            "KT1PWx2mnDueood7fEmfbBDKx1D9BAnnXitn": "tzBTC"
+            "KT1Jr5t9UvGiqkvvsuUbPJHaYx24NzdUwNW9": "Harbinger Storage: Coinbase Pro"
+            "KT1AdbYiPYb5hDuEuVrfxmFehtnBCXv4Np7r": "Harbinger Normalizer: Coinbase Pro"
+            "KT1Mx5sFU4BZqnAaJRpMzqaPbd2qMCFmcqea": "Harbinger Storage: Binance"
+            "KT1SpD9Xh3PcmBGwbZPhVmHUM8shTwYhQFBa": "Harbinger Normalizer: Binance"
+            "KT1Jud6STRGZs6hSfgZsaeztbkzfwC3JswJP": "Harbinger Storage: Gemini"
+            "KT1JywdJbaVW5HtsYh4XNNuHcVL2vE6sYh7W": "Harbinger Normalizer: Gemini"
+            "KT1G3UMEkhxso5cdx2fvoJRJu5nUjBWKMrET": "Harbinger Storage: OKEx"
+            "KT1J623FNZ6an8NHkWFbtvm5bKXgFzhBc5Zf": "Harbinger Normalizer: OKEx"
+            "KT1DrJV8vhkdLEj76h1H9Q4irZDqAkMPo1Qf": "Compromised Dexter tzBTC Pool"
+            "KT1Puc9St8wdNoGtLiD2WXaHbWU7styaxYhD": "Compromised Dexter USDtz Pool"
+            "KT19kgnqC5VWoxktLRdRUERbyUPku9YioE8W": "Kaiko Price Oracle"
+            "KT19at7rQUvyjxnZ2fBv7D9zc8rkyG7gAoU8": "ETHtz Token"
+            "KT19c8n5mWrqpxMcR3J687yssHxotj88nGhZ": "Compromised Dexter ETHtz Pool"
+            "KT1VYsVfmobT7rsMVivvZ4J8i3bPiqz12NaH": "wXTZ Token"
+            "KT1V4Vp7zhynCNuaBjWMpNU535Xm2sgqkz6M": "wXTZ Core"
+            "KT1FMSwqX2W2p1CCJeJNy2rvYEYEYjRiUza3": "Tezex Swap Contract"
+            "KT1PDrBE59Zmxnb8vXRgRAG1XmvTMTs5EDHU": "Dexter ETHtz Pool"
+            "KT1Tr2eG3eVmPRbymrbU2UppUmKjFPXomGG9": "Dexter USDtz Pool"
+            "KT1BGQR7t4izzKZ7eRodKWTodAsM23P38v7N": "Dexter tzBTC Pool"
+            "KT1D56HQfMmwdopmFLTwNHFJSs6Dsg2didFo": "Dexter wXTZ Pool"
+            "KT1H28iie4mW9LmmJeYLjH6zkC8wwSmfHf5P": "TzButton Round 2"
+            "KT1K9gCRgaLRFKTErYt1wVxA3Frb9FjasjTV": "Kolibri Token"
+            "KT1AbYeDbjjcAnV1QK7EZUUdqku77CdkTuv6": "Dexter kUSD Pool"
+            "KT1Hkg5qeNhfwpKW4fXvq7HGZB9z2EnmCCA9": "hic et nunc Art House"
+            "KT1HbQepzV1nVGg8QVznG7z4RcHseD5kwqBn": "hic et nunc Art House v2"
+            "KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton": "hic et nunc NFT"
+            "KT1AFA2mwNUMNd4SsujE1YYp29vd8BZejyKW": "hic et nunc hDAO"
+            "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU": "tzcolors Auction House"
+            "KT1FyaDqiMQWg7Exo7VUiXAgZbd2kCzo3d4s": "tzcolors NFT"
+            "KT1VG2WtYdSWz5E7chTeAdDPZNy2MpP8pTfL": "Atomex"
+            "KT1VgXHLXRgh6J5iGw4zkk7vUfjLoPhRnt9L": "RAMP DeFi rStake Manager"
+            "KT1MEouXPpCx9eFJYnxfAWpFA7NxhW3rDgUN": "BLND Token"
+            "KT1AEfeckNbdEYwaMKkytBwPJPycz7jdSGea": "Staker Governance Token (STKR)"
+            "KT1JdufSdfg3WyxWJcCRNsBFV9V3x9TQBkJ2": "Kolibri Oven Proxy"
+            "KT1Ty2uAmF5JxWyeGrVpk17MEyzVB8cXs8aJ": "Kolibri Minter"
+            "KT1Ldn1XWQmk7J4pYgGFjjwV57Ew8NYvcNtJ": "Kolibri Oven Registry"
+            "KT1TybhR7XraG75JFYKSrh7KnxukMBT5dor6": "OBJKT-hDAO Curation"
+            "KT1Mgy95DVzqVBNYhsW93cyHuB57Q94UFhrh": "Kolibri Oven Factory"
+            "KT1AxaBxkFLCUi3f8rdDAAxBKHfzY8LfKDRA": "kUSD Liquidation Pool"
+            "KT1EH8yKXkRoxNkULRB1dSuwhkKyi5LJH82o": "Tezos Mandala"
+            "KT1QZt5o2eU2ymEpUW8EFhybaLpd9cWfqfUL": "Kalamint IPFS Registry"
+            "KT1EpGgjQs73QfFJs9z7m1Mxm5MTnpC2tqse": "Kalamint Art House"
+            "KT1A5P4ejnLix13jtadsfV9GCnXLMNnab8UT": "KALAM Token"
+            "KT1HvpCCHvC9c4iNzAa6rx4MqNsmPRJf6CEw": "Alchememist Auction"
+            "KT1BwxoxUJEnGcrWtfz2CiCZ19KN1xiN7dNF": "Project Uanon Rewards Distributor"
+            "KT1AUaGsGAkiYgH5wXvQ2tR8JV5dTkenM8XN": "Project Uanon NFT Distributor"
+            "KT1VJsKdNFYueffX6xcfe6Gg9eJA6RUnFpYr": "Project Uanon Puzzle Oracle"
+            "KT1EpQVwqLGSH7vMCWKJnq6Uxi851sEDbhWL": "Atomex FA1.2"
+            "KT1NmoofGosSaWFKgAbt7AMTqnV1xfqeAhLT": "RAMP DeFi rStake Creator"
+            "KT1UmxSSUQ5716tRa2RLNSAkiSG6TWbzZ7GL": "tezostaco.shop"
+            "KT1JBThDEqyqrEHimhxoUBCSnsKAqFcuHMkP": "NFTz.fun NFT"
+            "KT1MWxucqexguPjhqEyk4XndE1M5tHnhNhH7": "QuipuSwap 1.0 USDtz Pool"
+            "KT1CiSKXR68qYSxnbzjwvfeMCRburaSDonT2": "QuipuSwap 1.0 kUSD Pool"
+            "KT1NABnnQ4pUTJHUwFLiVM2uuEu1RXihAVmB": "QuipuSwap 1.0 wXTZ Pool"
+            "KT1N1wwNPqT5jGhM91GQ2ae5uY8UzFaXHMJS": "QuipuSwap 1.0 tzBTC Pool"
+            "KT1DX1kpCEfEg5nG3pXSSwvtkjTr6ZNYuxP4": "QuipuSwap 1.0 ETHtz Pool"
+            "KT1R5Fp415CJxSxxXToUj6QvxP1LHaYXaxV6": "QuipuSwap 1.0 STKR Pool"
+            "KT1V41fGzkdTJki4d11T1Rp9yPkCmDhB7jph": "QuipuSwap 1.0 hDAO Pool"
+            "KT1T4wNjJtNqZ9XCKSZqR5BXsuGczTxhV9Vu": "QuipuSwap 1.0 USDS Pool"
+            "KT1WxgZ1ZSfMgmsSDDcUn8Xn577HwnQ7e1Lb": "QuipuSwap 1.1 USDtz Pool"
+            "KT1K4EwTpbvYN9agJdjpyJm4ZZdhpUNKB3F6": "QuipuSwap 1.1 kUSD Pool"
+            "KT1W3VGRUjvS869r4ror8kdaxqJAZUbPyjMT": "QuipuSwap 1.1 wXTZ Pool"
+            "KT1WBLrLE2vG8SedBqiSJFm4VVAZZBytJYHc": "QuipuSwap 1.1 tzBTC Pool"
+            "KT1Evsp2yA19Whm24khvFPcwimK6UaAJu8Zo": "QuipuSwap 1.1 ETHtz Pool"
+            "KT1BMEEPX7MWzwwadW3NCSZe9XGmFJ7rs7Dr": "QuipuSwap 1.1 STKR Pool"
+            "KT1Qm3urGqkRsWsovGzNb2R81c3dSfxpteHG": "QuipuSwap 1.1 hDAO Pool"
+            "KT1H4NVBGeHXRh1voDv5PPC1Xb6M7xJFQcW5": "QuipuSwap 1.1 USDS Pool"
+            "KT1QxLqukyfohPV5kPkw97Rs6cw1DDDvYgbB": "QuipuSwap 1.2 hDAO Pool"
+            "KT1KFszq8UFCcWxnXuhZPUyHT9FK3gjmSKm6": "QuipuSwap 1.2 USDS Pool"
+            "KT1PrRTVNgxkRgyqqNQvwTiVhd55dqyxXJ6n": "QuipuSwap sDAO Pool"
+            "KT1WDe2vJCDqz5euKupppQsioPcakUd45Tfo": "QuipuSwap rSAL Pool"
+            "KT1DssMzoSr8fnUUq1WxeSuHfLG4gzS7pgge": "QuipuSwap bDAO Pool"
+            "KT1WYQj3HEt3sxdsV4dMLA8RKzUnYAzXgguS": "QuipuSwap GUTS Pool"
+            "KT1WtFb1mTsFRd1n1nAYMdrE2Ud9XREz5hjK": "QuipuSwap QLkUSD Pool"
+            "KT1BgezWwHBxA9NrczwK9x3zfgFnUkc7JJ4b": "QuipuSwap Hedgehoge Pool"
+            "KT1Lpysr4nzcFegC9ci9kjoqVidwoanEmJWt": "QuipuSwap wLINK Pool"
+            "KT1GsTjbWkTgtsWenM6oWuTuft3Qb46p2x4c": "Quipuswap wHT Pool"
+            "KT1UMAE2PBskeQayP5f2ZbGiVYF7h8bZ2gyp": "Quipuswap wBUSD Pool"
+            "KT1MpRQvn2VRR26VJFPYUGcB8qqxBbXgk5xe": "Quipuswap wLEO Pool"
+            "KT1AN7BBmeSUN5eDDQLEhWmXv1gn4exc5k8R": "Quipuswap wHUSD Pool"
+            "KT1Lvtxpg4MiT2Bs38XGxwh3LGi5MkCENp4v": "Quipuswap wAAVE Pool"
+            "KT1SzCtZYesqXt57qHymr3Hj37zPQT47JN6x": "Quipuswap wFTT Pool"
+            "KT1GSjkSg6MFmEMnTJSk6uyYpWXaEYFahrS4": "Quipuswap wCRO Pool"
+            "KT1DA8NH6UqCiSZhEg5KboxosMqLghwwvmTe": "Quipuswap wCOMP Pool"
+            "KT1PQ8TMzGMfViRq4tCMFKD2QF5zwJnY67Xn": "Quipuswap wDAI Pool"
+            "KT1DksKXvCBJN7Mw6frGj6y6F3CbABWZVpj1": "Quipuswap wWBTC Pool"
+            "KT1FG63hhFtMEEEtmBSX2vuFmP87t9E7Ab4t": "Quipuswap WRAP Pool"
+            "KT1X1LgNkQShpF9nRLYw3Dgdy4qp38MX617z": "Quipuswap PLENTY Pool"
+            "KT1NXdxJkCiPkhwPvaT9CytFowuUoNcwGM1p": "Quipuswap SOIL Pool"
+            "KT1J3wTYb4xk5BsSBkg6ML55bX1xq7desS34": "Quipuswap KALAM Pool"
+            "KT1RRgK6eXvCWCiEGWhRZCSVGzhDzwXEEjS4": "Quipuswap CRUNCHY Pool"
+            "KT1DuYujxrmgepwSDHtADthhKBje9BosUs1w": "Quipuswap wWETH Pool"
+            "KT1Q93ftAUzvfMGPwC78nX8eouL1VzmHPd4d": "Quipuswap FLAME Pool"
+            "KT1U2hs5eNdeCpHouAvQXGMzGFGJowbhjqmo": "Quipuswap wUSDC Pool"
+            "KT1T4pfr6NL8dUiz8ibesjEvH2Ne3k6AuXgn": "Quipuswap wUSDT Pool"
+            "KT1RsfuBee5o7GtYrdB7bzQ1M6oVgyBnxY4S": "Quipuswap wMATIC Pool"
+            "KT1Ti3nJT85vNn81Dy5VyNzgufkAorUoZ96q": "Quipuswap wUNI Pool"
+            "KT1Ca5FGSeFLH3ugstc5p56gJDMPeraBcDqE": "Quipuswap wPAX AMM"
+            "KT1X3zxdTzPB9DgVzA3ad6dgZe9JEamoaeRy": "QuipuSwap QUIPU AMM"
+            "KT1K8A8DLUTVuHaDBCZiG6AJdvKJbtH8dqmN": "QuipuSwap PAUL AMM"
+            "KT1Gdix8LoDoQng7YqdPNhdP5V7JRX8FqWvM": "QuipuSwap SMAK AMM"
+            "KT1FHiJmJUgZMPtv5F8M4ZEa6cb1D9Lf758T": "QuipuSwap crDAO AMM"
+            "KT1EtjRRCBC2exyCRXz8UfV7jz7svnkqi7di": "QuipuSwap uUSD AMM"
+            "KT1PL1YciLdwMbydt21Ax85iZXXyGSrKT2BE": "QuipuSwap YOU AMM"
+            "KT1NEa7CmaLaWgHNi6LkRi5Z1f4oHfdzRdGA": "QuipuSwap kDAO AMM"
+            "KT1JyPE1BWdYoRGBvvKhEPbcVRd3C9NCCwQC": "QuipuSwap GOT AMM"
+            "KT1Wa8yqRBpFCusJWgcQyjhRz7hUQAmFxW7j": "FLAME Token"
+            "KT1KPoyzkj82Sbnafm6pfesZKEhyCpXwQfMc": "fDAO"
+            "KT1Ph8ptSU4rf7PPg2YBMR6LTpr6rc4MMyrq": "Catz Token"
+            "KT1K7whn5yHucGXMN7ymfKiX5r534QeaJM29": "QuipuSwap 1.0 FA1.2 Pool Factory"
+            "KT1MMLb2FVrrE9Do74J3FH1RNNc4QhDuVCNX": "QuipuSwap 1.0 FA2 Pool Factory"
+            "KT1Lw8hCoaBrHeTeMXbqHPG4sS4K1xn7yKcD": "QuipuSwap 1.1 FA1.2 Pool Factory"
+            "KT1SwH9P1Tx8a58Mm6qBExQFTcy2rwZyZiXS": "Quipuswap 1.1 FA2 Pool Factory"
+            "KT1PvEyN1xCFCgorN92QCfYjw3axS6jawCiJ": "Quipuswap 1.2 FA2 AMM Factory"
+            "KT1REEb5VxWRjcHm5GzDMwErMmNFftsE5Gpf": "Stably USD"
+            "KT1J5dqegz1qYaYc7X3KjynYL9St1wcZ8ZyV": "Maelstrom Mixer"
+            "KT19ovJhcsUn4YU8Q5L3BGovKSixfbWcecEA": "Salsa"
+            "KT1DLif2x9BtK6pUq9ZfFVVyW5wN2kau9rkW": "WRAP Quorum"
+            "KT1GUNKmkrgtMQjJp3XxcmCj6HZBhkUmMbge": "Bazaar DAO"
+            "KT1WtCq6FuL2kYTK1x7AkmpPjb8wEJZTUwvX": "Wrapped Taco Token"
+            "KT1LRboPna9yQY9BrjtQYDS1DVxhKESK4VVd": "WRAP Token"
+            "KT1G1cCRNBgQ48mVDjopHjEmTN5Sbtar8nn9": "Hedgehoge Token"
+            "KT1BHCumksALJQJ8q8to2EPigPW6qpyTr7Ng": "Crunchy.network Token"
+            "KT1XPFjZqCULSnqfKaaYy8hJjeY63UNSGwXg": "crDAO"
+            "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS": "Tezos Domains Registry"
+            "KT1CaSP4dn8wasbMsfdtGiCPgYFW7bvnPRRT": "Tezos Domains Auction"
+            "KT1P8n2qzJjwMPbHJfi4o8xu6Pe3gaU3u2A3": "Tezos Domains Committer",
+            "KT191reDVKrLxU9rjTSxg53wRqj6zh8pnHgr": "Tezos Domains Sales",
+            "KT1TnTr6b2YxSx2xUQ8Vz3MoWy771ta66yGx": "Tezos Domains Claim Reverse Record",
+            "KT1J9VpjiH5cmcsskNb8gEXpBtjD4zrAx4Vo": "Tezos Domains Update Reverse Record",
+            "KT1CozhoKRtWSoEvyk7mXrPNFxawMcmXvZtM": "Hicathon Token"
+            "KT1Nbc9cmx19qFrYYFpkiDoojVYL8UZJYVcj": "GUTS Gaming Token"
+            "KT1TtaMcoSx5cZrvaVBWsFoeZ1L15cxo5AEy": "SOIL Token"
+            "KT1GRSvLoikDsXujKgZPsGLX8k8VvR2Tq95b": "Plenty Token"
+            "KT1UDe1YP963CQSb5xN7cQ1X8NJ2pUyjGw5T": "Plenty 1.0 Token Pool"
+            "KT1J7v85udA8GnaBupacgY9mMvrb8zQdYb3E": "Plenty 1.0 ETHtz Pool"
+            "KT1Vs8gqh7YskPnUQMfmjogZh3A5ZLpqQGcg": "Plenty 1.0 hDAO Pool"
+            "KT1JCkdS3x5hTWdrTQdzK6vEkeAdQzsm2wzf": "Plenty 1.0 wLINK Pool"
+            "KT1TNzH1KiVsWh9kpFrWACrDNnfK4ihvGAZs": "Plenty 1.0 wMATIC Pool"
+            "KT1K5cgrw1A8WTiizZ5b6TxNdFnBq9AtyQ7X": "Plenty 1.0 USDtz Pool"
+            "KT1BfQLAsQNX8BjSBzgjTLx3GTd3qhwLoWNz": "Plenty 1.0 QuipuSwap Liquidity Farm"
+            "KT1JQAZqShNMakSNXc2cgTzdAWZFemGcU6n1": "Plenty 1.1 QuipuSwap Liquidity Farm"
+            "KT1QqjR4Fj9YegB37PQEqXUPHmFbhz6VJtwE": "Plenty 1.1 Token Pool"
+            "KT19asUVzBNidHgTHp8MP31YSphooMb3piWR": "Plenty 1.1 ETHtz Pool"
+            "KT1Ga15wxGR5oWK1vBG2GXbjYM6WqPgpfRSP": "Plenty 1.1 hDAO Pool"
+            "KT1MBqc3GHpApBXaBZyvY63LF6eoFyTWtySn": "Plenty 1.1 USDtz Pool"
+            "KT1KyxPitU1xNbTriondmAFtPEcFhjSLV1hz": "Plenty 1.1 wLINK Pool"
+            "KT1XherecVvrE6X4PV5RTwdEKNzA294ZE9T9": "Plenty 1.1 wMATIC Pool"
+            "KT1KJhxkCpZNwAFQURDoJ79hGqQgSC9UaWpG": "Plenty wBUSD LP Farm"
+            "KT1VCrmywPNf8ZHH95HKHvYA4bBQJPa8g2sr": "Plenty USDtz LP Farm"
+            "KT1M82a7arHVwcwaswnNUUuCnQ45xjjGKNd1": "Plenty wWBTC LP Farm"
+            "KT1La1qZiJtDRcd9ek8w5KYD47i9MQqAQHmP": "Plenty wWBTC LP Token"
+            "KT1UqnQ6b1EwQgYiKss4mDL7aktAHnkdctTQ": "Plenty wLINK LP Farm"
+            "KT1UP9XHQigWMqNXYp9YXaCS1hV9jJkCF4h4": "Plenty wMATIC LP Farm"
+            "KT1PuPNtDFLR6U7e7vDuxunDoKasVT6kMSkz": "Plenty wUSDC AMM"
+            "KT1Gz1mx1jm7JHqU7GuMVWF6soB9RjsfLN3o": "Plenty wUSDC LP Token"
+            "KT1D36ZG99YuhoCRZXLL86tQYAbv36bCq9XM": "Plenty USDtz AMM"
+            "KT18qSo4Ch2Mfq4jP3eME7SWHB8B8EDTtVBu": "Plenty USDtz LP Token"
+            "KT1XXAavg3tTj12W1ADvd3EEnm1pu6XTmiEF": "Plenty wBUSD AMM"
+            "KT1UC3vcVZ4K9b39uQxaMNA2N1RuJXKLCnoA": "PLENTY wBUSD LP Token"
+            "KT19Dskaofi6ZTkrw3Tq4pK7fUqHqCz4pTZ3": "Plenty wWBTC AMM"
+            "KT1XVrXmWY9AdVri6KpxKo4CWxizKajmgzMt": "Plenty wLINK Swap"
+            "KT1VeNQa4mucRj36qAJ9rTzm4DTJKfemVaZT": "Plenty wMATIC AMM"
+            "KT18fp5rcTW7mbWDmzFwjLDUhs5MeJmagDSZ": "Wrap Token Family"
+            "KT1KENVgwsrAnXZHkm5MptHWhMYiXeG5hwa3": "Wrap wLink Farm"
+            "KT1LXQT3b39wLSiFQ1rHatzALzeKsRGmd8gr": "Wrap wAAVE Farm"
+            "KT1Stv6ATejBZ2uD9eMm5HyQ3nrNrC32zpRL": "Wrap wBUSD Farm"
+            "KT1FQBbU7uNkHSq4oLyiTyBFTZ7KfTWGLpcv": "Wrap wCEL Farm"
+            "KT1NSKpB8ppqABLAEDozUmcLv3QUceN5uHQi": "Wrap wCOMP Farm"
+            "KT1HLJ9E4nd8a6DnKdrZNXiEHihk5nyJJDoR": "Wrap wCRO Farm"
+            "KT1UfeNuqT3F6ntYwucDGPHwHdYa1pQbWfST": "Wrap wDAI Farm"
+            "KT1KY55T9jVZwFaCpRcj62LQNwoVYgtRHG6F": "Wrap wFTT Farm"
+            "KT1U9pATbqyDL3ZXzTQnPN2LnaGN78UnpzUw": "Wrap wHT Farm"
+            "KT1BKu6MnA86QF7JDUPj8anAEPDJNDsUYs3v": "Wrap wHUSD Farm"
+            "KT1N7RC3hLLsKgmKhjnYBiVxY2jfYcohZzwR": "Wrap wLEO Farm"
+            "KT1GCNfU4RQ85VgQF3fsj69Lgw8Ucz7RGoph": "Wrap wMATIC Farm"
+            "KT19ohHrCtSv5u4RzU3SySZJPKGhcovkf9sS": "Wrap wMKR Farm"
+            "KT1K5oY3YC16AgcxPYBDty96xyzVPa89X3yh": "Wrap wOKB Farm"
+            "KT1UxnT4id9zKz1tgK1UxwpigFi5ny7vTCu9": "Wrap wPAX Farm"
+            "KT1Ls37uwiU2vD7sSBRmUV7ccdNuvgRTxtCQ": "Wrap wSUSHI Farm"
+            "KT1UeEeeSfSd7uDWpbxBTBkBBpVeDrcqcUr7": "Wrap wUNI Farm"
+            "KT1HVrGpv4GUoSR6qCmkxmHzAFtwfKxzfcop": "Wrap wUSDC Farm"
+            "KT1DQg57yTJ7QKxzk6AkPtDGvZYTM5pX4GYE": "Wrap wUSDT Farm"
+            "KT1SZVLvLDQvqx6qMbF8oXZe2tfP7bJMASy2": "Wrap wWBTC Farm"
+            "KT1J82G1XVAA4oqjC44qskihdWerrneNVHnn": "Wrap wWETH Farm"
+            "KT1AnsHEdYKEdM62QCNpZGc5PfpXhftcdu22": "Wrap Token Farm"
+            "KT1QY4siBbWg9qpj52fEzrWdWfkbFcwwjfoA": "Wrap LP Farm"
+            "KT1T9zQKY259fbCt6tKHFnrMHEePgmsWAJYW": "Wrap wLINK LP Farm"
+            "KT1AxiZu1CtCMg5g5YiPL145cDx9axdwAexX": "Wrap wWBTC LP Farm"
+            "KT1BN1Si6u8ndd46RbbES5cNGojyRK6T8Md8": "Wrap wWETH LP Farm"
+            "KT1NvQJYeMCdEtzF45bs3UNpMmjfY97u2qW2": "Wrap wAAVE LP Farm"
+            "KT19hzFPbMW9cYgUhLNghytkWEymMKsPrdfX": "PixelPotus v1"
+            "KT1WGDVRnff4rmGzJUbdCRAJBmYt12BrPzdD": "PixelPotus v2"
+            "KT1KY2x1XrWykYd2dbBNXfE6tVUU3eYNB4wo": "PixelPotus Market"
+            "KT1My1wDZHDGweCrJnQJi3wcFaS67iksirvj": "hic et nunc SUBJKT"
+            "KT1TwzD6zV3WeJ39ukuqxcfK2fJCnhvrdN1X": "SMAK Token"
+            "KT1VHd7ysjnvxEzwtjBAmYAmasvVCfPpSkiG": "Green Salsa Token"
+            "KT193D4vozYnhGJQVtw7CoxxqphqUEEwK6Vb": "QuipuSwap DAO Token"
+            "KT1KnuE87q1EKjPozJ5sRAjQA24FPsP57CE3": "Crunchy Farms v1"
+            "KT1FvqJwEDWb1Gwc55Jd1jjTHRVWbYKUUpyq": "objkt.com Market"
+            "KT1XjcRq5MLAzMKQ3UHsrue2SeU2NbxUrzmU": "objkt.com English Auction"
+            "KT1DdxmJujm3u2ZNkYwV24qLBJ6iR7sc58B9": "Tezzardz Crowdsale"
+            "KT1LHHLso8zQWQWg1HUukajdxxbkGfNoHjh6": "Tezzardz NFT"
+            "KT19DUSZw7mfeEATrbWVPHRrWNVbNnmfFAE6": "PAUL Token"
+            "KT1Xobej4mc6XgEjDoJoHtTKgbD1ELMvcQuL": "YOU Governance Token"
+            "KT1Lz5S39TMHEA7izhQn8Z1mQoddm6v1jTwH": "Youves Reward Pool"
+            "KT1FFE2LC5JpVakVjHm5mM36QVp2p3ZzH4hH": "Youves Vault Originator"
+            "KT1RkQaK5X84deBAT6sXJ2VLs7zN4pM7Y3si": "Youves uUSD Options"
+            "KT1XRPEPXbZK25r3Htzp2o1x7xdMMmfocKNW": "uUSD Token"
+            "KT1RC22chBZGJtWv82e5pSeyqyBLEyDRqobz": "Ubinetic uUSD Price Oracle"
+            "KT1TxqZ8QtKvLu3V3JH7Gx58n7Co8pgtpQU5": "Granada tzBTC AMM"
+            "KT1BijKznvGCkU4iFEgdfSaEQgnbRViMh97f": "Flame Poker"
+            "KT1GioMCKwRyWoQpdrwxvsPVEsFJkkLyquVZ": "GOT Token"
+            "KT1Cq3pyv6QEXugsAC2iyXr7ecFqN7fJVTnA": "Tezotopia Resources"
+            "KT1PSUKkif8KZzSeWdPewWMkx61QBR8VuXsm": "Tezotopia Market"
+            "KT1HGL8vx7DP4xETVikL4LUYvFxSV19DxdFN": "aka NFT Market"
+            "KT19JYndHaesXpvUfiwgg8BtE41HKkjjGMRC": "Rocket Tokens"
+            "KT1H5KJDxuM9DURSfttepebb6Cn7GbvAAT45": "MAG Token"
+            "KT1FVbyctinHvVJNyMWeueCzXFFX2MCqsYDj": "tzPunks NFT"
+            "KT1KEa8z6vWXDJrVqtMrAeDVzsvxat3kHaCE": "fxhash GENTK"
+            "KT1Xo5B7PNBAeynZPmca4bRh6LQow4og1Zb9": "fxhash Market"
+            "KT1LjmAdYQCLBjwv4S2oFkEzyHVkomAf5MrW": "Versum Items"
+            "tz1dtzgLYUHMhP6sWeFtFsHkHqyPezBBPLsZ": "fxhash Treasury"
+            "KT1XCoGnfupWk7Sp8536EfrxcP73LmT68Nyr": "fxhash Minter"
+            "KT1GyRAJNdizF1nojQz62uGYkx8WFRUJm9X5": "Versum Market"
+            "tz1TWrPXuG3T3rR9NR5EqsBegJMwiMcobjkt": "objkt Treasury"
+            "KT1ErKVqEhG9jxXgUG2KGLW3bNM7zXHX8SDF": "Unobtanium Token"
+            "KT1GA6KaLWpURnjvmnxB4wToErzM2EXHqrMo": "Gap Threads Asset Manager"
+            "KT1JWnPVJfRrQCqA2ntLZf6zgVphJ1NJCaYi": "Gap Threads Minter"
+            "KT1ViVwoVfGSCsDaxjwoovejm1aYSGz7s2TZ": "Teztopia NFT Registry"
+            "KT1Aq4wWmVanpQhq4TTfjZXB5AjFpx15iQMM": "objkt.com minter"
+            "KT1Mqx5meQbhufngJnUAGEGpa4ZRxhPSiCgB": "Tezos Domains TLDRegistrar"
+            "KT1PnUZCp3u2KzWr93pn4DD7HAJnm3rWVrgn": "WTZ Token"
+            "KT1PwoZxyv4XkPEGnTqWYvjA1UYiPTgAGyqL": "SpicySwap Router"
+            "KT18pVpRXKPY2c4U2yFEGSH3ZnhB2kL8kwXS": "Rarible NFT"
+            "KT1KRvNVubq64ttPbQarxec5XdS6ZQU4DVD2": "Materia Token"
+            "KT1NUrzs7tiT4VbNPqeTxgAFa4SXeV1f3xe9": "Versum Identity"
+            "KT1SjXiUX63QvdNMcM2m492f7kuf8JxXRLp4": "Ctez Token"
+            "KT198mqFKkiWerXLmMCw69YB1i6yzYtmGVrC": "Rarible Exchange v2"
+            "tz1MtU1ZH9cLSRjyrZXstEGxJcbRfvX4E9Ga": "Smartlink Treasury"
+            "KT1Xphnv7A1sUgRwZsecmAGFWm7WNxJz76ax": "Tez Dozen NFT"
+            "KT1D2fZiUNo6RPj3zKofH8DqDDgoV7KoyEbb": "Rarible Fill Storage"
+            "KT1M81KrJr6TxYLkZkVqcpSTNKGoya8XytWT": "ECoin Network"
+            "KT1JherLR5WrarWLPxg1e2frRhULkrsscf7i": "Tezotopia Ticket Lottery"
+            "KT1D9PA7tvuCe9XnDskd2F67XwdrT4ueqjGe": "QuipuSwap ECN AMM"
+            "KT1AFq5XorPduoYyWxs5gEyrFK6fVjJVbtCj": "akaSwap NFT"
+            "KT1HZVd9Cjc2CMe3sQvXgbxhpJkdena21pih": "Randomly Common Skeles NFT"
+            "tz1U7xSdkqfv2Q4WHp9x6e1kv8FoE31kgimv": "Gap Threads Treasury"
+            "KT1TR4qabnDU6aAUym6nauSGaRwJpoKU3efP": "SMAK Staking"
+          }
+        }
+        parameters: {
+          visible: true
+        }
+        parameters_micheline: {
+          visible: true
+        }
+        parameters_entrypoints: {
+          visible: true
+        }
+        manager_pubkey: {
+          visible: true
+        }
+        balance: {
+          visible: true
+          scale: 6,
+          data-type: "currency"
+          currency-symbol-code: 42793
+        }
+        spendable: {
+          visible: true
+        }
+        delegatable: {
+          visible: true
+        }
+        script: {
+          visible: true
+        }
+        storage: {
+          visible: true
+        }
+        status: {
+          visible: true
+          cache-config {
+            cached: true,
+            min-match-length: 1,
+            max-result-size: 100
+          }
+        }
+        consumed_gas: {
+          visible: true
+          display-name: "Consumed Gas"
+        }
+        block_hash: {
+          display-name: "Block Hash"
+          data-type: "hash"
+          visible: true
+          reference: {
+            entity: "blocks"
+            key: "hash"
+          }
+        }
+        block_level: {
+          visible: true
+          display-name: "Block Level"
+          data-type: "int"
+          reference: {
+            entity: "blocks"
+            key: "level"
+          }
+        }
+        timestamp: {
+          visible: true
+          data-format: "YYYY MMM DD, HH:mm"
+        }
+        internal {
+          visible: true
+          cache-config {
+            cached: true
+          }
+        }
+        originated_contracts {
+          visible: true
+          display-name: "Originated Account"
+          data-type: "accountAddress"
+          reference {
+            entity: "accounts"
+            key: "account_id"
+          }
+          cache-config {
+            cached: true,
+            min-match-length: 4,
+            max-result-size: 100
+          }
+        }
+        storage_size {
+          display-name: "Storage Size"
+          visible: true
+        }
+        paid_storage_size_diff {
+          visible: true
+        }
+        ballot: {
+          visible: true
+          display-name: "Vote"
+        }
+        ballot_period: {
+          data-type: "int"
+          visible: true
+        }
+        number_of_slots: {
+          visible: true
+          display-name: "Slots"
+        }
+        branch: {
+          data-type: "hash"
+          visible: true
+        }
+        proposal: {
+          data-type: "hash"
+          visible: true
+          value-map: {
+            "Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A": "Ithaca 2.0"
+            "PsiThaCaT47Zboaw71QWScM8sXeMM7bbQFncK9FLqYc6EKdpjVP": "Ithaca"
+            "PtHangz2aRngywmSRGGvrcTyMbbdpWdpFKuS4uMWxg2RaH9i1qx": "Hangzhou Actual"
+            "PsCUKj6wydGtDNGPRdxasZDs4esZcVD9tf44MMiVy46FkD9q1h9": "Hanghouz-USDtz-LB"
+            "PtHangzHogokSuiMHemCuowEavgYTP8J5qQ9fQS793MHYFpCY3r": "Hangzhou"
+            "PtGRENLBgC4kALRCjYwBAgDNSvK9ZDCst7cRQ1aNP9Ke1cZDwnY": "Grenada LB-removed"
+            "PsmarYW3qFVZUNYwJaYvPEYG96N3awx5SpYs3PxiAWmCzRBAhY8": "Grenada LB-disabled"
+            "PtGRANADsDU8R9daYKAgWnQYAJ64omN1o3KMGVCykShA97vQbvV": "Grenada"
+            "PsFLorenaUUuikDWvMDr6fGBRG8kt3e3D3fHoXK1j1BFRxeSH4i": "Florence no-BA"
+            "PsFLorBArSaXjuy9oP76Qv1v2FRYnUs7TFtteK5GkRBC24JvbdE": "Florence BA"
+            "PtEdo2ZkT9oKpimTah6x2embF25oss54njMuPzkJTEi5RqfdZFA": "Edo Actual"
+            "PtEdoTezd3RHSC31mpxxo1npxFjoWWcFgQtxapi51Z8TLu6v6Uq": "Edo"
+            "PsDELPH1Kxsxt8f9eWbxQeRxkjfbxoqM52jvs5Y5fBxWWh4ifpo": "Delphi"
+            "PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb": "Carthage 2.0"
+            "PtCarthavAMoXqbjBPVgDCRd5LgT7qqKWUPXnYii3xCaHRBMfHH": "Carthage"
+            "PsBabyM1eUXZseaJdmXFApDSBqj8YBfwELoxZHHW77EMcAbbwAS": "Babylon 2.1"
+            "PsBABY5HQTSkA4297zNHfsZNKtxULfL18y95qb3m53QJiXGmrbU": "Babylon 2.0"
+            "PsBABY5nk4JhdEv1N1pZbt6m6ccB9BfNqa23iKZcHBh23jmRS9f": "Babylon"
+            "PtdRxBHvc91c2ea2evV6wkoqnzW7TadTg9aqS9jAn2GbcPGtumD": "Brest A"
+            "Psd1ynUBhMZAeajwcZJAeq5NrxorM6UCU4GJqxZ7Bx2e9vUWB6z": "Athens B"
+            "Pt24m4xiPbLDhVgVfABUjirbmda3yohdN82Sp9FeuAXJ4eV9otd": "Athens A"
+          }
+        }
+        period: {
+          visible: true
+        }
+        errors: {
+          visible: true
+        }
+        utc_year: {
+          visible: true
+        }
+        utc_month: {
+          visible: true
+        }
+        utc_day: {
+          visible: true
+        }
+        utc_time: {
+          visible: true
+        }
+        operation_order: {
+          visible: true
+        }
+      }
+    }
+    bakers {
+      display-name-plural: "Bakers"
+      display-name: "Baker"
+      visible: true
+      attributes {
+        pkh {
+          display-name: "Address"
+          visible: true
+          data-type: "accountAddress"
+          reference: {
+            entity: "accounts"
+            key: "account_id"
+          }
+          cache-config {
+            cached: true,
+            min-match-length: 4,
+            max-result-size: 100
+          }
+          value-map: {
+            "tz1gk3TDbU7cJuiBRMhwQXVvgDnjsxuWhcEA": "Airfoil"
+            "tz1MJx9vhaNRSimcuXPK2rW4fLccQnDAnVKJ": "AirGap"
+            "tz3e75hU4EhDU3ukyJueh5v6UvEHzGwkg3yC": "At James"
+            "tz1ei4WtWEMEJekSv8qDnu9PExG6Q8HgRGr3": "Bake Tz"
+            "tz1NortRftucvAkD1J58L32EhSVrQEWJCEnB": "Bake'n'Rolls"
+            "tz1S8MNvuFEUsWgjHvi3AxibRBf388NhT1q2": "Binance Baker"
+            "tz1KtGwriE7VuLwT3LwuvU9Nv4wAxP7XZ57d": "Bitfinex"
+            "tz1SYq214SCBy9naR6cvycQsYcUGpBqQAE8d": "Coinone Baker"
+            "tz1eEnQhbwf6trb8Q8mPb2RaPkNk2rN7BKi8": "Chorus One"
+            "tz1MXFrtZoaXckE41bjUCSjAjAap3AFDSr3N": "Everstake (Legacy)"
+            "tz1TzaNn7wSQSP5gYPXCnNzBCpyMiidCq1PX": "Flippin' tacos"
+            "tz3RDC3Jdn4j15J7bBHZd29EUee9gVB1CxD9": "Foundation Baker 1"
+            "tz3bvNMQ95vfAYtG8193ymshqjSvmxiCUuR5": "Foundation Baker 2"
+            "tz3RB4aoyjov4KEVRbuhvQ1CKJgBJMWhaeB8": "Foundation Baker 3"
+            "tz3bTdwZinP8U1JmSweNzVKhmwafqWmFWRfk": "Foundation Baker 4"
+            "tz3NExpXn9aPNZPorRE4SdjJ2RGrfbJgMAaV": "Foundation Baker 5"
+            "tz3UoffC7FG7zfpmvmjUmUeAaHvzdcUvAj6r": "Foundation Baker 6"
+            "tz3WMqdzXqRWXwyvj5Hp2H7QEepaUuS7vd9K": "Foundation Baker 7"
+            "tz3VEZ4k6a4Wx42iyev6i2aVAptTRLEAivNN": "Foundation Baker 8"
+            "tz1NpWrAyDL9k2Lmnyxcgr9xuJakbBxdq7FB": "Gate.io"
+            "tz1WCd2jm4uSt4vntk4vSuUWoZQGhLcDuR9q": "Happy Tezos"
+            "tz1gfArv665EUkSg2ojMBzcbfwuPxAvqPvjo": "Kraken"
+            "tz1X1fpAZtwQk94QXUgZwfgsvkQgyc2KHp9d": "ownBLOCK (Legacy)"
+            "tz1hTFcQk2KJRPzZyHkCwbj7E1zY1xBkiHsk": "ownBLOCK"
+            "tz1dkP8pW6UzamUysFx3WqHZGQMNCZsEaeH6": "ownBLOCK Payouts"
+            "tz1P2Po7YM526ughEsRbY4oR9zaUPDZjxFrb": "P2P Validator"
+            "tz1KtvGSYU5hdKD288a1koTBURWYuADJGrLE": "\u00D8 Crypto Pool (Legacy)"
+            "tz1Yju7jmmsaUiG9qQLoYv35v5pHgnWoLWbt": "Polychain Labs 1"
+            "tz2TSvNTh2epDMhZHrw73nV9piBX7kLZ9K9m": "Polychain Labs 2"
+            "tz1Y42aKCk53vMbaJNpf1hBg1rznGdBxHJ5C": "Tezos Berlin"
+            "tz1Vyuu4EJ5Nym4JcrfRLnp3hpaq1DSEp1Ke": "POS Bakerz"
+            "tz1b7YSEeNRqgmjuX4d4aiai2sQTF4A7WBZf": "Tezos Japan (Legacy)"
+            "tz1ijdEfmUoQXJfSiKCLRioeCfSrKP3sVsff": "Tezos Japan (Legacy B)"
+            "tz1aDiEJf9ztRrAJEXZfcG3CKimoKsGhwVAi": "Tezos Japan"
+            "tz1PPUo28B8BroqmVCMMNDudG4ShA2bzicrU": "Tezos Korea"
+            "tz1b3SaPHFSw51r92ARcV5mGyYbSSsdFd5Gz": "Tezos MX"
+            "tz1Kf25fX1VdmYGSEzwFy1wNmkbSEZ2V83sY": "Tezos Seoul"
+            "tz1RAzdkp1x5ZDqms4ZUrSdfJuUYGH9JTPK2": "Tezos Spanish"
+            "tz1Lh9jeLSWDHYy8AshvG2dpNQseDaHg7cms": "Tezos Spanish (Legacy)"
+            "tz1hAYfexyzPGG6RhZZMpDvAHifubsbb6kgn": "Tezos Suisse"
+            "tz1VYQpZvjVhv1CdcENuCNWJQXu1TWBJ8KTD": "Tezos Tokyo"
+            "tz1R6Ej25VSerE3MkSoEEeBjKHCDTFbpKuSX": "TezosSEAsia"
+            "tz1Lh9jeLSWDHYy8AshvG2dpNQseDaHg7cms": "TezosSpanish"
+            "tz1PesW5khQNhy4revu2ETvMtWPtuVyH2XkZ": "Tz Dutch"
+            "tz1Pwgj6j55akKCyvTwwr9X4np1RskSXpQY4": "Validators.com"
+            "tz1g8vkmcde6sWKaG2NN9WKzCkDM6Rziq194": "StakeNow"
+            "tz1WnfXMPaNTBmH7DBPwqCWs9cPDJdkGBTZ8": "TezosHODL"
+            "tz2FCNBrERXtaTtNX6iimR1UJ5JSDxvdHM93": "stakefish"
+            "tz3QCNyySViKHmeSr45kzDxzchys7NiXCWoa": "Proofofbake.com"
+            "tz1abmz7jiCV2GH2u81LRrGgAFFgvQgiDiaf": "Tessellated Geometry"
+            "tz1TDSmoZXwVevLTEvKCTHWpomG76oC9S2fJ": "Tezos Capital Legacy"
+            "tz1UdeKoMJivgqRgRUNzroMwRJYmJY8BtaWe": "alphaTezos"
+            "tz1RSWMYKGAykpizFteowByYMueCYv9TMn1L": "Tezos Alliance"
+            "tz1Zhv3RkfU2pHrmaiDyxp7kFZpZrUCu1CiF": "TzBake"
+            "tz1Vd1rXpV8hTHbFXCXN3c3qzCsgcU5BZw1e": "TzNode"
+            "tz1fZ767VDbqx4DeKiFswPSHh513f51mKEUZ": "Tezos Bakery"
+            "tz1TqUDvdck5UrPSgdjJu8RPHafet5vyWQFk": "Tezos Bakery Payouts"
+            "tz1aKxnrzx5PXZJe7unufEswVRCMU9yafmfb": "Tezos Canada"
+            "tz1WGpyzJ1WdZQyKgFN1MY1d7KExGzipFmPJ": "Tezos Canada Payouts"
+            "tz1S5WxdZR5f9NzsPXhr7L9L1vrEb5spZFur": "Baking Benjamins"
+            "tz1V3yg82mcrPJbegqVCPn6bC8w1CSTRp3f8": "Staking Shop"
+            "tz1hxtCEcD7idQJEDiJEq37vBkoRcwF6KC2X": "Staking Shop Payouts"
+            "tz1cYufsxHXJcvANhvS55h3aY32a9BAFB494": "Bakery IL"
+            "tz1iVCqjMRG7MfBoFnVjbLQyeLAeJQfLxXze": "Bakery IL Payouts"
+            "tz1WBfwbT66FC6BTLexc2BoyCCBM9LG7pnVW": "888XTZ"
+            "tz1U638Z3xWRiXDDKx2S125MCCaAeGDdA896": "Tezos France"
+            "tz1Zrqm4TkJwqTxm5TiyVFh6taXG4Wrq7tko": "Bake'n'Rolls Payouts"
+            "tz1aRoaRhSpRYvFdyvgWLL6TGyRoGF51wDjM": "Everstake"
+            "tz1W1en9UpMCH4ZJL8wQCh8JDKCZARyVx2co": "Everstake Payouts"
+            "tz1XXayQohB8XRXN7kMoHbf2NFwNiH3oMRQQ": "Bit Cat"
+            "tz1Wy5Ph1FkD1ypUjpFpsHLXLEXDAeCRkZce": "Bit Cat Payouts"
+            "tz1cZfFQpcYhwDp7y1njZXDsZqCrn2NqmVof": "Tezos Rio"
+            "tz1Y2bfsQAYHrWZpM1AwomYMw2KEtaJ5VMfU": "Tezos Rio Payouts"
+            "tz3bEQoFCZEEfZMskefZ8q8e4eiHH1pssRax": "Ceibo XTZ"
+            "tz1ceiboANJ72iqG1g9Xig8vW74JJijv4mb8": "Ceibo XTZ Payouts"
+            "tz1PFeoTuFen8jAMRHajBySNyCwLmY5RqF9M": "Paradigm Bakery"
+            "tz1fb7c66UwePkkfDXz4ajFaBP9hVNLdS7JJ": "Tezos NU"
+            "tz1VfoA5qPksECBkvr2EUuT6u5VgLCi3vTPV": "Tezos NU Payouts"
+            "tz1fUjvVhJrHLZCbhPNvDRckxApqbkievJHN": "Tezzieland"
+            "tz1WntXgznbivRjyhE7Y5jEzoebAhMPB2iJa": "Tezzieland Payouts"
+            "tz1VceyYUpq1gk5dtp6jXQRtCtY8hm5DKt72": "TeZetetic"
+            "tz1S1Aew75hMrPUymqenKfHo8FspppXKpW7h": "Tezos Mars"
+            "tz1bRaSjKZrSrSeQHBDiCqjKXqtZYZM1t8FW": "Imma Baker"
+            "tz1bLwpPfr3xqy1gWBF4sGvv8bLJyPHR11kx": "Tezos Hot Bakery"
+            "tz1ZcTRk5uxD86EFEn1vvNffWWqJy7q5eVhc": "ATEZA"
+            "tz1UJvHTgpVzcKWhTazGxVcn5wsHru5Gietg": "Tezry"
+            "tz1MQJPGNMijnXnVoBENFz9rUhaPt3S7rWoz": "Tezmania"
+            "tz1eCzNtidHvVgeRzQ38C81FPcYnxMsCEL6Z": "TezLoom"
+            "tz1Q8QkSBS63ZQnH3fBTiAMPes9R666Rn6Sc": "YieldWallet"
+            "tz1LnWa4AiFCjMezTgSNa65QFoo7DQGEWgEU": "Tezeract"
+            "tz1NEKxGEHsFufk87CVZcrqWu8o22qh46GK6": "Money Every 3 Days"
+            "tz1NkFRjmkqqcGkAhqe78fdgemDNKXvL7Bod": "BakeMyStake"
+            "tz1SohptP53wDPZhzTWzDUFAUcWF6DMBpaJV": "Hayek Lab"
+            "tz1d6Fx42mYgVFnHUW8T8A7WBfJ6nD9pVok8": "MyTezosBaking"
+            "tz1fJHFn6sWEd3NnBPngACuw2dggTv6nQZ7g": "Baking Team"
+            "tz1iJ4qgGTzyhaYEzd1RnC6duEkLBd1nzexh": "Tz Envoy"
+            "tz1UsFcWtY6BxchK1L9619oXBzy3C2JCrRut": "Baking Tezos 4U"
+            "tz1QXrzaHrGACVn15UiCg33aLCJ6npWdQb3J": "Moku"
+            "tz1QGtMpkbdSM8Y1eHTru3WY51sXhFikbaAC": "TezosNigeria_001"
+            "tz1Vc9XAD7iphycJoRwE1Nxx5krB9C7XyBu5": "\u00D8 Crypto Pool"
+            "tz1irJKkXS2DBWkU1NnmFQx1c1L7pbGg4yhk": "Coinbase Custody"
+            "tz1VQnqCCqX4K5sP3FNkVSNKTdCAMJDd3E1n": "PosDog"
+            "tz1RCFbB9GpALpsZtu6J58sb74dm8qe6XBzv": "Staked"
+            "tz1KfEsrtDaA1sX7vdM4qmEPWuSytuqCDp5j": "XTZ Master"
+            "tz1isXamBXpTUgbByQ6gXgZQg4GWNW7r6rKE": "Tez Whale"
+            "tz1Ldzz6k1BHdhuKvAtMRX7h5kJSMHESMHLC": "PayTezos"
+            "tz1UvkANVPWppVgMkLnvN7BwYZsCP7vm6NVd": "Neokta Labs"
+            "tz1YhNsiRRU8aHNGg7NK3uuP6UDAyacJernB": "Tez Baguette"
+            "tz3adcvQaKXTCg12zbninqo3q8ptKKtDFTLv": "Tezzigator"
+            "tz1RV1MBbZMR68tacosb7Mwj6LkbPSUS1er1": "Baking Tacos"
+            "tz1W5VkdB5s7ENMESVBtwyt9kyvLqPcUczRT": "Tezgate"
+            "tz1PWCDnz783NNGGQjEFFsHtrcK5yBW4E2rm": "Melange"
+            "tz1V2FYediKBAEaTpXXJBSjuQpjkyCzrTSiE": "Stake House"
+            "tz1Scdr2HsZiQjc7bHMeBbmDRXYVvdhjJbBh": "Figment"
+            "tz1VmiY38m3y95HqQLjMwqnMS7sdMfGomzKi": "Lucid Mining"
+            "tz1WctSwL49BZtdWAQ75NY6vr4xsAx6oKdah": "Tezos Wake n' Bake"
+            "tz1PeZx7FXy7QRuMREGXGxeipb24RsMMzUNe": "Tezos Panda"
+            "tz1bHzftcTKZMTZgLLtnrXydCm6UEqf4ivca": "Tezos Vote"
+            "tz1S8e9GgdZG78XJRB3NqabfWeM37GnhZMWQ": "0xb1 PlusMinus"
+            "tz1LmaFsWRkjr7QMCx5PtV6xTUz3AmEpKQiF": "Blockpower Staking"
+            "tz1RjoHc98dBoqaH2jawF62XNKh7YsHwbkEv": "OKEx Baker"
+            "tz1cX93Q3KsiTADpCC4f12TBvAmS5tw7CW19": "Tz Bakery"
+            "tz1VHFxUuBhwopxC9YC9gm5s2MHBHLyCtvN1": "HyperBlocks"
+            "tz1aiYKXmSRckyJ9EybKmpVry373rfyngJU8": "View Nodes"
+            "tz1STeamwbp68THcny9zk3LsbG3H36DMvbRK": "StakingTeam"
+            "tz1hUSVvSq4YbZcREBqKHf6eXM1yvXuGYUNZ": "Metablock Baker"
+            "tz1Tnjaxk6tbAeC2TmMApPh8UsrEVQvhHvx5": "Crypto Delegate"
+            "tz1LBEKXaxQbd5Gtzbc1ATCwc3pppu81aWGc": "Tez-Baking"
+            "tz1dbfppLAAxXZNtf2SDps7rch3qfUznKSoK": "Coinhouse"
+            "tz1dRKU4FQ9QRRQPdaH4zCR6gmCmXfcvcgtB": "Spice"
+            "tz1Z2jXfEXL7dXhs6bsLmyLFLfmAkXBzA9WE": "Tezos Boutique"
+            "tz1dNVDWPf3Q59SdJqnjdnu277iyvReiRS9M": "Steak and Bake"
+            "tz1Zcxkfa5jKrRbBThG765GP29bUCU3C4ok5": "Tezz City"
+            "tz1Lhf4J9Qxoe3DZ2nfe8FGDnvVj7oKjnMY6": "Tez Baker"
+            "tz1XhnCdVENzgko5x1MMswLHSoQbJ5NPwLZ6": "Anonstake"
+            "tz1WpeqFaBG9Jm73Dmgqamy8eF8NWLz9JCoY": "Staking Facilities"
+            "tz1iZEKy4LaAjnTmn2RuGDf2iqdAQKnRi8kY": "Tezzigator (Legacy)"
+            "tz1MkjfzHNF3kk7PMUDVsaTrF8iRD6fpHftR": "LuxBaker"
+            "tz1hWB6QV5GBQKdEJN8EowHhLJyCMPhH18sA": "Tezos Cameroun"
+          }
+        }
+        block_id {
+          display-name: "Block Hash"
+          data-type: "hash"
+          visible: true
+          reference: {
+            entity: "blocks"
+            key: "hash"
+          }
+        }
+        balance {
+          visible: true
+          scale: 6,
+          data-type: "currency"
+          currency-symbol-code: 42793
+        }
+        frozen_balance {
+          display-name: "Frozen Balance"
+          visible: true
+          scale: 6,
+          data-type: "currency"
+          currency-symbol-code: 42793
+        }
+        staking_balance {
+          display-name: "Staking Balance"
+          visible: true
+          scale: 6,
+          data-type: "currency"
+          currency-symbol-code: 42793
+        }
+        delegated_balance {
+          display-name: "Delegated Balance"
+          visible: true
+          scale: 6,
+          data-type: "currency"
+          currency-symbol-code: 42793
+        }
+        rolls {
+          visible: true
+        }
+        deactivated {
+          visible: true
+        }
+        grace_period {
+          visible: true
+        }
+        block_level {
+          visible: true
+          display-name: "Block Level"
+          data-type: "int"
+          reference: {
+            entity: "blocks"
+            key: "level"
+          }
+        }
+        cycle {
+          visible: true
+        }
+        period {
+          visible: true
+        }
+      }
+    }
+    bakers_history {
+      display-name-plural: "Bakers history"
+      display-name: "Baker history"
+      temporal-partition: "pkh"
+      visible: true
+      attributes {
+        pkh {
+          display-name: "Address"
+          visible: true
+          data-type: "accountAddress"
+          reference: {
+            entity: "accounts"
+            key: "account_id"
+          }
+          cache-config {
+            cached: true,
+            min-match-length: 4,
+            max-result-size: 100
+          }
+          value-map: {
+            "tz1gk3TDbU7cJuiBRMhwQXVvgDnjsxuWhcEA": "Airfoil"
+            "tz1MJx9vhaNRSimcuXPK2rW4fLccQnDAnVKJ": "AirGap"
+            "tz3e75hU4EhDU3ukyJueh5v6UvEHzGwkg3yC": "At James"
+            "tz1ei4WtWEMEJekSv8qDnu9PExG6Q8HgRGr3": "Bake Tz"
+            "tz1NortRftucvAkD1J58L32EhSVrQEWJCEnB": "Bake'n'Rolls"
+            "tz1S8MNvuFEUsWgjHvi3AxibRBf388NhT1q2": "Binance Baker"
+            "tz1KtGwriE7VuLwT3LwuvU9Nv4wAxP7XZ57d": "Bitfinex"
+            "tz1SYq214SCBy9naR6cvycQsYcUGpBqQAE8d": "Coinone Baker"
+            "tz1eEnQhbwf6trb8Q8mPb2RaPkNk2rN7BKi8": "Chorus One"
+            "tz1MXFrtZoaXckE41bjUCSjAjAap3AFDSr3N": "Everstake (Legacy)"
+            "tz1TzaNn7wSQSP5gYPXCnNzBCpyMiidCq1PX": "Flippin' tacos"
+            "tz3RDC3Jdn4j15J7bBHZd29EUee9gVB1CxD9": "Foundation Baker 1"
+            "tz3bvNMQ95vfAYtG8193ymshqjSvmxiCUuR5": "Foundation Baker 2"
+            "tz3RB4aoyjov4KEVRbuhvQ1CKJgBJMWhaeB8": "Foundation Baker 3"
+            "tz3bTdwZinP8U1JmSweNzVKhmwafqWmFWRfk": "Foundation Baker 4"
+            "tz3NExpXn9aPNZPorRE4SdjJ2RGrfbJgMAaV": "Foundation Baker 5"
+            "tz3UoffC7FG7zfpmvmjUmUeAaHvzdcUvAj6r": "Foundation Baker 6"
+            "tz3WMqdzXqRWXwyvj5Hp2H7QEepaUuS7vd9K": "Foundation Baker 7"
+            "tz3VEZ4k6a4Wx42iyev6i2aVAptTRLEAivNN": "Foundation Baker 8"
+            "tz1NpWrAyDL9k2Lmnyxcgr9xuJakbBxdq7FB": "Gate.io"
+            "tz1WCd2jm4uSt4vntk4vSuUWoZQGhLcDuR9q": "Happy Tezos"
+            "tz1gfArv665EUkSg2ojMBzcbfwuPxAvqPvjo": "Kraken"
+            "tz1X1fpAZtwQk94QXUgZwfgsvkQgyc2KHp9d": "ownBLOCK (Legacy)"
+            "tz1hTFcQk2KJRPzZyHkCwbj7E1zY1xBkiHsk": "ownBLOCK"
+            "tz1dkP8pW6UzamUysFx3WqHZGQMNCZsEaeH6": "ownBLOCK Payouts"
+            "tz1P2Po7YM526ughEsRbY4oR9zaUPDZjxFrb": "P2P Validator"
+            "tz1KtvGSYU5hdKD288a1koTBURWYuADJGrLE": "\u00D8 Crypto Pool (Legacy)"
+            "tz1Yju7jmmsaUiG9qQLoYv35v5pHgnWoLWbt": "Polychain Labs 1"
+            "tz2TSvNTh2epDMhZHrw73nV9piBX7kLZ9K9m": "Polychain Labs 2"
+            "tz1Y42aKCk53vMbaJNpf1hBg1rznGdBxHJ5C": "Tezos Berlin"
+            "tz1Vyuu4EJ5Nym4JcrfRLnp3hpaq1DSEp1Ke": "POS Bakerz"
+            "tz1b7YSEeNRqgmjuX4d4aiai2sQTF4A7WBZf": "Tezos Japan (Legacy)"
+            "tz1ijdEfmUoQXJfSiKCLRioeCfSrKP3sVsff": "Tezos Japan (Legacy B)"
+            "tz1aDiEJf9ztRrAJEXZfcG3CKimoKsGhwVAi": "Tezos Japan"
+            "tz1PPUo28B8BroqmVCMMNDudG4ShA2bzicrU": "Tezos Korea"
+            "tz1b3SaPHFSw51r92ARcV5mGyYbSSsdFd5Gz": "Tezos MX"
+            "tz1Kf25fX1VdmYGSEzwFy1wNmkbSEZ2V83sY": "Tezos Seoul"
+            "tz1RAzdkp1x5ZDqms4ZUrSdfJuUYGH9JTPK2": "Tezos Spanish"
+            "tz1Lh9jeLSWDHYy8AshvG2dpNQseDaHg7cms": "Tezos Spanish (Legacy)"
+            "tz1hAYfexyzPGG6RhZZMpDvAHifubsbb6kgn": "Tezos Suisse"
+            "tz1VYQpZvjVhv1CdcENuCNWJQXu1TWBJ8KTD": "Tezos Tokyo"
+            "tz1R6Ej25VSerE3MkSoEEeBjKHCDTFbpKuSX": "TezosSEAsia"
+            "tz1Lh9jeLSWDHYy8AshvG2dpNQseDaHg7cms": "TezosSpanish"
+            "tz1PesW5khQNhy4revu2ETvMtWPtuVyH2XkZ": "Tz Dutch"
+            "tz1Pwgj6j55akKCyvTwwr9X4np1RskSXpQY4": "Validators.com"
+            "tz1g8vkmcde6sWKaG2NN9WKzCkDM6Rziq194": "StakeNow"
+            "tz1WnfXMPaNTBmH7DBPwqCWs9cPDJdkGBTZ8": "TezosHODL"
+            "tz2FCNBrERXtaTtNX6iimR1UJ5JSDxvdHM93": "stakefish"
+            "tz3QCNyySViKHmeSr45kzDxzchys7NiXCWoa": "Proofofbake.com"
+            "tz1abmz7jiCV2GH2u81LRrGgAFFgvQgiDiaf": "Tessellated Geometry"
+            "tz1TDSmoZXwVevLTEvKCTHWpomG76oC9S2fJ": "Tezos Capital Legacy"
+            "tz1UdeKoMJivgqRgRUNzroMwRJYmJY8BtaWe": "alphaTezos"
+            "tz1RSWMYKGAykpizFteowByYMueCYv9TMn1L": "Tezos Alliance"
+            "tz1Zhv3RkfU2pHrmaiDyxp7kFZpZrUCu1CiF": "TzBake"
+            "tz1Vd1rXpV8hTHbFXCXN3c3qzCsgcU5BZw1e": "TzNode"
+            "tz1fZ767VDbqx4DeKiFswPSHh513f51mKEUZ": "Tezos Bakery"
+            "tz1TqUDvdck5UrPSgdjJu8RPHafet5vyWQFk": "Tezos Bakery Payouts"
+            "tz1aKxnrzx5PXZJe7unufEswVRCMU9yafmfb": "Tezos Canada"
+            "tz1WGpyzJ1WdZQyKgFN1MY1d7KExGzipFmPJ": "Tezos Canada Payouts"
+            "tz1S5WxdZR5f9NzsPXhr7L9L1vrEb5spZFur": "Baking Benjamins"
+            "tz1V3yg82mcrPJbegqVCPn6bC8w1CSTRp3f8": "Staking Shop"
+            "tz1hxtCEcD7idQJEDiJEq37vBkoRcwF6KC2X": "Staking Shop Payouts"
+            "tz1cYufsxHXJcvANhvS55h3aY32a9BAFB494": "Bakery IL"
+            "tz1iVCqjMRG7MfBoFnVjbLQyeLAeJQfLxXze": "Bakery IL Payouts"
+            "tz1WBfwbT66FC6BTLexc2BoyCCBM9LG7pnVW": "888XTZ"
+            "tz1U638Z3xWRiXDDKx2S125MCCaAeGDdA896": "Tezos France"
+            "tz1Zrqm4TkJwqTxm5TiyVFh6taXG4Wrq7tko": "Bake'n'Rolls Payouts"
+            "tz1aRoaRhSpRYvFdyvgWLL6TGyRoGF51wDjM": "Everstake"
+            "tz1W1en9UpMCH4ZJL8wQCh8JDKCZARyVx2co": "Everstake Payouts"
+            "tz1XXayQohB8XRXN7kMoHbf2NFwNiH3oMRQQ": "Bit Cat"
+            "tz1Wy5Ph1FkD1ypUjpFpsHLXLEXDAeCRkZce": "Bit Cat Payouts"
+            "tz1cZfFQpcYhwDp7y1njZXDsZqCrn2NqmVof": "Tezos Rio"
+            "tz1Y2bfsQAYHrWZpM1AwomYMw2KEtaJ5VMfU": "Tezos Rio Payouts"
+            "tz3bEQoFCZEEfZMskefZ8q8e4eiHH1pssRax": "Ceibo XTZ"
+            "tz1ceiboANJ72iqG1g9Xig8vW74JJijv4mb8": "Ceibo XTZ Payouts"
+            "tz1PFeoTuFen8jAMRHajBySNyCwLmY5RqF9M": "Paradigm Bakery"
+            "tz1fb7c66UwePkkfDXz4ajFaBP9hVNLdS7JJ": "Tezos NU"
+            "tz1VfoA5qPksECBkvr2EUuT6u5VgLCi3vTPV": "Tezos NU Payouts"
+            "tz1fUjvVhJrHLZCbhPNvDRckxApqbkievJHN": "Tezzieland"
+            "tz1WntXgznbivRjyhE7Y5jEzoebAhMPB2iJa": "Tezzieland Payouts"
+            "tz1VceyYUpq1gk5dtp6jXQRtCtY8hm5DKt72": "TeZetetic"
+            "tz1S1Aew75hMrPUymqenKfHo8FspppXKpW7h": "Tezos Mars"
+            "tz1bRaSjKZrSrSeQHBDiCqjKXqtZYZM1t8FW": "Imma Baker"
+            "tz1bLwpPfr3xqy1gWBF4sGvv8bLJyPHR11kx": "Tezos Hot Bakery"
+            "tz1ZcTRk5uxD86EFEn1vvNffWWqJy7q5eVhc": "ATEZA"
+            "tz1UJvHTgpVzcKWhTazGxVcn5wsHru5Gietg": "Tezry"
+            "tz1MQJPGNMijnXnVoBENFz9rUhaPt3S7rWoz": "Tezmania"
+            "tz1eCzNtidHvVgeRzQ38C81FPcYnxMsCEL6Z": "TezLoom"
+            "tz1Q8QkSBS63ZQnH3fBTiAMPes9R666Rn6Sc": "YieldWallet"
+            "tz1LnWa4AiFCjMezTgSNa65QFoo7DQGEWgEU": "Tezeract"
+            "tz1NEKxGEHsFufk87CVZcrqWu8o22qh46GK6": "Money Every 3 Days"
+            "tz1NkFRjmkqqcGkAhqe78fdgemDNKXvL7Bod": "BakeMyStake"
+            "tz1SohptP53wDPZhzTWzDUFAUcWF6DMBpaJV": "Hayek Lab"
+            "tz1d6Fx42mYgVFnHUW8T8A7WBfJ6nD9pVok8": "MyTezosBaking"
+            "tz1fJHFn6sWEd3NnBPngACuw2dggTv6nQZ7g": "Baking Team"
+            "tz1iJ4qgGTzyhaYEzd1RnC6duEkLBd1nzexh": "Tz Envoy"
+            "tz1UsFcWtY6BxchK1L9619oXBzy3C2JCrRut": "Baking Tezos 4U"
+            "tz1QXrzaHrGACVn15UiCg33aLCJ6npWdQb3J": "Moku"
+            "tz1QGtMpkbdSM8Y1eHTru3WY51sXhFikbaAC": "TezosNigeria_001"
+            "tz1Vc9XAD7iphycJoRwE1Nxx5krB9C7XyBu5": "\u00D8 Crypto Pool"
+            "tz1irJKkXS2DBWkU1NnmFQx1c1L7pbGg4yhk": "Coinbase Custody"
+            "tz1VQnqCCqX4K5sP3FNkVSNKTdCAMJDd3E1n": "PosDog"
+            "tz1RCFbB9GpALpsZtu6J58sb74dm8qe6XBzv": "Staked"
+            "tz1KfEsrtDaA1sX7vdM4qmEPWuSytuqCDp5j": "XTZ Master"
+            "tz1isXamBXpTUgbByQ6gXgZQg4GWNW7r6rKE": "Tez Whale"
+            "tz1Ldzz6k1BHdhuKvAtMRX7h5kJSMHESMHLC": "PayTezos"
+            "tz1UvkANVPWppVgMkLnvN7BwYZsCP7vm6NVd": "Neokta Labs"
+            "tz1YhNsiRRU8aHNGg7NK3uuP6UDAyacJernB": "Tez Baguette"
+            "tz3adcvQaKXTCg12zbninqo3q8ptKKtDFTLv": "Tezzigator"
+            "tz1RV1MBbZMR68tacosb7Mwj6LkbPSUS1er1": "Baking Tacos"
+            "tz1W5VkdB5s7ENMESVBtwyt9kyvLqPcUczRT": "Tezgate"
+            "tz1PWCDnz783NNGGQjEFFsHtrcK5yBW4E2rm": "Melange"
+            "tz1V2FYediKBAEaTpXXJBSjuQpjkyCzrTSiE": "Stake House"
+            "tz1Scdr2HsZiQjc7bHMeBbmDRXYVvdhjJbBh": "Figment"
+            "tz1VmiY38m3y95HqQLjMwqnMS7sdMfGomzKi": "Lucid Mining"
+            "tz1WctSwL49BZtdWAQ75NY6vr4xsAx6oKdah": "Tezos Wake n' Bake"
+            "tz1PeZx7FXy7QRuMREGXGxeipb24RsMMzUNe": "Tezos Panda"
+            "tz1bHzftcTKZMTZgLLtnrXydCm6UEqf4ivca": "Tezos Vote"
+            "tz1S8e9GgdZG78XJRB3NqabfWeM37GnhZMWQ": "0xb1 PlusMinus"
+            "tz1LmaFsWRkjr7QMCx5PtV6xTUz3AmEpKQiF": "Blockpower Staking"
+            "tz1RjoHc98dBoqaH2jawF62XNKh7YsHwbkEv": "OKEx Baker"
+            "tz1cX93Q3KsiTADpCC4f12TBvAmS5tw7CW19": "Tz Bakery"
+            "tz1VHFxUuBhwopxC9YC9gm5s2MHBHLyCtvN1": "HyperBlocks"
+            "tz1aiYKXmSRckyJ9EybKmpVry373rfyngJU8": "View Nodes"
+            "tz1STeamwbp68THcny9zk3LsbG3H36DMvbRK": "StakingTeam"
+            "tz1hUSVvSq4YbZcREBqKHf6eXM1yvXuGYUNZ": "Metablock Baker"
+            "tz1Tnjaxk6tbAeC2TmMApPh8UsrEVQvhHvx5": "Crypto Delegate"
+            "tz1LBEKXaxQbd5Gtzbc1ATCwc3pppu81aWGc": "Tez-Baking"
+            "tz1dbfppLAAxXZNtf2SDps7rch3qfUznKSoK": "Coinhouse"
+            "tz1dRKU4FQ9QRRQPdaH4zCR6gmCmXfcvcgtB": "Spice"
+            "tz1Z2jXfEXL7dXhs6bsLmyLFLfmAkXBzA9WE": "Tezos Boutique"
+            "tz1dNVDWPf3Q59SdJqnjdnu277iyvReiRS9M": "Steak and Bake"
+            "tz1Zcxkfa5jKrRbBThG765GP29bUCU3C4ok5": "Tezz City"
+            "tz1Lhf4J9Qxoe3DZ2nfe8FGDnvVj7oKjnMY6": "Tez Baker"
+            "tz1XhnCdVENzgko5x1MMswLHSoQbJ5NPwLZ6": "Anonstake"
+            "tz1WpeqFaBG9Jm73Dmgqamy8eF8NWLz9JCoY": "Staking Facilities"
+            "tz1iZEKy4LaAjnTmn2RuGDf2iqdAQKnRi8kY": "Tezzigator (Legacy)"
+            "tz1MkjfzHNF3kk7PMUDVsaTrF8iRD6fpHftR": "LuxBaker"
+            "tz1hWB6QV5GBQKdEJN8EowHhLJyCMPhH18sA": "Tezos Cameroun"
+          }
+        }
+        block_id {
+          display-name: "Block Hash"
+          data-type: "hash"
+          visible: true
+          reference: {
+            entity: "blocks"
+            key: "hash"
+          }
+        }
+        balance {
+          visible: true
+          scale: 6,
+          data-type: "currency"
+          currency-symbol-code: 42793
+        }
+        frozen_balance {
+          display-name: "Frozen Balance"
+          visible: true
+          scale: 6,
+          data-type: "currency"
+          currency-symbol-code: 42793
+        }
+        staking_balance {
+          display-name: "Staking Balance"
+          visible: true
+          scale: 6,
+          data-type: "currency"
+          currency-symbol-code: 42793
+        }
+        delegated_balance {
+          display-name: "Delegated Balance"
+          visible: true
+          scale: 6,
+          data-type: "currency"
+          currency-symbol-code: 42793
+        }
+        rolls {
+          visible: true
+        }
+        deactivated {
+          visible: true
+        }
+        grace_period {
+          visible: true
+        }
+        block_level {
+          visible: true
+          display-name: "Block Level"
+          data-type: "int"
+          reference: {
+            entity: "blocks"
+            key: "level"
+          }
+          temporal-column: true
+        }
+        cycle {
+          visible: true
+        }
+        period {
+          visible: true
+        }
+        asof {
+          visible: true
+          data-format: "YYYY MMM DD, HH:mm"
+          temporal-column: true
+        }
+      }
+    }
+    accounts_checkpoint {
+      visible: false
+    }
+    bakers_checkpoint {
+      visible: false
+    }
+    baking_rights {
+      visible: true
+      attributes {
+        block_hash {
+          visible: true
+          display-name: "Block Hash"
+          visible: true
+          data-type: "hash"
+          reference: {
+            entity: "blocks"
+            key: "hash"
+          }
+        }
+        governance_period {
+          display-name: "Period"
+          visible: true
+        }
+        cycle {
+          display-name: "Cycle"
+          visible: true
+        }
+        block_level {
+          visible: true
+          display-name: "Block Level"
+          data-type: "int"
+          reference: {
+            entity: "blocks"
+            key: "level"
+          }
+        }
+        delegate {
+          visible: true
+          display-name: "Baker"
+          data-type: "accountAddress"
+          reference: {
+            entity: "accounts"
+            key: "account_id"
+          }
+        }
+        priority {
+          visible: true
+        }
+        estimated_time {
+          visible: true
+          data-format: "YYYY MMM DD, HH:mm"
+        }
+      }
+    }
+    endorsing_rights {
+      visible: true
+      attributes {
+        block_hash {
+          display-name: "Block Hash"
+          visible: true
+          data-type: "hash"
+          reference: {
+            entity: "blocks"
+            key: "hash"
+          }
+        }
+        governance_period {
+          display-name: "Period"
+          visible: true
+        }
+        cycle {
+          display-name: "Cycle"
+          visible: true
+        }
+        block_level {
+          visible: true
+          display-name: "Block Level"
+          data-type: "int"
+          reference: {
+            entity: "blocks"
+            key: "level"
+          }
+        }
+        delegate {
+          visible: true
+          display-name: "Baker"
+          data-type: "accountAddress"
+          reference: {
+            entity: "accounts"
+            key: "account_id"
+          }
+        }
+        slot {
+          visible: true
+        }
+        estimated_time {
+          visible: true
+          data-format: "YYYY MMM DD, HH:mm"
+        }
+        endorsed_block {
+          data-type: "int"
+          visible: true
+        }
+      }
+    }
+    registered_tokens {
+      visible: true
+      attributes {
+        id {
+          display-name: "Id"
+          visible: true
+        }
+        name {
+          display-name: "Name"
+          visible: true
+        }
+        contract_type {
+          display-name: "Standard"
+          visible: true
+        }
+        account_id {
+          visible: true
+          display-name: "Address"
+          data-type: "accountAddress"
+        }
+        scale {
+          visible: true
+        }
+      }
+    }
+    governance {
+      visible: true
+      attributes {
+        voting_period {
+          display_name: "Voting period"
+          visible: true
+        }
+        voting_period_kind {
+          display_name: "Voting period kind"
+          visible: true
+          cache-config {
+            cached: true
+          }
+        }
+        cycle {
+          display_name: "Cycle"
+          visible: true
+        }
+        level {
+          display_name: "Level"
+          data-type: "int"
+          visible: true
+        }
+        block_hash {
+          display_name: "Block Hash"
+          data-type: "hash"
+          reference: {
+            entity: "blocks"
+            key: "hash"
+          }
+          visible: true
+        }
+        proposal_hash {
+          display_name: "Proposal"
+          data-type: "hash"
+          visible: true
+          value-map: {
+            "Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A": "Ithaca 2.0"
+            "PsiThaCaT47Zboaw71QWScM8sXeMM7bbQFncK9FLqYc6EKdpjVP": "Ithaca"
+            "PtHangz2aRngywmSRGGvrcTyMbbdpWdpFKuS4uMWxg2RaH9i1qx": "Hangzhou Actual"
+            "PsCUKj6wydGtDNGPRdxasZDs4esZcVD9tf44MMiVy46FkD9q1h9": "Hanghouz-USDtz-LB"
+            "PtHangzHogokSuiMHemCuowEavgYTP8J5qQ9fQS793MHYFpCY3r": "Hangzhou"
+            "PtGRENLBgC4kALRCjYwBAgDNSvK9ZDCst7cRQ1aNP9Ke1cZDwnY": "Grenada LB-removed"
+            "PsmarYW3qFVZUNYwJaYvPEYG96N3awx5SpYs3PxiAWmCzRBAhY8": "Grenada LB-disabled"
+            "PtGRANADsDU8R9daYKAgWnQYAJ64omN1o3KMGVCykShA97vQbvV": "Grenada"
+            "PsFLorenaUUuikDWvMDr6fGBRG8kt3e3D3fHoXK1j1BFRxeSH4i": "Florence no-BA"
+            "PsFLorBArSaXjuy9oP76Qv1v2FRYnUs7TFtteK5GkRBC24JvbdE": "Florence BA"
+            "PtEdo2ZkT9oKpimTah6x2embF25oss54njMuPzkJTEi5RqfdZFA": "Edo 2.0"
+            "PtEdoTezd3RHSC31mpxxo1npxFjoWWcFgQtxapi51Z8TLu6v6Uq": "Edo"
+            "PsDELPH1Kxsxt8f9eWbxQeRxkjfbxoqM52jvs5Y5fBxWWh4ifpo": "Delphi"
+            "PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb": "Carthage 2.0"
+            "PtCarthavAMoXqbjBPVgDCRd5LgT7qqKWUPXnYii3xCaHRBMfHH": "Carthage"
+            "PsBabyM1eUXZseaJdmXFApDSBqj8YBfwELoxZHHW77EMcAbbwAS": "Babylon 2.1"
+            "PsBABY5HQTSkA4297zNHfsZNKtxULfL18y95qb3m53QJiXGmrbU": "Babylon 2.0"
+            "PsBABY5nk4JhdEv1N1pZbt6m6ccB9BfNqa23iKZcHBh23jmRS9f": "Babylon"
+            "PtdRxBHvc91c2ea2evV6wkoqnzW7TadTg9aqS9jAn2GbcPGtumD": "Brest A"
+            "Psd1ynUBhMZAeajwcZJAeq5NrxorM6UCU4GJqxZ7Bx2e9vUWB6z": "Athens B"
+            "Pt24m4xiPbLDhVgVfABUjirbmda3yohdN82Sp9FeuAXJ4eV9otd": "Athens A"
+          }
+        }
+        yay_count {
+          display_name: "Yay Votes"
+          visible: true
+        }
+        nay_count {
+          display_name: "Nay Votes"
+          visible: true
+        }
+        pass_count {
+          display_name: "Pass Votes"
+          visible: true
+        }
+        yay_rolls {
+          display_name: "Yay Rolls"
+          visible: true
+        }
+        nay_rolls {
+          display_name: "Nay Rolls"
+          visible: true
+        }
+        pass_rolls {
+          display_name: "Pass Rolls"
+          visible: true
+        }
+        total_rolls {
+          display_name: "Total Rolls"
+          visible: true
+        }
+        block_yay_count {
+          display_name: "Block Yay Votes"
+          visible: true
+        }
+        block_nay_count {
+          display_name: "Block Nay Votes"
+          visible: true
+        }
+        block_pass_count {
+          display_name: "Block Pass Votes"
+          visible: true
+        }
+        block_yay_rolls {
+          display_name: "Block Yay Rolls"
+          visible: true
+        }
+        block_nay_rolls {
+          display_name: "Block Nay Rolls"
+          visible: true
+        }
+        block_pass_rolls {
+          display_name: "Block Pass Rolls"
+          visible: true
+        }
+      }
+    }
+    known_addresses {
+      visible: true
+      attributes {
+        address {
+          display-name: "Address"
+          data-type: "accountAddress"
+          visible: true
+        }
+        alias {
+          display-name: "Alias"
+          visible: true
+        }
+      }
+    }
+    baker_registry {
+      visible: true
+      attributes {
+        name {
+          display-name: "Name"
+          visible: true
+        }
+        is_accepting_delegation {
+          display-name: "Is accepting delegation"
+          visible: true
+        }
+        external_data_url {
+          display-name: "External data URL"
+          visible: true
+        }
+        split {
+          display-name: "Split"
+          visible: true
+        }
+        payment_accounts {
+          display-name: "Payment accounts"
+          visible: true
+        }
+        minimum_delegation {
+          display-name: "Minimum delegation"
+          visible: true
+        }
+        payout_delay {
+          display-name: "Payout delay"
+          visible: true
+        }
+        payout_frequency {
+          display-name: "Payout frequency"
+          visible: true
+        }
+        minimum_payout {
+          display-name: "Minimum payout"
+          visible: true
+        }
+        is_cheap {
+          display-name: "Is cheap"
+          visible: true
+        }
+        pay_for_own_blocks {
+          display-name: "Pay for own blocks"
+          visible: true
+        }
+        pay_for_endorsements {
+          display-name: "Pay for endorsements"
+          visible: true
+        }
+        pay_gained_fees {
+          display-name: "Pay gained fees"
+          visible: true
+        }
+        pay_for_accusation_gains {
+          display-name: "Pay for accusation gains"
+          visible: true
+        }
+        subtract_lost_deposits_when_accused {
+          display-name: "Subtract lost deposits when accused"
+          visible: true
+        }
+        subtract_lost_rewards_when_accused {
+          display-name: "Subtract lost rewards when accused"
+          visible: true
+        }
+        subtract_lost_fees_when_accused {
+          display-name: "Subtract lost fees when accused"
+          visible: true
+        }
+        pay_for_revelation {
+          display-name: "Pay for revelation"
+          visible: true
+        }
+        subtract_lost_rewards_when_miss_revelation {
+          display-name: "Subtract lost rewards when miss revelation"
+          visible: true
+        }
+        subtract_lost_fees_when_miss_revelation {
+          display-name: "Subtract lost fees when miss revelation"
+          visible: true
+        }
+        compensate_missed_blocks {
+          display-name: "Compensate missed blocks"
+          visible: true
+        }
+        pay_for_stolen_blocks {
+          display-name: "Pay for stolen blocks"
+          visible: true
+        }
+        compensate_missed_endorsements {
+          display-name: "Compensate missed endorsements"
+          visible: true
+        }
+        compensate_low_priority_endorsement_loss {
+          display-name: "Compensate low priority endorsement loss"
+          visible: true
+        }
+        overdelegation_threshold {
+          display-name: "Overdelegation threshold"
+          visible: true
+        }
+        subtract_rewards_from_uninvited_delegation {
+          display-name: "Subtract rewards from uninvited delegation"
+          visible: true
+        }
+        record_manager {
+          display-name: "Record manager"
+          visible: true
+        }
+        timestamp {
+          display-name: "Timestamp"
+          data-format: "YYYY MMM DD, HH:mm"
+          visible: true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is a follow up to #1115. 

These changes allow Conseil to be run for Tezos Limanet. 